### PR TITLE
Timeslots visualized with available_times prop

### DIFF
--- a/commons/types/Availability.d.ts
+++ b/commons/types/Availability.d.ts
@@ -5,5 +5,11 @@ declare namespace Availability {
     slot_size: 15 | 30 | 60;
     start_date: Date;
     dates_to_show: number;
+    available_times: TimeSlot[];
+  }
+
+  interface TimeSlot {
+    start_time: Date;
+    end_time: Date;
   }
 }

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -130,7 +130,6 @@
       display: grid;
       grid-auto-flow: column;
       grid-auto-columns: auto;
-      // height: 100vh;
     }
 
     .day {
@@ -154,8 +153,6 @@
         .slot {
           border: 1px solid #fff;
           background: #eee;
-          // display: flex;
-          // flex-direction: column;
           position: relative;
           align-items: center;
           justify-content: center;
@@ -193,20 +190,23 @@
         <header>
           <h2>{new Date(day.timestamp).toLocaleDateString()}</h2>
         </header>
-        <ul class="slots">
+        <div class="slots">
           {#each day.slots as slot}
-            <li
+            <button
               class="slot {slot.selectionStatus} {slot.availability}"
               data-start-time={new Date(slot.start_time).toLocaleString()}
               data-end-time={new Date(slot.end_time).toLocaleString()}
+              on:mouseover={() =>
+                console.log(
+                  "TODO: temp; ",
+                  new Date(slot.start_time).toLocaleString(),
+                )}
               on:click={() => {
                 slot.selectionStatus = handleTimeSlotClick(slot);
               }}
-              on:mouseover={() =>
-                console.log(new Date(slot.start_time).toLocaleString())}
             />
           {/each}
-        </ul>
+        </div>
       </div>
     {/each}
   </div>

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -35,7 +35,7 @@
 
   //#region layout
   let main: Element;
-  let slotSelection: any[] = [];
+  let slotSelection: Availability.TimeSlot[] = [];
 
   // You can have as few as 1, and as many as 7, days shown
   $: startDay = d3.timeDay(new Date().setDate(start_date.getDate()));
@@ -85,12 +85,6 @@
     });
   //#endregion layout
 
-  function getEndTime(start_time: Date): Date {
-    let end_time = new Date(start_time.valueOf());
-    end_time.setMinutes(end_time.getMinutes() + slot_size);
-    return end_time;
-  }
-
   function handleTimeSlotClick(selectedSlot: any): string {
     if (selectedSlot.selectionStatus === "unselected") {
       if (click_action === "choose") {
@@ -107,15 +101,15 @@
     }
   }
 
-  function sendTimeSlot(selectedSlot: any) {
-    let start_time = new Date(selectedSlot.time);
-    let end_time = getEndTime(start_time);
+  function sendTimeSlot(selectedSlot: Availability.TimeSlot) {
+    let start_time = new Date(selectedSlot.start_time);
+    let end_time = new Date(selectedSlot.end_time);
     const timeslot: Availability.TimeSlot = {
-      start_time: start_time.toLocaleTimeString(),
-      end_time: end_time.toLocaleTimeString(),
+      start_time,
+      end_time,
     };
     dispatchEvent("timeSlotChosen", {
-      timeslot: timeslot,
+      timeslot,
     });
   }
 </script>
@@ -193,6 +187,9 @@
         <div class="slots">
           {#each day.slots as slot}
             <button
+              aria-label="{new Date(
+                slot.start_time,
+              ).toLocaleString()} - {new Date(slot.end_time).toLocaleString()}}"
               class="slot {slot.selectionStatus} {slot.availability}"
               data-start-time={new Date(slot.start_time).toLocaleString()}
               data-end-time={new Date(slot.end_time).toLocaleString()}

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -174,14 +174,6 @@
             border: 1px solid red;
             opacity: 0.3;
           }
-          span {
-            position: absolute;
-            width: 100%;
-            height: 100%;
-            display: grid;
-            justify-content: center;
-            align-content: center;
-          }
         }
       }
     }
