### PR TITLE
Tracking as an optional field

### DIFF
--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -60,6 +60,7 @@
   export let afterSendSuccess: Function | null = null;
   export let afterSendError: Function | null = null;
   export let template: string = "";
+  export let tracking: Composer.Tracking | null = null;
 
   // Attributes
   export let minimized: Composer.Attribute;
@@ -126,6 +127,11 @@
         show_from = false;
       }
     }
+    if (tracking) {
+      // Set tracking on message object
+      update("tracking", tracking);
+    }
+
     isLoading = false;
     themeLoaded = true;
   });
@@ -292,7 +298,7 @@
         });
     } else if (id) {
       // Middleware
-      sendMessage(id, msg, access_token)
+      sendMessage(id, msg, tracking, access_token)
         .then((res) => {
           if (afterSendSuccess) afterSendSuccess(res);
           if (reset_after_send) resetAfterSend($message.from);

--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -298,7 +298,7 @@
         });
     } else if (id) {
       // Middleware
-      sendMessage(id, msg, tracking, access_token)
+      sendMessage(id, msg, access_token)
         .then((res) => {
           if (afterSendSuccess) afterSendSuccess(res);
           if (reset_after_send) resetAfterSend($message.from);

--- a/components/composer/src/composer.d.ts
+++ b/components/composer/src/composer.d.ts
@@ -48,6 +48,13 @@ declare namespace Composer {
 
   type Attribute = string | boolean | void;
 
+  interface Tracking {
+    links: boolean;
+    opens: boolean;
+    thread_replies: boolean;
+    payload: string;
+  }
+
   interface Attachment {
     filename: string;
     size: number;

--- a/components/composer/src/index.html
+++ b/components/composer/src/index.html
@@ -13,6 +13,15 @@
     <script>
       document.addEventListener("DOMContentLoaded", function () {
         const composer = document.querySelector("nylas-composer");
+        /* to enable tracking, uncomment the following */
+        /*
+        composer.tracking = {
+          links: true,
+          opens: true,
+          thread_replies: true,
+          payload: "Testing from Composer demo"
+        }
+        */
         composer.replace_fields = [{ from: "[hi]", to: "hello" }];
         // This is same as setting below, attribute with strigified value
         // composer.setAttribute("replace_fields", JSON.stringify([{ "from": "[hi]", "to": "hello" }]));


### PR DESCRIPTION
Adds the ability to add [message tracking](https://developer.nylas.com/docs/developer-tools/webhooks/message-tracking/#thread-replied) to sent messages, with customization options that mirror what we allow when calling the Nylas `/send` endpoint.

For testing purposes, please make sure if you're enabling the tracking object, you are using a composer ID tied to a paid Nylas account. Otherwise, you'll receive the following warning on a `403`:

![CleanShot 2021-08-02 at 21 32 58](https://user-images.githubusercontent.com/713991/127943751-97f7e89d-2212-4584-a547-fd547d36bc6b.png)


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
