### PR TITLE
Ticks as their own column in an optional prop

### DIFF
--- a/commons/types/Availability.d.ts
+++ b/commons/types/Availability.d.ts
@@ -6,6 +6,7 @@ declare namespace Availability {
     start_date: Date;
     dates_to_show: number;
     available_times: TimeSlot[];
+    show_ticks: boolean;
   }
 
   interface TimeSlot {

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -83,7 +83,8 @@
 
   let ticks: Date[] = [];
 
-  const minimumTickHeight = 30;
+  const minimumTickHeight = 30; // minimum pixels between ticks, vertically
+  const slotSizes = [15, 30, 60, 180, 360]; // we only want to show ticks in intervals of 15 mins, 30 mins, 60 mins, 3 hours, or 6 hours.
 
   $: ticks = generateTicks(
     clientHeight,
@@ -100,8 +101,7 @@
     intervalCounter: number = 0,
   ): Date[] => {
     // console.time('ticks')
-    let slotSizes = [15, 30, 60, 180, 360]; // we only want to show ticks in intervals of 15 mins, 30 mins, 60 mins, 3 hours, or 6 hours.
-    let tickIters = slotSizes[intervalCounter];
+    const tickIters = slotSizes[intervalCounter];
 
     // ternary here because timeMinute.every(120) doesnt work, but timeHour.every(2) does.
     let timeInterval =
@@ -110,10 +110,10 @@
         : timeMinute.every(tickIters);
 
     ticks = scaleTime()
-      .domain([ticks[0], ticks[ticks.length - 1]])
+      .domain(ticks)
       .ticks(timeInterval as TimeInterval);
 
-    let averageTickHeight = height / ticks.length;
+    const averageTickHeight = height / ticks.length;
 
     if (
       tickIters < slot_size || // dont show 15-min ticks if slot size is hourly

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -42,10 +42,9 @@
   let slotSelection: Availability.SelectableSlot[] = [];
 
   // You can have as few as 1, and as many as 7, days shown
-  $: startDay = timeDay(new Date(new Date().setDate(start_date.getDate())));
-  $: endDay = timeDay(
-    new Date(new Date().setDate(start_date.getDate() + dates_to_show - 1)),
-  );
+  $: console.log({ start_date }, { startDay }, timeDay.floor(start_date));
+  $: startDay = timeDay.floor(start_date);
+  $: endDay = timeDay.offset(start_date, dates_to_show - 1);
 
   // map over the ticks() of the time scale between your start day and end day
   // populate them with as many slots as your start_hour, end_hour, and slot_size dictate
@@ -131,6 +130,7 @@
     .domain([startDay, endDay])
     .ticks(timeDay)
     .map((timestamp) => {
+      console.log("timestamp here", timestamp);
       let slots = generateDaySlots(timestamp, start_hour, end_hour);
       return {
         slots,

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -68,7 +68,7 @@
         let slotIsAvailable = true; // default
         if (available_times.length) {
           slotIsAvailable = available_times.some((slot) => {
-            return time > slot.start_time && endTime < slot.end_time;
+            return time >= slot.start_time && endTime <= slot.end_time;
           });
         }
 

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -5,7 +5,8 @@
   import { onMount, tick } from "svelte";
   import { get_current_component } from "svelte/internal";
   import { getEventDispatcher } from "@commons/methods/component";
-  import { timeDay, timeHour, TimeInterval, timeMinute } from "d3-time";
+  import type { TimeInterval } from "d3-time";
+  import { timeDay, timeHour, timeMinute } from "d3-time";
   import { scaleTime } from "d3-scale";
 
   //#region props
@@ -18,6 +19,7 @@
   export let dates_to_show: number = 1;
   export let click_action: "choose" | "verify" = "choose";
   export let available_times: Availability.TimeSlot[] = [];
+  export let show_ticks: boolean = true;
 
   //#endregion props
 
@@ -118,26 +120,59 @@
 </script>
 
 <style lang="scss">
+  $headerHeight: 50px;
   main {
     height: 100vh;
     overflow: hidden;
     display: grid;
     grid-template-rows: 1fr auto;
+
+    &.ticked {
+      grid-template-columns: auto 1fr;
+    }
+
     .days {
       display: grid;
       grid-auto-flow: column;
       grid-auto-columns: auto;
     }
 
+    .ticks {
+      display: grid;
+      grid-auto-flow: row;
+      grid-auto-rows: auto;
+      height: calc(100% - #{$headerHeight});
+      list-style-type: none;
+      margin: 0;
+      padding: 0;
+      overflow: hidden;
+      padding-top: $headerHeight;
+      font-size: 0.6rem;
+      font-family: sans-serif;
+      // text-align: right;
+
+      li {
+        display: block;
+        position: relative;
+        height: auto;
+        overflow: hidden;
+        padding: 0.25rem;
+        display: grid;
+        align-content: center;
+        justify-content: right;
+      }
+    }
+
     .day {
       display: grid;
-      grid-template-rows: auto 1fr;
+      grid-template-rows: $headerHeight 1fr;
 
       h2 {
         margin: 0;
         padding: 0;
         text-align: center;
       }
+
       .slots {
         display: grid;
         grid-auto-flow: row;
@@ -175,12 +210,20 @@
     footer.confirmation {
       text-align: center;
       padding: 1rem;
+      grid-column: -1 / 1;
     }
   }
 </style>
 
 <nylas-error {id} />
-<main bind:this={main}>
+<main bind:this={main} class:ticked={show_ticks}>
+  {#if show_ticks}
+    <ul class="ticks">
+      {#each days[0].slots as slot}
+        <li class="tick">{new Date(slot.start_time).toLocaleTimeString()}</li>
+      {/each}
+    </ul>
+  {/if}
   <div class="days">
     {#each days as day}
       <div class="day">

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -55,6 +55,15 @@
               component.click_action = event.target.value;
             });
           });
+
+        document
+          .querySelectorAll('input[name="show-ticks"]')
+          .forEach((elem) => {
+            elem.addEventListener("change", function (event) {
+              console.log("ya", event);
+              component.show_ticks = JSON.parse(event.target.value);
+            });
+          });
       });
     </script>
   </head>
@@ -78,6 +87,14 @@
 
     aside label {
       display: block;
+    }
+
+    .demo-box {
+      width: 80vw;
+      margin-left: 10vw;
+      border: 1px solid #f00;
+      height: 80vh;
+      margin-top: 10vh;
     }
   </style>
   <body>
@@ -145,10 +162,21 @@
         <input type="radio" name="click-action" value="verify" />
         <strong>Verify</strong>
       </label>
+      <strong>Show Ticks</strong>
+      <label>
+        <input checked type="radio" name="show-ticks" value="true" />
+        <strong>True</strong>
+      </label>
+      <label>
+        <input type="radio" name="show-ticks" value="false" />
+        <strong>False</strong>
+      </label>
     </aside>
 
     <main>
-      <nylas-availability id="demo-availability"></nylas-availability>
+      <div class="demo-box">
+        <nylas-availability id="demo-availability"></nylas-availability>
+      </div>
     </main>
   </body>
 </html>

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -60,7 +60,6 @@
           .querySelectorAll('input[name="show-ticks"]')
           .forEach((elem) => {
             elem.addEventListener("change", function (event) {
-              console.log("ya", event);
               component.show_ticks = JSON.parse(event.target.value);
             });
           });
@@ -92,7 +91,8 @@
     .demo-box {
       width: 80vw;
       margin-left: 10vw;
-      border: 1px solid #f00;
+      box-shadow: 0 0 10px rgba(0, 0, 0, 0.25);
+      padding: 2rem;
       height: 80vh;
       margin-top: 10vh;
     }

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -15,12 +15,12 @@
 
         const available_times = [
           {
-            start_time: new Date(new Date().setHours(3)),
-            end_time: new Date(new Date().setHours(6)),
+            start_time: new Date(new Date().setHours(3, 0, 0, 0)),
+            end_time: new Date(new Date().setHours(6, 0, 0, 0)),
           },
           {
-            start_time: new Date(new Date().setHours(9)),
-            end_time: new Date(new Date().setHours(15)),
+            start_time: new Date(new Date().setHours(9, 0, 0, 0)),
+            end_time: new Date(new Date().setHours(15, 0, 0, 0)),
           },
         ];
 

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -70,7 +70,6 @@
     body {
       padding: 0;
       margin: 0;
-      height: 100vh;
     }
 
     aside {
@@ -91,8 +90,6 @@
     .demo-box {
       width: 80vw;
       margin-left: 10vw;
-      box-shadow: 0 0 10px rgba(0, 0, 0, 0.25);
-      padding: 2rem;
       height: 80vh;
       margin-top: 10vh;
     }

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -137,4 +137,45 @@ describe("availability component", () => {
         });
     });
   });
+
+  describe("axis ticks", () => {
+    it("shows ticks by default", () => {
+      cy.get("ul.ticks").should("exist");
+    });
+
+    it("allows you to disable ticks column", () => {
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.show_ticks = false;
+          cy.get("ul.ticks").should("not.exist");
+        });
+    });
+
+    it("dynamically skips ticks depending on screen size and number of slots", () => {
+      cy.viewport(550, 1500);
+      cy.get("li.tick").should("have.length", 24);
+      cy.viewport(550, 750);
+      cy.get("li.tick").should("have.length", 8);
+      cy.viewport(550, 150);
+      cy.get("li.tick").should("have.length", 4);
+      cy.viewport(550, 2500);
+      cy.get("li.tick").should("have.length", 48);
+      cy.viewport(550, 4000);
+      cy.get("li.tick").should("have.length", 96);
+
+      cy.get("nylas-availability").invoke("attr", "slot_size", 60);
+      cy.get("li.tick").should("have.length", 24);
+
+      cy.get("nylas-availability").invoke("attr", "slot_size", 30);
+      cy.get("li.tick").should("have.length", 48);
+
+      cy.get("nylas-availability").invoke("attr", "slot_size", 15);
+      cy.get("nylas-availability").invoke("attr", "end_hour", 8);
+
+      cy.viewport(550, 1500);
+      cy.get("li.tick").should("have.length", 32);
+    });
+  });
 });

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -17,7 +17,7 @@ describe("availability component", () => {
         .should("eq", today.toLocaleString());
       cy.get(".slot")
         .last()
-        .invoke("attr", "data-start-time")
+        .invoke("attr", "data-end-time")
         .should("eq", tomorrow.toLocaleString());
     });
 