@@ -205,14 +197,14 @@
           {#each day.slots as slot}
             <li
               class="slot {slot.selectionStatus} {slot.availability}"
+              data-start-time={new Date(slot.start_time).toLocaleString()}
+              data-end-time={new Date(slot.end_time).toLocaleString()}
               on:click={() => {
                 slot.selectionStatus = handleTimeSlotClick(slot);
               }}
               on:mouseover={() =>
-                console.log(new Date(slot.start_time).toLocaleTimeString())}
-            >
-              <span>{new Date(slot.start_time).toLocaleString()}</span>
-            </li>
+                console.log(new Date(slot.start_time).toLocaleString())}
+            />
           {/each}
         </ul>
       </div>

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -108,8 +108,16 @@
 
 <style lang="scss">
   main {
-    display: grid;
     height: 100vh;
+    overflow: hidden;
+    display: grid;
+    grid-template-rows: 1fr auto;
+    .days {
+      display: grid;
+      grid-auto-flow: column;
+      grid-auto-columns: auto;
+      // height: 100vh;
+    }
 
     .day {
       display: grid;
@@ -128,11 +136,13 @@
         list-style-type: none;
         margin: 0;
         padding: 0;
+
         .slot {
           border: 1px solid #fff;
           background: #eee;
-          display: flex;
-          flex-direction: column;
+          // display: flex;
+          // flex-direction: column;
+          position: relative;
           align-items: center;
           justify-content: center;
           align-content: center;
@@ -141,6 +151,7 @@
             background-color: yellow;
           }
           span {
+            position: absolute;
             width: 100%;
             height: 100%;
             display: grid;
@@ -160,27 +171,29 @@
 
 <nylas-error {id} />
 <main bind:this={main}>
-  {#each days as day}
-    <div class="day">
-      <header>
-        <h2>{new Date(day.timestamp).toLocaleDateString()}</h2>
-      </header>
-      <ul class="slots">
-        {#each day.slots as slot}
-          <li
-            class="slot {slot.status}"
-            on:click={() => {
-              slot.status = handleTimeSlotClick(slot);
-            }}
-            on:mouseover={() =>
-              console.log(new Date(slot.time).toLocaleTimeString())}
-          >
-            <span>{new Date(slot.time).toLocaleString()}</span>
-          </li>
-        {/each}
-      </ul>
-    </div>
-  {/each}
+  <div class="days">
+    {#each days as day}
+      <div class="day">
+        <header>
+          <h2>{new Date(day.timestamp).toLocaleDateString()}</h2>
+        </header>
+        <ul class="slots">
+          {#each day.slots as slot}
+            <li
+              class="slot {slot.status}"
+              on:click={() => {
+                slot.status = handleTimeSlotClick(slot);
+              }}
+              on:mouseover={() =>
+                console.log(new Date(slot.time).toLocaleTimeString())}
+            >
+              <span>{new Date(slot.time).toLocaleString()}</span>
+            </li>
+          {/each}
+        </ul>
+      </div>
+    {/each}
+  </div>
   {#if click_action === "verify"}
     <footer class="confirmation">
       Confirm time?

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -27,7 +27,7 @@
         component.available_times = available_times;
 
         component.addEventListener("timeSlotChosen", (event) => {
-          console.log(event.detail.timeslot);
+          console.log(event.detail);
         });
 
         startTimeInput.addEventListener("input", (event) => {

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -13,6 +13,19 @@
         const endTimeInput = document.querySelector("input#end-time");
         const daysInput = document.querySelector("input#days-to-show");
 
+        const available_times = [
+          {
+            start_time: new Date(new Date().setHours(3)),
+            end_time: new Date(new Date().setHours(6)),
+          },
+          {
+            start_time: new Date(new Date().setHours(9)),
+            end_time: new Date(new Date().setHours(15)),
+          },
+        ];
+
+        component.available_times = available_times;
+
         component.addEventListener("timeSlotChosen", (event) => {
           console.log(event.detail.timeslot);
         });

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -11,8 +11,14 @@ describe("availability component", () => {
       const tomorrow = new Date();
       tomorrow.setHours(0, 0, 0);
       tomorrow.setDate(today.getDate() + 1);
-      cy.get(".slot").first().contains(today.toLocaleString());
-      cy.get(".slot").last().contains(tomorrow.toLocaleString());
+      cy.get(".slot")
+        .first()
+        .invoke("attr", "data-start-time")
+        .should("eq", today.toLocaleString());
+      cy.get(".slot")
+        .last()
+        .invoke("attr", "data-start-time")
+        .should("eq", tomorrow.toLocaleString());
     });
 
     it("Updates start_hour via component prop", () => {
@@ -24,7 +30,10 @@ describe("availability component", () => {
           const start_time = new Date();
           start_time.setHours(component.start_hour, 0, 0);
           cy.get(".slot").should("have.length", 65);
-          cy.get(".slot").first().contains(start_time.toLocaleString());
+          cy.get(".slot")
+            .first()
+            .invoke("attr", "data-start-time")
+            .should("eq", start_time.toLocaleString());
         });
     });
 
@@ -37,7 +46,10 @@ describe("availability component", () => {
           const end_time = new Date();
           end_time.setHours(component.end_hour, 0, 0);
           cy.get(".slot").should("have.length", 33);
-          cy.get(".slot").last().contains(end_time.toLocaleString());
+          cy.get(".slot")
+            .last()
+            .invoke("attr", "data-start-time")
+            .should("eq", end_time.toLocaleString());
         });
     });
   });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cy:open": "cypress open",
     "cy:run": "cypress run",
     "dev": "lerna run --parallel dev",
-    "dev:scoped": "concurrently 'live-server . --host=localhost --port=8000' 'lerna run --parallel dev --scope=@nylas/components-{day,email}'",
+    "dev:scoped": "concurrently 'live-server . --host=localhost --port=8000' 'lerna run --parallel dev --scope=@nylas/components-{availability}'",
     "link": "lerna link convert",
     "lint": "eslint --ext .ts -f visualstudio .",
     "lint:ci": "yarn lint:fix -- --quiet",


### PR DESCRIPTION

- new component property: `available_times`. Array of `{ start_time: Date, end_time: Date }`
- we now assign an `availability` status to all timeslots: `available` or `unavailable`
- if no `available_times` array is present, we assume all time slots are available
- if an `available_times` array IS present, it checks to see if each time slot falls within one of the available_times objects

Ugly design, but gets the point across!

![CleanShot 2021-07-19 at 17 00 57](https://user-images.githubusercontent.com/713991/126226822-38416fbd-1dab-4893-a1f2-e376191ef38a.png)
![CleanShot 2021-07-19 at 17 01 07](https://user-images.githubusercontent.com/713991/126226840-f71edea5-e84e-4005-8d51-7651cac4ffcc.png)
![CleanShot 2021-07-19 at 17 01 26](https://user-images.githubusercontent.com/713991/126226891-6e340746-103c-4cb8-b428-948047a1b7a4.png)


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
