### PR TITLE
Accept multiple sets of availability, plus "busy" designations

### DIFF
--- a/commons/types/Availability.d.ts
+++ b/commons/types/Availability.d.ts
@@ -5,16 +5,19 @@ declare namespace Availability {
     slot_size: 15 | 30 | 60;
     start_date: Date;
     dates_to_show: number;
-    available_times: TimeSlot[] | Timeslot[][];
-    unavailable_times: TimeSlot[] | Timeslot[][];
     show_ticks: boolean;
+    calendars: Calendar[];
   }
 
+  interface Calendar {
+    email_address: string;
+    availability: "free" | "busy";
+    timeslots: TimeSlot[];
+  }
   interface TimeSlot {
     start_time: Date;
     end_time: Date;
   }
-
   interface SelectableSlot extends TimeSlot {
     selectionStatus: "unselected" | "selected";
     availability: "available" | "unavailable" | "partial";

--- a/commons/types/Availability.d.ts
+++ b/commons/types/Availability.d.ts
@@ -1,4 +1,10 @@
 declare namespace Availability {
+  enum AvailabilityStatus {
+    Free = "free",
+    Busy = "busy",
+    Partial = "partial",
+  }
+
   interface Manifest extends Nylas.Manifest {
     start_hour: number;
     end_hour: number;
@@ -10,8 +16,8 @@ declare namespace Availability {
   }
 
   interface Calendar {
-    email_address: string;
-    availability: "free" | "busy";
+    emailAddress: string;
+    availability: AvailabilityStatus.Free | AvailabilityStatus.Busy;
     timeslots: TimeSlot[];
   }
   interface TimeSlot {
@@ -20,6 +26,6 @@ declare namespace Availability {
   }
   interface SelectableSlot extends TimeSlot {
     selectionStatus: "unselected" | "selected";
-    availability: "available" | "unavailable" | "partial";
+    availability: AvailabilityStatus;
   }
 }

--- a/commons/types/Availability.d.ts
+++ b/commons/types/Availability.d.ts
@@ -6,6 +6,7 @@ declare namespace Availability {
     start_date: Date;
     dates_to_show: number;
     available_times: TimeSlot[];
+    unavailable_times: TimeSlot[];
     show_ticks: boolean;
   }
 

--- a/commons/types/Availability.d.ts
+++ b/commons/types/Availability.d.ts
@@ -5,8 +5,8 @@ declare namespace Availability {
     slot_size: 15 | 30 | 60;
     start_date: Date;
     dates_to_show: number;
-    available_times: TimeSlot[];
-    unavailable_times: TimeSlot[];
+    available_times: TimeSlot[] | Timeslot[][];
+    unavailable_times: TimeSlot[] | Timeslot[][];
     show_ticks: boolean;
   }
 
@@ -17,5 +17,6 @@ declare namespace Availability {
 
   interface SelectableSlot extends TimeSlot {
     selectionStatus: "unselected" | "selected";
+    availability: "available" | "unavailable" | "partial";
   }
 }

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -75,7 +75,7 @@
               }
             } else if (c.availability === "free" || !c.availability) {
               // if they pass in a calendar, but don't have availability, assume the timeslots are available.
-              if (availabilityavailabilityExistsInSlotExistsInSlot) {
+              if (availabilityExistsInSlot) {
                 freeCalendars.push(c.emailAddress);
               }
             }

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -60,28 +60,23 @@
       .slice(0, -1) // dont show the 25th hour
       .map((time) => {
         const endTime = timeMinute.offset(time, slot_size);
-        let freeCalendars = [];
+        const freeCalendars: string[] = [];
 
         let availability = "available"; // default
 
         if (calendars.length) {
           calendars.forEach((c) => {
+            let availabilityExistsInSlot = c.timeslots.some(
+              (slot) => time >= slot.start_time && endTime <= slot.end_time,
+            );
             if (c.availability === "busy") {
-              if (
-                !c.timeslots.some(
-                  (slot) => time >= slot.start_time && endTime <= slot.end_time,
-                )
-              ) {
-                freeCalendars.push(c.email_address);
+              if (!availabilityExistsInSlot) {
+                freeCalendars.push(c.emailAddress);
               }
             } else if (c.availability === "free" || !c.availability) {
               // if they pass in a calendar, but don't have availability, assume the timeslots are available.
-              if (
-                c.timeslots.some(
-                  (slot) => time >= slot.start_time && endTime <= slot.end_time,
-                )
-              ) {
-                freeCalendars.push(c.email_address);
+              if (availabilityavailabilityExistsInSlotExistsInSlot) {
+                freeCalendars.push(c.emailAddress);
               }
             }
           });

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -19,14 +19,7 @@
   export let dates_to_show: number = 1;
   export let click_action: "choose" | "verify" = "choose";
   export let calendars: Availability.Calendar[] = [];
-  // export let available_times:
-  //   | Availability.TimeSlot[]
-  //   | Availability.TimeSlot[][] = [];
-  // export let unavailable_times:
-  //   | Availability.TimeSlot[]
-  //   | Availability.TimeSlot[][] = [];
   export let show_ticks: boolean = true;
-
   //#endregion props
 
   //#region mount

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -19,6 +19,7 @@
   export let dates_to_show: number = 1;
   export let click_action: "choose" | "verify" = "choose";
   export let available_times: Availability.TimeSlot[] = [];
+  export let unavailable_times: Availability.TimeSlot[] = [];
   export let show_ticks: boolean = true;
 
   //#endregion props
@@ -65,9 +66,16 @@
         const endTime = timeMinute.offset(time, slot_size);
 
         let slotIsAvailable = true; // default
+
+        // available_times and unavailable_times are mutually exclusive props: if you use one, don't use the other.
+        // If you have both available_times and unavailable_times, for some reason, available_times will be observed and unavailable_times will be ignored.
         if (available_times.length) {
           slotIsAvailable = available_times.some((slot) => {
             return time >= slot.start_time && endTime <= slot.end_time;
+          });
+        } else if (unavailable_times.length) {
+          slotIsAvailable = unavailable_times.every((slot) => {
+            return !(time >= slot.start_time && endTime <= slot.end_time);
           });
         }
 

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -26,8 +26,18 @@
           ],
           [
             {
-              start_time: new Date(new Date().setHours(1, 0, 0, 0)),
+              start_time: new Date(new Date().setHours(4, 0, 0, 0)),
               end_time: new Date(new Date().setHours(11, 0, 0, 0)),
+            },
+          ],
+          [
+            {
+              start_time: new Date(new Date().setHours(5, 0, 0, 0)),
+              end_time: new Date(new Date().setHours(11, 0, 0, 0)),
+            },
+            {
+              start_time: new Date(new Date().setHours(21, 0, 0, 0)),
+              end_time: new Date(new Date().setHours(23, 0, 0, 0)),
             },
           ],
         ];

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -129,7 +129,7 @@
           class="days"
           type="range"
           min="1"
-          max="14"
+          max="7"
           step="1"
           value="1"
         />

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -13,36 +13,44 @@
         const endTimeInput = document.querySelector("input#end-time");
         const daysInput = document.querySelector("input#days-to-show");
 
-        const available_times = [
-          [
-            {
-              start_time: new Date(new Date().setHours(3, 0, 0, 0)),
-              end_time: new Date(new Date().setHours(6, 0, 0, 0)),
-            },
-            {
-              start_time: new Date(new Date().setHours(9, 0, 0, 0)),
-              end_time: new Date(new Date().setHours(15, 0, 0, 0)),
-            },
-          ],
-          [
-            {
-              start_time: new Date(new Date().setHours(4, 0, 0, 0)),
-              end_time: new Date(new Date().setHours(11, 0, 0, 0)),
-            },
-          ],
-          [
-            {
-              start_time: new Date(new Date().setHours(5, 0, 0, 0)),
-              end_time: new Date(new Date().setHours(11, 0, 0, 0)),
-            },
-            {
-              start_time: new Date(new Date().setHours(21, 0, 0, 0)),
-              end_time: new Date(new Date().setHours(23, 0, 0, 0)),
-            },
-          ],
+        const calendars = [
+          {
+            email_address: "person@name.com",
+            availability: "busy",
+            timeslots: [
+              {
+                start_time: new Date(new Date().setHours(3, 0, 0, 0)),
+                end_time: new Date(new Date().setHours(6, 0, 0, 0)),
+              },
+              {
+                start_time: new Date(new Date().setHours(9, 0, 0, 0)),
+                end_time: new Date(new Date().setHours(15, 0, 0, 0)),
+              },
+            ],
+          },
+          {
+            email_address: "thelonious@nylas.com",
+            availability: "busy",
+            timeslots: [
+              {
+                start_time: new Date(new Date().setHours(4, 0, 0, 0)),
+                end_time: new Date(new Date().setHours(11, 0, 0, 0)),
+              },
+            ],
+          },
+          {
+            email_address: "booker@nylas.com",
+            availability: "free",
+            timeslots: [
+              {
+                start_time: new Date(new Date().setHours(5, 30, 0, 0)),
+                end_time: new Date(new Date().setHours(16, 0, 0, 0)),
+              },
+            ],
+          },
         ];
 
-        component.available_times = available_times;
+        component.calendars = calendars;
 
         component.addEventListener("timeSlotChosen", (event) => {
           console.log(event.detail.timeslot);
@@ -121,7 +129,7 @@
           class="days"
           type="range"
           min="1"
-          max="7"
+          max="14"
           step="1"
           value="1"
         />

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -15,7 +15,7 @@
 
         const calendars = [
           {
-            email_address: "person@name.com",
+            emailAddress: "person@name.com",
             availability: "busy",
             timeslots: [
               {
@@ -29,7 +29,7 @@
             ],
           },
           {
-            email_address: "thelonious@nylas.com",
+            emailAddress: "thelonious@nylas.com",
             availability: "busy",
             timeslots: [
               {
@@ -39,7 +39,7 @@
             ],
           },
           {
-            email_address: "booker@nylas.com",
+            emailAddress: "booker@nylas.com",
             availability: "free",
             timeslots: [
               {

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -14,14 +14,22 @@
         const daysInput = document.querySelector("input#days-to-show");
 
         const available_times = [
-          {
-            start_time: new Date(new Date().setHours(3, 0, 0, 0)),
-            end_time: new Date(new Date().setHours(6, 0, 0, 0)),
-          },
-          {
-            start_time: new Date(new Date().setHours(9, 0, 0, 0)),
-            end_time: new Date(new Date().setHours(15, 0, 0, 0)),
-          },
+          [
+            {
+              start_time: new Date(new Date().setHours(3, 0, 0, 0)),
+              end_time: new Date(new Date().setHours(6, 0, 0, 0)),
+            },
+            {
+              start_time: new Date(new Date().setHours(9, 0, 0, 0)),
+              end_time: new Date(new Date().setHours(15, 0, 0, 0)),
+            },
+          ],
+          [
+            {
+              start_time: new Date(new Date().setHours(1, 0, 0, 0)),
+              end_time: new Date(new Date().setHours(11, 0, 0, 0)),
+            },
+          ],
         ];
 
         component.available_times = available_times;

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -4,6 +4,87 @@ describe("availability component", () => {
     cy.get("nylas-availability").should("exist");
   });
 
+  describe("available times", () => {
+    it("observes available times", () => {
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.available_times = [];
+          cy.get(".slot.unavailable").should("not.exist");
+        });
+
+      const available_times = [
+        {
+          start_time: new Date(new Date().setHours(1, 0, 0, 0)),
+          end_time: new Date(new Date().setHours(3, 0, 0, 0)),
+        },
+        {
+          start_time: new Date(new Date().setHours(8, 0, 0, 0)),
+          end_time: new Date(new Date().setHours(16, 0, 0, 0)),
+        },
+      ];
+
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.available_times = available_times;
+          cy.get(".slot.unavailable").should("exist");
+          cy.get(".slot.available").should("have.length", 40);
+        });
+
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.slot_size = 30;
+          cy.get(".slot.available").should("have.length", 20);
+        });
+    });
+  });
+
+  describe("unavailable times", () => {
+    it("observes unavailable times", () => {
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.available_times = [];
+          component.unavailable_times = [];
+          cy.get(".slot.unavailable").should("not.exist");
+        });
+
+      const unavailable_times = [
+        {
+          start_time: new Date(new Date().setHours(1, 0, 0, 0)),
+          end_time: new Date(new Date().setHours(3, 0, 0, 0)),
+        },
+        {
+          start_time: new Date(new Date().setHours(8, 0, 0, 0)),
+          end_time: new Date(new Date().setHours(16, 0, 0, 0)),
+        },
+      ];
+
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.unavailable_times = unavailable_times;
+          cy.get(".slot.unavailable").should("exist");
+          cy.get(".slot.available").should("have.length", 56);
+        });
+
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.slot_size = 30;
+          cy.get(".slot.available").should("have.length", 28);
+        });
+    });
+  });
+
   describe("start and ending hour props", () => {
     it("Shows timeslots from 12AM to the next day's 12AM by default", () => {
       const today = new Date();

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -10,18 +10,23 @@ describe("availability component", () => {
         .as("availability")
         .then((element) => {
           const component = element[0];
-          component.available_times = [];
-          cy.get(".slot.unavailable").should("not.exist");
+          component.calendars = [];
+          cy.get(".slot.busy").should("not.exist");
         });
 
-      const available_times = [
+      const calendars = [
         {
-          start_time: new Date(new Date().setHours(1, 0, 0, 0)),
-          end_time: new Date(new Date().setHours(3, 0, 0, 0)),
-        },
-        {
-          start_time: new Date(new Date().setHours(8, 0, 0, 0)),
-          end_time: new Date(new Date().setHours(16, 0, 0, 0)),
+          availability: "free",
+          timeslots: [
+            {
+              start_time: new Date(new Date().setHours(1, 0, 0, 0)),
+              end_time: new Date(new Date().setHours(3, 0, 0, 0)),
+            },
+            {
+              start_time: new Date(new Date().setHours(8, 0, 0, 0)),
+              end_time: new Date(new Date().setHours(16, 0, 0, 0)),
+            },
+          ],
         },
       ];
 
@@ -29,9 +34,9 @@ describe("availability component", () => {
         .as("availability")
         .then((element) => {
           const component = element[0];
-          component.available_times = available_times;
-          cy.get(".slot.unavailable").should("exist");
-          cy.get(".slot.available").should("have.length", 40);
+          component.calendars = calendars;
+          cy.get(".slot.busy").should("exist");
+          cy.get(".slot.free").should("have.length", 40);
         });
 
       cy.get("nylas-availability")
@@ -39,7 +44,7 @@ describe("availability component", () => {
         .then((element) => {
           const component = element[0];
           component.slot_size = 30;
-          cy.get(".slot.available").should("have.length", 20);
+          cy.get(".slot.free").should("have.length", 20);
         });
     });
   });
@@ -50,19 +55,23 @@ describe("availability component", () => {
         .as("availability")
         .then((element) => {
           const component = element[0];
-          component.available_times = [];
-          component.unavailable_times = [];
-          cy.get(".slot.unavailable").should("not.exist");
+          component.calendars = [];
+          cy.get(".slot.busy").should("not.exist");
         });
 
-      const unavailable_times = [
+      const calendars = [
         {
-          start_time: new Date(new Date().setHours(1, 0, 0, 0)),
-          end_time: new Date(new Date().setHours(3, 0, 0, 0)),
-        },
-        {
-          start_time: new Date(new Date().setHours(8, 0, 0, 0)),
-          end_time: new Date(new Date().setHours(16, 0, 0, 0)),
+          availability: "busy",
+          timeslots: [
+            {
+              start_time: new Date(new Date().setHours(1, 0, 0, 0)),
+              end_time: new Date(new Date().setHours(3, 0, 0, 0)),
+            },
+            {
+              start_time: new Date(new Date().setHours(8, 0, 0, 0)),
+              end_time: new Date(new Date().setHours(16, 0, 0, 0)),
+            },
+          ],
         },
       ];
 
@@ -70,9 +79,9 @@ describe("availability component", () => {
         .as("availability")
         .then((element) => {
           const component = element[0];
-          component.unavailable_times = unavailable_times;
-          cy.get(".slot.unavailable").should("exist");
-          cy.get(".slot.available").should("have.length", 56);
+          component.calendars = calendars;
+          cy.get(".slot.busy").should("exist");
+          cy.get(".slot.free").should("have.length", 56);
         });
 
       cy.get("nylas-availability")
@@ -80,49 +89,59 @@ describe("availability component", () => {
         .then((element) => {
           const component = element[0];
           component.slot_size = 30;
-          cy.get(".slot.available").should("have.length", 28);
+          cy.get(".slot.free").should("have.length", 28);
         });
     });
   });
 
   describe("multiple availability sets", () => {
     it("observes multiple availabilites", () => {
-      const available_times = [
-        [
-          {
-            start_time: new Date(new Date().setHours(0, 0, 0, 0)),
-            end_time: new Date(new Date().setHours(6, 0, 0, 0)),
-          },
-          {
-            start_time: new Date(new Date().setHours(9, 0, 0, 0)),
-            end_time: new Date(new Date().setHours(15, 0, 0, 0)),
-          },
-        ],
-        [
-          {
-            start_time: new Date(new Date().setHours(4, 0, 0, 0)),
-            end_time: new Date(new Date().setHours(11, 0, 0, 0)),
-          },
-        ],
-        [
-          {
-            start_time: new Date(new Date().setHours(5, 0, 0, 0)),
-            end_time: new Date(new Date().setHours(11, 0, 0, 0)),
-          },
-          {
-            start_time: new Date(new Date().setHours(21, 0, 0, 0)),
-            end_time: new Date(new Date().setHours(23, 0, 0, 0)),
-          },
-        ],
+      const calendars = [
+        {
+          email_address: "person@name.com",
+          availability: "busy",
+          timeslots: [
+            {
+              start_time: new Date(new Date().setHours(3, 0, 0, 0)),
+              end_time: new Date(new Date().setHours(6, 0, 0, 0)),
+            },
+            {
+              start_time: new Date(new Date().setHours(9, 0, 0, 0)),
+              end_time: new Date(new Date().setHours(15, 0, 0, 0)),
+            },
+          ],
+        },
+        {
+          email_address: "thelonious@nylas.com",
+          availability: "busy",
+          timeslots: [
+            {
+              start_time: new Date(new Date().setHours(4, 0, 0, 0)),
+              end_time: new Date(new Date().setHours(11, 0, 0, 0)),
+            },
+          ],
+        },
+        {
+          email_address: "booker@nylas.com",
+          availability: "busy",
+          timeslots: [
+            {
+              start_time: new Date(new Date().setHours(5, 30, 0, 0)),
+              end_time: new Date(new Date().setHours(16, 0, 0, 0)),
+            },
+          ],
+        },
       ];
 
       cy.get("nylas-availability")
         .as("availability")
         .then((element) => {
           const component = element[0];
-          component.available_times = available_times;
+          component.calendars = calendars;
           cy.get(".slot.partial").should("exist");
-          cy.get(".slot.partial").should("have.length", 56);
+          cy.get(".slot.partial").should("have.length", 42);
+          cy.get(".slot.busy").should("have.length", 10);
+          cy.get(".slot.free").should("have.length", 44);
         });
     });
   });

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -85,6 +85,48 @@ describe("availability component", () => {
     });
   });
 
+  describe("multiple availability sets", () => {
+    it("observes multiple availabilites", () => {
+      const available_times = [
+        [
+          {
+            start_time: new Date(new Date().setHours(0, 0, 0, 0)),
+            end_time: new Date(new Date().setHours(6, 0, 0, 0)),
+          },
+          {
+            start_time: new Date(new Date().setHours(9, 0, 0, 0)),
+            end_time: new Date(new Date().setHours(15, 0, 0, 0)),
+          },
+        ],
+        [
+          {
+            start_time: new Date(new Date().setHours(4, 0, 0, 0)),
+            end_time: new Date(new Date().setHours(11, 0, 0, 0)),
+          },
+        ],
+        [
+          {
+            start_time: new Date(new Date().setHours(5, 0, 0, 0)),
+            end_time: new Date(new Date().setHours(11, 0, 0, 0)),
+          },
+          {
+            start_time: new Date(new Date().setHours(21, 0, 0, 0)),
+            end_time: new Date(new Date().setHours(23, 0, 0, 0)),
+          },
+        ],
+      ];
+
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.available_times = available_times;
+          cy.get(".slot.partial").should("exist");
+          cy.get(".slot.partial").should("have.length", 56);
+        });
+    });
+  });
+
   describe("start and ending hour props", () => {
     it("Shows timeslots from 12AM to the next day's 12AM by default", () => {
       const today = new Date();


### PR DESCRIPTION
[Nylas RFC](https://paper.dropbox.com/doc/RFC-representing-single-user-or-multi-user-available-times-in-nylas-availability--BPU4Z3W8oVHkwTICby0CYxkkAQ-9Gi9578z7oqppkp236lM9)

- Adds an additional prop for `calendars` instead of `available_times` / `unavailable_times` looks like:

```
  interface Calendar {
    email_address: string;
    availability: "free" | "busy";
    timeslots: TimeSlot[];
  }
```

- Introduces the ability to represent multiple users' schedules
- Represent the availability status with a light grey colour for now to show it's partially available

### ~Design decision to make:  do we want to share a property name between `available_times` for a single user and for a set of users? or should we separate those?~
^--- `calendars` direction was made after deliberation

<img width="885" alt="CleanShot 2021-07-27 at 00 14 43@2x" src="https://user-images.githubusercontent.com/713991/127094374-f7ba62b8-2dd3-435a-ad52-a47cf7ed6a1c.png">


# Readiness checklist

- [x] Cypress tests passing?
- [x] New cypress tests added?
- [x] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
