### PR TITLE
Chore/tree shaking

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
   },
   plugins: ["svelte3", "@typescript-eslint", "cypress"],
   extends: [
+    "plugin:svelte3/defaultWithJsx",
     "eslint:recommended",
     "prettier",
     "plugin:@typescript-eslint/eslint-recommended",

--- a/commons/src/components/NError.svelte
+++ b/commons/src/components/NError.svelte
@@ -2,9 +2,8 @@
 
 <script lang="ts">
   import { NErrorExplanationMap } from "./NErrorMapping";
-  import { store } from "../index";
+  import { ErrorStore } from "../index";
 
-  const { ErrorStore } = store;
   export let id; // component id
 
   $: error = $ErrorStore[id] || { name: "" };

--- a/commons/src/components/NErrorMapping.ts
+++ b/commons/src/components/NErrorMapping.ts
@@ -15,33 +15,35 @@ type INErrorExplanationMap = {
   [Key in NErrorType[number]]: () => Explanation;
 };
 
-export const NErrorExplanationMap: INErrorExplanationMap = new Proxy<INErrorExplanationMap>(
-  {
-    DatabaseError: () => ({
-      title: "",
-      subtitle: "",
-    }),
-    HostDomainNotAllowedError: () => ({
-      title: `
+export const NErrorExplanationMap: INErrorExplanationMap =
+  new Proxy<INErrorExplanationMap>(
+    {
+      DatabaseError: () => ({
+        title: "",
+        subtitle: "",
+      }),
+      HostDomainNotAllowedError: () => ({
+        title: `
         You are trying to access this component from <code>${window.location.hostname}</code>. 
         The component's settings do not allow access from this domain.
       `,
-      subtitle: `The list of allowed domains can be modified in your <a href="https://dashboard.nylas.com">Dashboard</a>.`,
-    }),
-    RequestNotAllowed: () => ({
-      title: "",
-      subtitle: "",
-    }),
-    UserInputError: () => ({
-      title: "",
-      subtitle: "",
-    }),
-    MiddlewareError: () => ({
-      title: "",
-      subtitle: "",
-    }),
-  } as INErrorExplanationMap,
-  {
-    get: (target, prop) => target[prop] || target.MiddlewareError, // fall back to middleware error
-  },
-);
+        subtitle: `The list of allowed domains can be modified in your <a href="https://dashboard.nylas.com">Dashboard</a>.`,
+      }),
+      RequestNotAllowed: () => ({
+        title: "",
+        subtitle: "",
+      }),
+      UserInputError: () => ({
+        title: "",
+        subtitle: "",
+      }),
+      MiddlewareError: () => ({
+        title: "",
+        subtitle: "",
+      }),
+    } as INErrorExplanationMap,
+    {
+      get: (target, prop: keyof INErrorExplanationMap) =>
+        target[prop] || target.MiddlewareError, // fall back to middleware error
+    },
+  );

--- a/commons/src/define-component-patch.ts
+++ b/commons/src/define-component-patch.ts
@@ -1,7 +1,9 @@
-const origDefine = window.customElements.define.bind(window.customElements);
+export const originalDefine = window.customElements.define.bind(
+  window.customElements,
+);
 window.customElements.define = (name: string, ...args) => {
   if (customElements.get(name)) {
     return;
   }
-  return origDefine(name, ...args);
+  return originalDefine(name, ...args);
 };

--- a/commons/src/index.ts
+++ b/commons/src/index.ts
@@ -1,75 +1,41 @@
-import { createEvent, fetchEvents, fetchCalendars } from "./connections/events";
-import {
+export { createEvent, fetchEvents, fetchCalendars } from "./connections/events";
+export {
   fetchContacts,
   fetchContactsByQuery,
   fetchContactImage,
   fetchContactThreads,
 } from "./connections/contacts";
-import { fetchThreads, fetchThread, updateThread } from "./connections/threads";
-import { fetchManifest } from "./connections/manifest";
-import {
+export { fetchThreads, fetchThread, updateThread } from "./connections/threads";
+export { fetchManifest } from "./connections/manifest";
+export {
   sendMessage,
   uploadFile,
   fetchMessages,
   fetchMessage,
   fetchEmail,
 } from "./connections/messages";
-import { fetchAccount } from "./connections/accounts";
-import {
+export { fetchAccount } from "./connections/accounts";
+export {
   fetchCleanConversations,
   sendCleanConversationFeedback,
 } from "./connections/neural";
 
-import { CalendarStore } from "./store/calendars";
-import { ContactStore } from "./store/contacts";
-import { ConversationStore } from "./store/conversations";
-import { EventStore } from "./store/events";
-import { MailboxStore, Threads } from "./store/threads";
-import { MessageStore } from "./store/messages";
-import { ManifestStore } from "./store/manifest";
-import {
+export { CalendarStore } from "./store/calendars";
+export { ContactStore } from "./store/contacts";
+export { ConversationStore } from "./store/conversations";
+export { EventStore } from "./store/events";
+export { MailboxStore, Threads } from "./store/threads";
+export { MessageStore } from "./store/messages";
+export { ManifestStore } from "./store/manifest";
+export {
   debounce,
   getEventDispatcher,
   parseBoolean,
 } from "./methods/component";
-import { ErrorStore } from "./store/error";
-
-export const store = {
-  CalendarStore,
-  ContactStore,
-  ConversationStore,
-  EventStore,
-  ErrorStore,
-  ManifestStore,
-  MailboxStore,
-  Threads,
-  MessageStore,
-};
-
-export const connections = {
-  createEvent,
-  fetchEvents,
-  fetchCalendars,
-  fetchContactsByQuery,
-  fetchContacts,
-  fetchContactImage,
-  fetchThreads,
-  updateThread,
-  fetchContactThreads,
-  fetchThread,
-  fetchManifest,
-  fetchMessages,
-  fetchMessage,
-  fetchEmail,
-  sendMessage,
-  fetchAccount,
-  uploadFile,
-  fetchCleanConversations,
-  sendCleanConversationFeedback,
-};
-
-export const methods = {
-  getEventDispatcher,
-  debounce,
-  parseBoolean,
-};
+export { ErrorStore } from "./store/error";
+/**
+ * Esbuild tree shakes NError, however it is used in each component
+ * This code prevents Esbuild from tree-shaking NError
+ */
+import _ from "./components/NError.svelte";
+void _;

--- a/commons/src/methods/api.ts
+++ b/commons/src/methods/api.ts
@@ -1,6 +1,8 @@
 import { ErrorStore } from "../store/error";
 
-async function handleResponse<T = unknown>(response: Response): Promise<T> {
+export async function handleResponse<T = unknown>(
+  response: Response,
+): Promise<T> {
   if (!response.ok) {
     const passedError = await response
       .json()
@@ -21,7 +23,7 @@ type FetchOptions = {
   access_token?: string;
 };
 
-function getFetchConfig(
+export function getFetchConfig(
   opts: FetchOptions = { component_id: "" },
 ): RequestInit {
   return {
@@ -36,7 +38,7 @@ function getFetchConfig(
   };
 }
 
-function handleError<T = any>(id: string, error: Nylas.Manifest["error"]): T {
+export function handleError(id: string, error: Nylas.Manifest["error"]): never {
   if (process.env.NODE_ENV !== "production") console.error(error);
   ErrorStore.update((errorMap) => ({ ...errorMap, [id]: error }));
   throw error;
@@ -48,7 +50,7 @@ const REGION_MAPPING: Record<string, string> = {
   "003": "canada-", // Canada
 };
 
-function getMiddlewareApiUrl(id: string): string {
+export function getMiddlewareApiUrl(id: string): string {
   let region = "";
   if (id.substring(3, 4) === "-") {
     const code = id.substring(0, 3);
@@ -59,5 +61,3 @@ function getMiddlewareApiUrl(id: string): string {
   const API_GATEWAY = `https://${region}${process.env.API_GATEWAY}`;
   return API_GATEWAY;
 }
-
-export { handleResponse, getFetchConfig, handleError, getMiddlewareApiUrl };

--- a/components/agenda/src/Agenda.svelte
+++ b/components/agenda/src/Agenda.svelte
@@ -4,7 +4,7 @@
   import { tick } from "svelte";
   import { get_current_component, onMount } from "svelte/internal";
   import { spring } from "svelte/motion";
-  import { store } from "@commons";
+  import { CalendarStore, EventStore, ManifestStore } from "@commons";
   import {
     buildInternalProps,
     getPropertyValue,
@@ -13,8 +13,6 @@
   import type { EventPosition } from "./methods/position";
   import { populatePositionMap, updateEventPosition } from "./methods/position";
   import { getDynamicEndTime, getDynamicStartTime } from "./methods/time";
-
-  const { CalendarStore, EventStore, ManifestStore } = store;
 
   // #region props
   const INTERNAL_EVENT_PROPS = Object.freeze([
@@ -1508,17 +1506,12 @@
                 class:expanded={expandedEventId === event.id}
                 class="event status-{event.attendeeStatus}"
                 data-calendar-id={calendarIDs.indexOf(event.calendar_id) + 1}
-                style="top: {event.relativeStartTime *
-                  100}%; height: 
+                style="top: {event.relativeStartTime * 100}%; height: 
               {condensed
                   ? `calc(${event.relativeRunTime * 100}% - 4px)`
-                  : `calc(${
-                      event.relativeRunTime * 100
-                    }%  - 4px)`};
-              left: {event.relativeOverlapOffset *
-                  100}%; 
-              width: calc({event.relativeOverlapWidth *
-                  100}% - 4px)"
+                  : `calc(${event.relativeRunTime * 100}%  - 4px)`};
+              left: {event.relativeOverlapOffset * 100}%; 
+              width: calc({event.relativeOverlapWidth * 100}% - 4px)"
               >
                 <div
                   class="inner"

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -1,14 +1,12 @@
 <svelte:options tag="nylas-availability" />
 
 <script lang="ts">
-  import { store } from "../../../commons/src";
+  import { ManifestStore } from "../../../commons/src";
   import { onMount, tick } from "svelte";
   import { get_current_component } from "svelte/internal";
   import { getEventDispatcher } from "@commons/methods/component";
   import { timeDay, timeHour, TimeInterval, timeMinute } from "d3-time";
   import { scaleTime } from "d3-scale";
-
-  const { ManifestStore } = store;
 
   //#region props
   export let id: string = "";

--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -7,21 +7,19 @@
   import "./components/DatepickerModal.svelte";
   import "../../contacts-search/src/ContactsSearch.svelte";
   import LoadingIcon from "./assets/loading.svg";
-  import { store, connections } from "@commons";
+  import {
+    ManifestStore,
+    sendMessage,
+    fetchAccount,
+    uploadFile as nylasUploadFile,
+  } from "@commons";
   import {
     buildInternalProps,
     getPropertyValue,
     getEventDispatcher,
   } from "@commons/methods/component";
   import { onMount, tick, get_current_component } from "svelte/internal";
-  import SendLaterIcon from "./assets/send-later.svg";
   import pkg from "../package.json";
-
-  const {
-    sendMessage,
-    fetchAccount,
-    uploadFile: nylasUploadFile,
-  } = connections;
 
   const dispatchEvent = getEventDispatcher(get_current_component());
   $: dispatchEvent("manifestLoaded", manifest);
@@ -43,7 +41,6 @@
   import AttachmentIcon from "./assets/attachment.svg";
   import ExpandIcon from "./assets/expand.svg";
 
-  const { ManifestStore } = store;
   let fileSelector: HTMLInputElement;
 
   type ContactSearchCallback =

--- a/components/contact-list/src/ContactList.svelte
+++ b/components/contact-list/src/ContactList.svelte
@@ -2,7 +2,12 @@
 
 <script lang="ts">
   import formatDistanceStrict from "date-fns/formatDistanceStrict";
-  import { connections, methods, store } from "@commons";
+  import {
+    fetchContactImage,
+    fetchContacts,
+    ContactStore,
+    ManifestStore,
+  } from "@commons";
   import { get_current_component, onMount } from "svelte/internal";
   import { tick } from "svelte";
   import { debounce } from "@commons/methods/component";
@@ -11,8 +16,6 @@
     getPropertyValue,
     getEventDispatcher,
   } from "@commons/methods/component";
-
-  const { ContactStore, ManifestStore } = store;
 
   export let id: string = "";
   export let access_token: string = "";
@@ -117,15 +120,15 @@
   */
   function setContacts() {
     status = "loading";
-    connections
-      .fetchContacts(query, offset, contacts_to_load)
-      .then((results: Contacts.Contact[]) => {
+    fetchContacts(query, offset, contacts_to_load).then(
+      (results: Contacts.Contact[]) => {
         if (results.length > 0) {
           hydratedContacts = $ContactStore[queryKey];
           offset += contacts_to_load;
         }
         status = "loaded";
-      });
+      },
+    );
   }
 
   /*
@@ -511,9 +514,7 @@
                 />
               {/if}
             {:else if contact.picture_url}
-              {#await connections
-                .fetchContactImage(query, contact.id)
-                .then((image) => (contact.picture = image))}
+              {#await fetchContactImage(query, contact.id).then((image) => (contact.picture = image))}
                 {(contact.picture = "Loading")}
               {/await}
             {:else if contact.default_picture}

--- a/components/day/src/Day.svelte
+++ b/components/day/src/Day.svelte
@@ -1,11 +1,14 @@
 <svelte:options tag="nylas-day" />
 
 <script lang="ts">
-  import { store, connections } from "../../../commons/src";
+  import {
+    EventStore,
+    MessageStore,
+    ManifestStore,
+    fetchMessages,
+  } from "../../../commons/src";
   import { get_current_component } from "svelte/internal";
   import { getEventDispatcher } from "@commons/methods/component";
-
-  const { EventStore, MessageStore, ManifestStore } = store;
 
   import {
     arc,
@@ -105,7 +108,6 @@
   const getEvents = async () => {
     if (!events && !$EventStore[JSON.stringify(eventsQuery)]) {
       eventStatus = "loading";
-      // await connections.fetchEvents(eventsQuery);
       events = (await EventStore.getEvents(eventsQuery)) || [];
     }
     eventStatus = "loaded";
@@ -115,7 +117,7 @@
   const getMessages = async () => {
     if (!messages && !$MessageStore[JSON.stringify(messagesQuery)]) {
       messageStatus = "loading";
-      await connections.fetchMessages(messagesQuery, 0, 100);
+      await fetchMessages(messagesQuery, 0, 100);
     }
     messageStatus = "loaded";
     return $MessageStore[JSON.stringify(messagesQuery)];

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -9,7 +9,6 @@
     updateThread,
     fetchMessage,
     fetchEmail,
-    ErrorStore,
   } from "@commons";
   import { get_current_component, onMount, tick } from "svelte/internal";
   import {

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -1,15 +1,22 @@
 <svelte:options tag="nylas-email" />
 
 <script lang="ts">
-  import { store, connections } from "@commons";
+  import {
+    MailboxStore,
+    Threads,
+    ManifestStore,
+    fetchAccount,
+    updateThread,
+    fetchMessage,
+    fetchEmail,
+    ErrorStore,
+  } from "@commons";
   import { get_current_component, onMount, tick } from "svelte/internal";
   import {
     buildInternalProps,
     getEventDispatcher,
     getPropertyValue,
   } from "@commons/methods/component";
-
-  const { MailboxStore, Threads, ManifestStore } = store;
 
   let manifest: Partial<Nylas.EmailProperties> = {};
 
@@ -44,6 +51,7 @@
 
   // The reference to $$props is lost each time it gets updated, so we have to rebuild the proxy each time
   // TODO - Find a way to improve this
+  let internalProps;
   $: internalProps = buildInternalProps($$props, manifest);
 
   $: theme = getPropertyValue(internalProps.theme, theme, "theme-1");
@@ -109,21 +117,21 @@
     });
   }
   // #endregion thread intake and set
-
+  let emailManuallyPassed;
   $: emailManuallyPassed = !!thread;
 
   $: if (id && !you.id) {
-    connections
-      .fetchAccount({ component_id: query.component_id })
-      .then((account: Nylas.Account) => {
+    fetchAccount({ component_id: query.component_id }).then(
+      (account: Nylas.Account) => {
         you = account;
-      });
+      },
+    );
   }
 
   function saveActiveThread() {
     // if thread and if component_id (security)
     if (activeThread && query.component_id && thread_id) {
-      connections.updateThread(query, activeThread).then((thread) => {
+      updateThread(query, activeThread).then((thread) => {
         $MailboxStore[queryKey] = [thread];
       });
     }
@@ -139,9 +147,8 @@
       //#endregion read/unread
 
       const lastMsgIndex = activeThread.messages.length - 1;
-      activeThread.messages[lastMsgIndex].expanded = !activeThread.messages[
-        lastMsgIndex
-      ].expanded;
+      activeThread.messages[lastMsgIndex].expanded =
+        !activeThread.messages[lastMsgIndex].expanded;
 
       if (!emailManuallyPassed) {
         // fetch last message
@@ -202,9 +209,8 @@
     if (msgIndex === activeThread.messages.length - 1) {
       doNothing(e);
     } else {
-      activeThread.messages[msgIndex].expanded = !activeThread.messages[
-        msgIndex
-      ].expanded;
+      activeThread.messages[msgIndex].expanded =
+        !activeThread.messages[msgIndex].expanded;
       dispatchEvent("messageClicked", {
         event: e,
         message: activeThread.messages[msgIndex],
@@ -222,9 +228,8 @@
       if (msgIndex === activeThread.messages.length - 1) {
         doNothing(e);
       } else {
-        activeThread.messages[msgIndex].expanded = !activeThread.messages[
-          msgIndex
-        ].expanded;
+        activeThread.messages[msgIndex].expanded =
+          !activeThread.messages[msgIndex].expanded;
       }
     }
   }
@@ -233,7 +238,7 @@
     const messageID = activeThread.messages[msgIndex].id;
 
     messageLoadStatus[msgIndex] = "loading";
-    connections.fetchMessage(query, messageID).then((json) => {
+    fetchMessage(query, messageID).then((json) => {
       activeThread.messages[msgIndex].body = json.body;
       messageLoadStatus[msgIndex] = "loaded";
     });
@@ -245,12 +250,10 @@
 
   // For cases when someone wants to show just a single email message, rather than the full thread.
   function fetchOneMessage() {
-    connections
-      .fetchEmail({ component_id: id, message_id: message_id })
-      .then((json) => {
-        message = json;
-        messageLoadStatus[0] = "loaded";
-      });
+    fetchEmail({ component_id: id, message_id: message_id }).then((json) => {
+      message = json;
+      messageLoadStatus[0] = "loaded";
+    });
   }
 </script>
 
@@ -500,7 +503,7 @@
                                 to&colon;&nbsp;{to.email === you.email_address
                                   ? "me"
                                   : to.name || to.email}
-                                {#if i != message.to.length - 1}
+                                {#if i !== message.to.length - 1}
                                   &nbsp;&comma;
                                 {/if}
                               {/if}
@@ -618,7 +621,7 @@
                       to&colon;&nbsp;{to.email === you.email_address
                         ? "me"
                         : to.name || to.email}
-                      {#if i != message.to.length - 1}
+                      {#if i !== message.to.length - 1}
                         &nbsp;&comma;
                       {/if}
                     {/if}

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -1,7 +1,7 @@
 <svelte:options tag="nylas-mailbox" />
 
 <script lang="ts">
-  import { store } from "@commons";
+  import { ManifestStore } from "@commons";
   import { get_current_component, onMount, tick } from "svelte/internal";
   import {
     buildInternalProps,
@@ -14,8 +14,6 @@
   import { AccountStore } from "@commons/store/accounts";
   import { fetchMessage } from "@commons/connections/messages";
   import LoadingIcon from "./assets/loading.svg";
-
-  const { ManifestStore } = store;
 
   let manifest: Partial<Nylas.EmailProperties> = {};
 
@@ -31,10 +29,8 @@
   export let unread_status: "read" | "unread" | "default";
   export let header: string | null;
   export let actionsBar: string[];
-  export let onSelectThread: (
-    event: Event,
-    t: Nylas.Thread,
-  ) => void = onSelectOne;
+  export let onSelectThread: (event: Event, t: Nylas.Thread) => void =
+    onSelectOne;
 
   let queryParams: Nylas.ThreadsQuery;
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "eslint": "^7.7.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-cypress": "^2.11.3",
-    "eslint-plugin-svelte3": "^2.7.3",
+    "eslint-plugin-svelte3": "git+https://github.com/nylas/eslint-plugin-svelte3.git#82ff79a12fd6d1d45a098b3fb69d572e42581dfa",
     "esbuild": "0.12.15",
     "rollup-plugin-esbuild": "4.5.0",
     "fetch-mock": "^9.11.0",

--- a/scripts/template/src/index.svelte
+++ b/scripts/template/src/index.svelte
@@ -1,10 +1,9 @@
 <svelte:options tag="nylas-$NAME$" />
 
 <script lang="ts">
-  import { store } from "../../../commons/src";
+  import { ManifestStore } from "../../../commons/src";
   import { onMount, tick } from "svelte";
 
-  const { ManifestStore } = store;
   export let id: string = "";
   export let access_token: string = "";
 

--- a/tests/agenda/agenda.spec.ts
+++ b/tests/agenda/agenda.spec.ts
@@ -1,5 +1,5 @@
 import { fireEvent, render } from "@testing-library/svelte";
-import { connections } from "../../commons/src/";
+import * as connections from "../../commons/src/";
 import { CalendarStore } from "../../commons/src/store/calendars";
 import { EventStore } from "../../commons/src/store/events";
 import { ManifestStore } from "../../commons/src/store/manifest";


### PR DESCRIPTION
- [x] Reorginize code in a way that allows esbuilt to strip off unused stores, when building a specific component. 
E.g. Agenda doesn't care about ContactStore
- [x] Adopt nylas eslint plugin for svelte
- [x] nylas-error was not included in any of the component, since it required implicit import. Fix that by importing it in commons and telling esbuilt to not tree-shake it
- [x] fix typescript warnings here and there