### PR TITLE
[mailbox/email] new designs + mobile view

### DIFF
--- a/components/email/rollup.config.js
+++ b/components/email/rollup.config.js
@@ -1,5 +1,8 @@
 import config, { svelteConfig } from "../../rollup.common.config";
 import svelte from "rollup-plugin-svelte";
+import svelteSVG from "rollup-plugin-svelte-svg";
+
+config.plugins.unshift(svelteSVG());
 
 config.plugins.unshift(
   svelte({

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -636,6 +636,7 @@
           }
         }
         &.condensed {
+          padding: 0 $spacing-s;
           display: grid;
           column-gap: $spacing-m;
           height: $collapsed-height;

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -20,14 +20,6 @@
 
   let manifest: Partial<Nylas.EmailProperties> = {};
   let viewportWidth: number;
-  let isViewingOnMobile: boolean;
-  $: {
-    viewportWidth = Math.max(
-      document.documentElement.clientWidth || 0,
-      window.innerWidth || 0,
-    );
-    isViewingOnMobile = viewportWidth <= 639;
-  }
 
   const dispatchEvent = getEventDispatcher(get_current_component());
   $: dispatchEvent("manifestLoaded", manifest);
@@ -347,11 +339,11 @@
   $mobile-collapsed-height: fit-content;
   $spacing-s: 0.5rem;
   $spacing-m: 1rem;
+  $spacing-l: 1.5rem;
 
   main {
     height: 100%;
     width: 100%;
-    overflow: auto;
     position: relative;
     font-family: -apple-system, BlinkMacSystemFont, sans-serif;
     .email-row {
@@ -360,11 +352,12 @@
       header {
         font-size: 1.2rem;
         font-weight: 700;
+        padding: $spacing-s;
+        padding-bottom: 0;
       }
       &.condensed {
         height: $mobile-collapsed-height;
-        padding-right: $spacing-m;
-        padding-left: $spacing-s;
+        padding: $spacing-s;
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -379,7 +372,7 @@
         .mobile-subject-snippet {
           display: block;
           font-size: 14px;
-          margin-top: $spacing-m;
+          margin-top: $spacing-s;
           flex-basis: 100%;
 
           .subject {
@@ -452,6 +445,7 @@
       }
       &.expanded {
         background: var(--white);
+        padding: 0;
 
         &.expanded-mailbox-thread {
           .message-from {
@@ -462,7 +456,8 @@
         }
         div.individual-message {
           width: 100%;
-          padding: 1rem 0;
+          box-sizing: border-box;
+          padding: $spacing-s;
 
           button.email-tooltip-btn {
             position: relative;
@@ -631,12 +626,20 @@
   @media #{$desktop} {
     main {
       .email-row {
+        header {
+          padding: $spacing-m $spacing-l 0;
+        }
+
+        &.expanded.singular {
+          .individual-message.expanded {
+            padding-top: $spacing-s;
+          }
+        }
         &.condensed {
           display: grid;
           column-gap: $spacing-m;
           height: $collapsed-height;
           grid-template-columns: 200px auto;
-          align-items: center;
           justify-content: initial;
 
           .mobile-subject-snippet {
@@ -647,22 +650,28 @@
         &.expanded {
           display: flex;
           flex-direction: column;
-          align-items: center;
+          box-sizing: border-box;
+          width: 100%;
           div.individual-message {
             display: flex;
             flex-direction: column;
             align-items: center;
+            padding: $spacing-m 0;
 
             div.message-head,
             div.message-body {
               width: 100%;
-              max-width: 570px;
+              box-sizing: border-box;
+              padding: 0 $spacing-l;
             }
 
             &.condensed {
               div.snippet {
                 width: 100%;
-                max-width: 570px;
+                box-sizing: border-box;
+                padding: 0 $spacing-l;
+                max-width: 95vw;
+                align-self: flex-start;
               }
             }
 
@@ -673,7 +682,7 @@
             &.expanded {
               div.message-head {
                 div.message-from-to {
-                  margin: 0.5rem 0;
+                  margin: $spacing-s 0;
                   div.message-to {
                     max-width: unset;
                     overflow: inherit;
@@ -931,7 +940,7 @@
               </div>
             </div>
             <div class="message-date">
-              <span>{new Date(message.date * 1000).toLocaleDateString()}</span>
+              <span> {formatPreviewDate(new Date(message.date * 1000))}</span>
             </div>
           </div>
           <div class="message-body">

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -16,6 +16,7 @@
     getEventDispatcher,
     getPropertyValue,
   } from "@commons/methods/component";
+  import DropdownSymbol from "./assets/chevron-down.svg";
 
   let manifest: Partial<Nylas.EmailProperties> = {};
   let viewportWidth: number;
@@ -214,8 +215,6 @@
       activeThread.starred = !activeThread.starred;
       saveActiveThread();
     }
-
-    console.log({ activeThread });
     //#endregion starred/unstarred
   }
 
@@ -385,7 +384,6 @@
           flex-basis: 100%;
 
           .subject {
-            font-weight: 600;
             text-overflow: ellipsis;
             white-space: nowrap;
             overflow: hidden;
@@ -414,7 +412,8 @@
         &.unread {
           background: var(--nylas-email-background, white);
           .from-message-count,
-          .date {
+          .date,
+          .subject {
             font-weight: 600;
             color: var(--black);
 
@@ -466,6 +465,31 @@
           width: 100%;
           padding: 1rem 0;
 
+          button.email-tooltip-btn {
+            position: relative;
+            display: inline-block;
+            background: transparent;
+
+            span.email-tooltip {
+              position: absolute;
+              visibility: hidden;
+              width: min-content;
+              z-index: 1;
+              top: 125%;
+              background: var(--grey-lightest);
+              color: var(--grey-dark);
+              padding: $spacing-s;
+              box-shadow: 0px 3px 2px rgba(0, 0, 0, 0.25);
+              border-radius: 2px;
+            }
+
+            &:hover {
+              span.email-tooltip {
+                visibility: visible;
+              }
+            }
+          }
+
           &.condensed {
             div.snippet {
               text-overflow: ellipsis;
@@ -491,11 +515,11 @@
           div.message-head {
             display: flex;
             justify-content: space-between;
-            align-items: center;
           }
           div.message-date {
             display: flex;
             color: gray;
+            font-size: 12px;
           }
 
           div.message-from {
@@ -504,9 +528,6 @@
               &.name {
                 font-weight: 600;
                 margin-right: 0.5rem;
-              }
-              &.email {
-                color: gray;
               }
             }
           }
@@ -528,7 +549,6 @@
             }
           }
           &.condensed {
-            //grid-template-columns: 100px auto;
             gap: 1rem;
             box-shadow: inset 0 -1px 0 0 rgb(100 121 143 / 12%);
             &:hover,
@@ -575,10 +595,6 @@
         }
       }
       .subject-snippet-date {
-        //display: grid;
-        //grid-template-columns: 1fr 70px;
-        //gap: 1rem;
-
         .desktop-subject-snippet {
           display: none;
         }
@@ -634,7 +650,12 @@
           flex-direction: column;
           align-items: center;
           div.individual-message {
-            width: 570px;
+            max-width: 570px;
+
+            div.message-date {
+              font-size: 14px;
+              align-self: center;
+            }
             &.expanded {
               div.message-head {
                 div.message-from-to {
@@ -713,10 +734,11 @@
                           <span class="name"
                             >{message.from[0].name ||
                               message.from[0].email}</span
+                          ><button class="email-tooltip-btn"
+                            ><DropdownSymbol /><span class="email-tooltip"
+                              >{message.from[0].email}</span
+                            ></button
                           >
-                          <!--span class="email"
-                            >&lt;{message.from[0].email}&gt;</span
-                          -->
                         </div>
                         <div class="message-to">
                           {#each message.to as to, i}
@@ -727,7 +749,11 @@
                                   : to.name || to.email}
                                 {#if i !== message.to.length - 1}
                                   &nbsp;&comma;
-                                {/if}
+                                {/if}<button class="email-tooltip-btn"
+                                  ><DropdownSymbol /><span class="email-tooltip"
+                                    >{message.to[0].email}</span
+                                  ></button
+                                >
                               {/if}
                             </span>
                           {/each}
@@ -753,6 +779,11 @@
                       <div class="message-from">
                         <span class="name"
                           >{message.from[0].name || message.from[0].email}</span
+                        ><button class="email-tooltip-btn"
+                          ><DropdownSymbol />
+                          <span class="email-tooltip"
+                            >{message.from[0].email}</span
+                          ></button
                         >
                       </div>
                       <div class="message-date">
@@ -862,8 +893,14 @@
           <div class="message-head">
             <div class="message-from-to">
               <div class="message-from">
-                <span class="name">{message.from[0].name}</span>
-                <span class="email">&lt;{message.from[0].email}&gt;</span>
+                <span class="name"
+                  >{message.from[0].name || message.from[0].email}</span
+                >
+                <button class="email-tooltip-btn"
+                  ><DropdownSymbol />
+                  <span class="email-tooltip">{message.from[0].email}</span
+                  ></button
+                >
               </div>
               <div class="message-to">
                 {#each message.to as to, i}
@@ -875,6 +912,11 @@
                       {#if i !== message.to.length - 1}
                         &nbsp;&comma;
                       {/if}
+                      <button class="email-tooltip-btn"
+                        ><DropdownSymbol />
+                        <span class="email-tooltip">{message.to[0].email}</span
+                        ></button
+                      >
                     {/if}
                   </span>
                 {/each}

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -254,6 +254,63 @@
       messageLoadStatus[0] = "loaded";
     });
   }
+
+  const weekdays = [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+  ];
+  function formatPreviewDate(date: Date): string {
+    const today = new Date();
+    const lastWeek = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate() - 6,
+    );
+
+    if (date >= lastWeek) {
+      return weekdays[date.getDay()];
+    } else {
+      return date.toLocaleDateString();
+    }
+  }
+
+  function formatExpandedDate(date: Date): string {
+    const months = [
+      "January",
+      "February",
+      "March",
+      "April",
+      "May",
+      "June",
+      "July",
+      "August",
+      "September",
+      "October",
+      "November",
+      "December",
+    ];
+    return (
+      date.toLocaleDateString("en-US", {
+        weekday: "short",
+        month: "long",
+        day: "numeric",
+      }) +
+      ", " +
+      date.toLocaleTimeString("en-US", {
+        hour12: true,
+        hour: "numeric",
+        minute: "2-digit",
+      })
+    );
+    // return `${weekdays[date.getDay()].slice(0, 3)}, ${
+    //   months[date.getMonth()]
+    // } ${date.getDate()}, ${date.getTime()}`;
+  }
 </script>
 
 <style lang="scss">
@@ -262,7 +319,7 @@
   @import "../../theming/animation.scss";
   @import "../../theming/variables.scss";
 
-  $border-style: 1px solid var(--grey-lighter);
+  $border-style: 1px solid #ebebeb;
   $hover-outline-width: 2px;
   $collapsed-height: 56px;
   $spacing-s: 0.5rem;
@@ -273,6 +330,7 @@
     width: 100%;
     overflow: auto;
     position: relative;
+    font-family: -apple-system, BlinkMacSystemFont, sans-serif;
     .email-row {
       display: grid;
       grid-column-gap: $spacing-m;
@@ -291,11 +349,20 @@
         &.show_star {
           grid-template-columns: 25px 200px auto;
         }
+
+        .thread-message-count {
+          margin-left: 1rem;
+          color: var(--grey-light);
+        }
         &.unread {
           background: var(--nylas-email-background, white);
           .from-participants,
           .date {
             font-weight: bold;
+
+            .thread-message-count {
+              color: var(--blue);
+            }
           }
         }
         div.starred {
@@ -329,7 +396,7 @@
       }
       &.expanded {
         overflow-y: scroll;
-        background: rgba(211, 211, 211, 0.302);
+        background: var(--white);
         div.individual-message {
           display: grid;
           padding: 1rem 0;
@@ -511,10 +578,10 @@
                         </div>
                       </div>
                       <div class="message-date">
-                        <span
-                          >{new Date(
-                            message.date * 1000,
-                          ).toLocaleDateString()}</span
+                        <span>
+                          {formatExpandedDate(
+                            new Date(message.date * 1000),
+                          )}</span
                         >
                       </div>
                     </div>
@@ -576,7 +643,9 @@
                       .from[0].email}</span
                 >
                 {#if show_number_of_messages}
-                  <span>{", " + activeThread.messages.length}</span>
+                  <span class="thread-message-count"
+                    >{activeThread.messages.length}</span
+                  >
                 {/if}
               {/if}
             </div>
@@ -591,9 +660,9 @@
               {#if show_received_timestamp}
                 <div class="date">
                   <span>
-                    {new Date(
-                      thread.last_message_timestamp * 1000,
-                    ).toLocaleDateString()}
+                    {formatPreviewDate(
+                      new Date(thread.last_message_timestamp * 1000),
+                    )}
                   </span>
                 </div>
               {/if}

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -355,7 +355,6 @@
     position: relative;
     font-family: -apple-system, BlinkMacSystemFont, sans-serif;
     .email-row {
-      padding: $spacing-s;
       background: var(--nylas-email-background, var(--grey-lightest));
       border: var(--nylas-email-border, #{$border-style});
       header {
@@ -364,7 +363,7 @@
       }
       &.condensed {
         height: $mobile-collapsed-height;
-        padding: $spacing-m;
+        padding-right: $spacing-m;
         padding-left: $spacing-s;
         display: flex;
         justify-content: space-between;
@@ -650,7 +649,22 @@
           flex-direction: column;
           align-items: center;
           div.individual-message {
-            max-width: 570px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+
+            div.message-head,
+            div.message-body {
+              width: 100%;
+              max-width: 570px;
+            }
+
+            &.condensed {
+              div.snippet {
+                width: 100%;
+                max-width: 570px;
+              }
+            }
 
             div.message-date {
               font-size: 14px;
@@ -795,13 +809,6 @@
                       </div>
                     </div>
                     <div class="snippet">
-                      {#if click_action !== "mailbox"}
-                        <span
-                          class={messageLoadStatus[msgIndex] === "loading"
-                            ? "loading"
-                            : "initial"}>Expanding your message...</span
-                        >
-                      {/if}
                       {message.snippet}
                     </div>
                   {/if}
@@ -842,8 +849,9 @@
                     >
                   {/if}
                   {#if activeThread.messages.length > 1 && activeThread.messages[0].from.length && activeThread.messages[0].from[0].email !== activeThread.messages[activeThread.messages.length - 1].from[0].email}
+                    ,
                     <span class="from-sub-section"
-                      >, {activeThread.messages[0].from[0].name ||
+                      >{activeThread.messages[0].from[0].name ||
                         activeThread.messages[0].from[0].email}</span
                     >
                   {/if}

--- a/components/email/src/assets/chevron-down.svg
+++ b/components/email/src/assets/chevron-down.svg
@@ -1,0 +1,3 @@
+<svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.1666 6.66666L8.50094 9.48258L5.83331 6.66666" stroke="#161717" stroke-miterlimit="10"/>
+</svg>

--- a/components/email/src/index.html
+++ b/components/email/src/index.html
@@ -78,8 +78,7 @@
           {
             account_id: "cou6r5tjgubx9rswikzvz9afb",
             bcc: [],
-            body:
-              "This is some manually-created body text. It's allowed to fully deviate from the snippet and you can even <marquee>include some html</marquee>",
+            body: "This is some manually-created body text. It's allowed to fully deviate from the snippet and you can even <marquee>include some html</marquee>",
             cc: [
               {
                 email: "phil.r@nylas.com",
@@ -243,6 +242,7 @@
     <nylas-email
       id="demo-email"
       thread_id="ak2q46em0srqkh7vri8f8vuqj"
+      click_action="default"
     ></nylas-email>
     <hr />
     <h2>Demo 2: Manually-passed thread; edited after 5sec</h2>

--- a/components/email/src/init.spec.js
+++ b/components/email/src/init.spec.js
@@ -220,10 +220,10 @@ describe("Email component", () => {
         cy.get(component).find(".message-body").should("contain", "Bye!");
         cy.get(component).find(".name").should("exist");
         cy.get(component).find(".name").should("contain", "Test User");
-        cy.get(component).find(".email").should("exist");
+        cy.get(component).find(".email-tooltip").should("exist");
         cy.get(component)
-          .find(".email")
-          .should("contain", "<nylascypresstest@gmail.com>");
+          .find(".email-tooltip")
+          .should("contain", "nylascypresstest@gmail.com");
         cy.get(component).find(".message-date span").should("exist");
         cy.get(component)
           .find(".message-date span")

--- a/components/email/src/init.spec.js
+++ b/components/email/src/init.spec.js
@@ -227,7 +227,7 @@ describe("Email component", () => {
         cy.get(component).find(".message-date span").should("exist");
         cy.get(component)
           .find(".message-date span")
-          .should("contain", "7/7/2021");
+          .should("contain", "July 7");
         cy.get(component).find(".message-to span").should("exist");
         cy.get(component)
           .find(".message-to span")

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -209,7 +209,6 @@
   main {
     height: 100%;
     width: 100%;
-    overflow: auto;
     position: relative;
     display: grid;
     font-family: -apple-system, BlinkMacSystemFont, sans-serif;
@@ -221,6 +220,10 @@
       align-items: center;
       padding: 24px 16px;
       gap: 8px;
+    }
+
+    .email-container {
+      padding-right: 0.5rem;
     }
 
     header {

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -298,6 +298,7 @@
   }
 
   .mailbox-loader {
+    width: calc(100vw - 16px);
     height: 100vh;
     display: flex;
     flex-direction: column;

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -148,7 +148,6 @@
       );
       threads = await MailboxStore.hydrateMessageInThread(message, query);
     }
-    console.log(openedEmailData);
   }
 
   async function refreshClicked(event: CustomEvent) {

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -14,6 +14,7 @@
   import { AccountStore } from "@commons/store/accounts";
   import { fetchMessage } from "@commons/connections/messages";
   import LoadingIcon from "./assets/loading.svg";
+  import LeftArrowLineIcon from "./assets/arrow-line.svg";
 
   let manifest: Partial<Nylas.EmailProperties> = {};
 
@@ -33,6 +34,7 @@
     onSelectOne;
 
   let queryParams: Nylas.ThreadsQuery;
+  let openedEmailData: Nylas.Thread | null;
 
   // paginations vars
   let paginatedThreads: Nylas.Thread[] = [];
@@ -140,11 +142,13 @@
   async function threadClicked(event: CustomEvent) {
     // console.debug('thread clicked from mailbox', event.detail);
     if (event.detail.thread?.expanded) {
+      openedEmailData = event.detail.thread;
       let message = await fetchIndividualMessage(
         event.detail.thread.messages[event.detail.thread.messages.length - 1],
       );
       threads = await MailboxStore.hydrateMessageInThread(message, query);
     }
+    console.log(openedEmailData);
   }
 
   async function refreshClicked(event: CustomEvent) {
@@ -252,7 +256,7 @@
 
       .checkbox-container.thread-checkbox {
         padding: 1rem 0 0 1rem;
-        align-self: baseline; // mobile; TODO: set for desktop
+        align-self: baseline;
       }
 
       &:hover {
@@ -307,83 +311,121 @@
       transform: rotate(360deg);
     }
   }
+
+  @media #{$desktop} {
+    main {
+      #mailboxlist li {
+        .checkbox-container.thread-checkbox {
+          padding: 0 0 0 $spacing-m;
+          align-self: center;
+        }
+      }
+    }
+  }
 </style>
 
 <main bind:this={main}>
-  {#if header}
-    <header>
-      <button on:click={refreshClicked}>
-        <svg width="16" height="16" viewBox="0 0 16 16">
-          <path
-            d="M9.41757 0.780979L9.57471 0.00782773C12.9388 0.717887 15.4617 3.80648 15.4617 7.49954C15.4617 8.7935 15.1519 10.0136 14.6046 11.083L16 12.458L11.6994 13.7113L12.7846 9.28951L14.0208 10.5077C14.4473 9.60009 14.6869 8.5795 14.6869 7.49954C14.6869 4.17742 12.4188 1.41444 9.41757 0.780979ZM0 2.90469L4.24241 1.46013L3.3489 5.92625L2.06118 4.7644C1.71079 5.60175 1.51627 6.5265 1.51627 7.49954C1.51627 10.8217 3.7844 13.5847 6.78563 14.2182L6.62849 14.9913C3.26437 14.2812 0.741524 11.1926 0.741524 7.49954C0.741524 6.32506 0.996751 5.21133 1.45323 4.21587L0 2.90469Z"
-          />
-        </svg>
+  {#if openedEmailData}
+    <header class="subject-title">
+      <button
+        on:click={() => {
+          openedEmailData.expanded = false;
+          openedEmailData = null;
+        }}
+      >
+        <LeftArrowLineIcon />
       </button>
-      <h1>{header}</h1>
+      <h1>{openedEmailData.subject}</h1>
     </header>
-  {/if}
-  {#if show_mailbox_toolbar}
-    <div role="toolbar" aria-label="Bulk actions" aria-controls="mailboxlist">
-      {#if show_thread_checkbox}<div class="thread-checkbox">
-          {#each [areAllSelected ? "Deselect all" : "Select all"] as selectAllTitle}
-            <input
-              title={selectAllTitle}
-              aria-label={selectAllTitle}
-              type="checkbox"
-              checked={areAllSelected}
-              on:click={(e) => onSelectAll(e)}
-            />
-          {/each}
-        </div>{/if}
-    </div>
-  {/if}
-  <ul id="mailboxlist">
-    {#each paginatedThreads as thread}
-      {#each [selectedThreads.has(thread) ? `Deselect thread ${thread.subject}` : `Select thread ${thread.subject}`] as selectTitle}
-        <li
-          class:unread={thread.unread}
-          class:checked={selectedThreads.has(thread)}
-        >
-          {#if show_thread_checkbox}<div
-              class="checkbox-container thread-checkbox"
-            >
-              <input
-                title={selectTitle}
-                aria-label={selectTitle}
-                type="checkbox"
-                checked={selectedThreads.has(thread)}
-                on:click={(e) => onSelectOne(e, thread)}
-              />
-            </div>{/if}
-          <div class="email-container">
-            <nylas-email
-              is_clean_conversation_enabled={false}
-              {thread}
-              {you}
-              {show_star}
-              unread={readStatusOutputs[unread_status]}
-              on:threadClicked={threadClicked}
-              on:messageClicked={messageClicked}
-            />
-          </div>
-        </li>
-      {/each}
-    {:else}
-      <div class="mailbox-loader">
-        <LoadingIcon
-          class="spinner"
-          style="height:18px; animation: rotate 2s linear infinite; margin:10px;"
-        />
-        Loading component...
-      </div>
-    {/each}
-    {#if threads.length > 0 && paginatedThreads}
-      <pagination-nav
-        current_page={currentPage}
-        last_page={lastPage}
-        visible={true}
-        on:changePage={changePage}
+    <div class="email-container">
+      <nylas-email
+        is_clean_conversation_enabled={false}
+        thread={openedEmailData}
+        {you}
+        {show_star}
+        click_action="mailbox"
+        unread={readStatusOutputs[unread_status]}
+        on:threadClicked={threadClicked}
+        on:messageClicked={messageClicked}
       />
+    </div>
+  {:else}
+    {#if header}
+      <header>
+        <button on:click={refreshClicked}>
+          <svg width="16" height="16" viewBox="0 0 16 16">
+            <path
+              d="M9.41757 0.780979L9.57471 0.00782773C12.9388 0.717887 15.4617 3.80648 15.4617 7.49954C15.4617 8.7935 15.1519 10.0136 14.6046 11.083L16 12.458L11.6994 13.7113L12.7846 9.28951L14.0208 10.5077C14.4473 9.60009 14.6869 8.5795 14.6869 7.49954C14.6869 4.17742 12.4188 1.41444 9.41757 0.780979ZM0 2.90469L4.24241 1.46013L3.3489 5.92625L2.06118 4.7644C1.71079 5.60175 1.51627 6.5265 1.51627 7.49954C1.51627 10.8217 3.7844 13.5847 6.78563 14.2182L6.62849 14.9913C3.26437 14.2812 0.741524 11.1926 0.741524 7.49954C0.741524 6.32506 0.996751 5.21133 1.45323 4.21587L0 2.90469Z"
+            />
+          </svg>
+        </button>
+        <h1>{header}</h1>
+      </header>
     {/if}
-  </ul>
+    {#if show_mailbox_toolbar}
+      <div role="toolbar" aria-label="Bulk actions" aria-controls="mailboxlist">
+        {#if show_thread_checkbox}<div class="thread-checkbox">
+            {#each [areAllSelected ? "Deselect all" : "Select all"] as selectAllTitle}
+              <input
+                title={selectAllTitle}
+                aria-label={selectAllTitle}
+                type="checkbox"
+                checked={areAllSelected}
+                on:click={(e) => onSelectAll(e)}
+              />
+            {/each}
+          </div>{/if}
+      </div>
+    {/if}
+    <ul id="mailboxlist">
+      {#each paginatedThreads as thread}
+        {#each [selectedThreads.has(thread) ? `Deselect thread ${thread.subject}` : `Select thread ${thread.subject}`] as selectTitle}
+          <li
+            class:unread={thread.unread}
+            class:checked={selectedThreads.has(thread)}
+          >
+            {#if show_thread_checkbox}<div
+                class="checkbox-container thread-checkbox"
+              >
+                <input
+                  title={selectTitle}
+                  aria-label={selectTitle}
+                  type="checkbox"
+                  checked={selectedThreads.has(thread)}
+                  on:click={(e) => onSelectOne(e, thread)}
+                />
+              </div>{/if}
+            <div class="email-container">
+              <nylas-email
+                is_clean_conversation_enabled={false}
+                {thread}
+                {you}
+                {show_star}
+                click_action="mailbox"
+                unread={readStatusOutputs[unread_status]}
+                on:threadClicked={threadClicked}
+                on:messageClicked={messageClicked}
+              />
+            </div>
+          </li>
+        {/each}
+      {:else}
+        <div class="mailbox-loader">
+          <LoadingIcon
+            class="spinner"
+            style="height:18px; animation: rotate 2s linear infinite; margin:10px;"
+          />
+          Loading component...
+        </div>
+      {/each}
+      {#if threads.length > 0 && paginatedThreads}
+        <pagination-nav
+          current_page={currentPage}
+          last_page={lastPage}
+          visible={true}
+          on:changePage={changePage}
+        />
+      {/if}
+    </ul>
+  {/if}
 </main>

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -205,6 +205,7 @@
     overflow: auto;
     position: relative;
     display: grid;
+    font-family: -apple-system, BlinkMacSystemFont, sans-serif;
 
     $border-style: 1px solid var(--grey-lighter);
     @mixin barStyle {

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -199,6 +199,9 @@
   @import "../../theming/animation.scss";
   @import "../../theming/variables.scss";
   @import "../../../commons/src/components/checkbox.scss";
+
+  $spacing-s: 0.5rem;
+  $spacing-m: 1rem;
   main {
     height: 100%;
     width: 100%;
@@ -248,7 +251,8 @@
       justify-content: left;
 
       .checkbox-container.thread-checkbox {
-        padding-left: 16px;
+        padding: 1rem 0 0 1rem;
+        align-self: baseline; // mobile; TODO: set for desktop
       }
 
       &:hover {

--- a/components/mailbox/src/assets/arrow-line.svg
+++ b/components/mailbox/src/assets/arrow-line.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.7605 17.3029L6.32422 12.1494L11.7605 6.99968" stroke="#161717" stroke-width="1.5" stroke-miterlimit="10"/>
+<path d="M6.42791 12.1494L18 12.1494" stroke="#161717" stroke-width="1.5" stroke-miterlimit="10"/>
+</svg>

--- a/components/mailbox/src/components/PaginationNav.svelte
+++ b/components/mailbox/src/components/PaginationNav.svelte
@@ -24,7 +24,7 @@
 <style lang="scss">
   .pagination-nav {
     --disabled-text: ##454954;
-    --font: "SF Pro Display", Arial; // need to import font
+    --font: -apple-system, BlinkMacSystemFont, sans-serif;
     display: flex;
     align-items: center;
   }


### PR DESCRIPTION
Implemented new UI for Email and Mailbox, including: 
- mobile view

- new desktop view

- dropdown email tooltip for sender and receiver contacts in expanded email view

- date formatting

- new `click_action` for `Email` --> "mailbox" --> when selected, clicking condensed threads/messages open a separate view (rather than expand within the mailbox view; see 2nd and 4th screenshots in "After" column)

- updated Cypress test for `Email` to reflect new UI

# Before and After
| Before | After |
|---|---|
| <img width="1440" alt="Screen Shot 2021-07-29 at 3 23 18 PM" src="https://user-images.githubusercontent.com/45607721/127554405-4f96f519-a1b0-4320-af94-43e1931fd33a.png"> | ![image](https://user-images.githubusercontent.com/45607721/127700640-7479b2e7-98db-45c8-ad3f-9511f84257f5.png) |
| <img width="1280" alt="Screen Shot 2021-07-29 at 3 22 24 PM" src="https://user-images.githubusercontent.com/45607721/127554189-567bfe73-5a44-4067-9433-8f2e8ff855e0.png"> | ![image](https://user-images.githubusercontent.com/45607721/127700722-9712c201-a650-4648-b3e3-640b8d4cd62a.png) |
| <img width="1055" alt="Screen Shot 2021-07-29 at 3 25 11 PM" src="https://user-images.githubusercontent.com/45607721/127553797-93a2117d-25c6-4f32-bc09-2675907b4ac4.png"> | <img width="1060" alt="Screen Shot 2021-07-29 at 3 24 47 PM" src="https://user-images.githubusercontent.com/45607721/127553802-8c060a47-0a60-4b66-b6b3-20f4908ad115.png"> |
| <img width="1060" alt="Screen Shot 2021-07-29 at 3 25 32 PM" src="https://user-images.githubusercontent.com/45607721/127553796-4344a758-18cf-4b90-b71e-e65b3de0e175.png"> | <img width="1059" alt="Screen Shot 2021-07-29 at 3 25 54 PM" src="https://user-images.githubusercontent.com/45607721/127553792-7a042e08-0879-4cfe-9d45-a577d17e5b46.png"> |
| ![image](https://user-images.githubusercontent.com/45607721/127700481-4e1c4de5-4330-4a8d-acd3-b58eee555f65.png) |  ![image](https://user-images.githubusercontent.com/45607721/127700399-06c97e49-df2e-4921-bb1a-d2f8ffc5a72b.png) |





# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