@@ -29,7 +29,7 @@ describe("availability component", () => {
           component.start_hour = 8;
           const start_time = new Date();
           start_time.setHours(component.start_hour, 0, 0);
-          cy.get(".slot").should("have.length", 65);
+          cy.get(".slot").should("have.length", 64);
           cy.get(".slot")
             .first()
             .invoke("attr", "data-start-time")
@@ -45,10 +45,10 @@ describe("availability component", () => {
           component.end_hour = 8;
           const end_time = new Date();
           end_time.setHours(component.end_hour, 0, 0);
-          cy.get(".slot").should("have.length", 33);
+          cy.get(".slot").should("have.length", 32);
           cy.get(".slot")
             .last()
-            .invoke("attr", "data-start-time")
+            .invoke("attr", "data-end-time")
             .should("eq", end_time.toLocaleString());
         });
     });
@@ -56,7 +56,7 @@ describe("availability component", () => {
 
   describe("slot_size prop", () => {
     it("Shows 15 minute time slots as default", () => {
-      cy.get(".slot").should("have.length", 97);
+      cy.get(".slot").should("have.length", 96);
     });
 
     it("Updates slot_size via component prop", () => {
@@ -65,7 +65,7 @@ describe("availability component", () => {
         .then((element) => {
           const component = element[0];
           component.slot_size = 60;
-          cy.get(".slot").should("have.length", 25);
+          cy.get(".slot").should("have.length", 24);
         });
     });
   });


### PR DESCRIPTION
- Added an optional property (defaults to true) to show ticks in the left-most column
- wrote a tick generator function that will recursively try to find out the most appropriate way to subdivide your shown day. (for example, conventions are to show hours 3, 6, 9, and 12 on a clock but not 2, 4, 6, 8, 10, 12)
- generator refires on height change, length of slot, or working hours

![CleanShot 2021-07-22 at 16 23 08](https://user-images.githubusercontent.com/713991/126704712-c30ad6c2-0b5b-44ce-8a0f-695c83403f7f.png)
![CleanShot 2021-07-22 at 16 23 20](https://user-images.githubusercontent.com/713991/126704732-49094252-9358-460e-9442-799edba0c21f.png)

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
