### PR TITLE
Nylas-Error component styling and restriction to localhost

### DIFF
--- a/commons/src/components/NError.svelte
+++ b/commons/src/components/NError.svelte
@@ -8,6 +8,7 @@
 
   $: error = $ErrorStore[id] || { name: "" };
   $: explanation = NErrorExplanationMap[error.name]();
+  const isDevEnv = window.location.href.includes("localhost");
 </script>
 
 <style>
@@ -29,7 +30,7 @@
   }
 </style>
 
-{#if error.name}
+{#if error.name && isDevEnv}
   <div class="message-container">
     <h3>
       {@html explanation.title}

--- a/commons/src/components/NError.svelte
+++ b/commons/src/components/NError.svelte
@@ -7,16 +7,23 @@
   export let id; // component id
 
   $: error = $ErrorStore[id] || { name: "" };
-  $: explanation = NErrorExplanationMap[error.name]();
+  $: explanation = NErrorExplanationMap[errorName]();
+  $: errorName = !error.name ? error.message?.name : error.name;
   const isDevEnv = window.location.href.includes("localhost");
 </script>
 
 <style>
   .message-container {
-    padding: 0.5rem;
-    font-size: 11px;
-    color: red;
-    text-align: initial;
+    background: #fff6f6;
+    border-radius: 5px;
+    box-shadow: 0 0 0 1px #aa92a0 inset, 0 0 0 0 transparent;
+    color: #9f3a38;
+    font-size: 1.25rem;
+    padding: 10px;
+    margin: 0 auto;
+    transition: opacity 500ms ease, color 500ms ease,
+      background-color 500ms ease, box-shadow 500ms ease,
+      -webkit-box-shadow 500ms ease;
   }
 
   .message-container *:focus {
@@ -25,22 +32,28 @@
   }
 
   .details {
-    font-size: 8px;
     color: #494949;
+    font-size: 0.75rem;
+    width: 100%;
   }
 </style>
 
-{#if error.name && isDevEnv}
+{#if errorName && isDevEnv}
   <div class="message-container">
-    <h3>
-      {@html explanation.title}
-    </h3>
-    <h4>
-      {@html explanation.subtitle}
-    </h4>
+    {#if explanation.title}
+      <h3>
+        {@html explanation.title}
+      </h3>
+    {/if}
+    {#if explanation.subtitle}
+      <h4>
+        {@html explanation.subtitle}
+      </h4>
+    {/if}
     <span class="details">Debug info:</span>
-    <textarea class="details" readonly cols={64}>
-      {error.name}: {id}
+    <textarea class="details" readonly>
+      {errorName}: {id}
+      {error.message.message ? error.message.message : ""}
     </textarea>
   </div>
 {/if}


### PR DESCRIPTION
# Changes
- Added boolean variable to restrict visibility of nylas-error component to URL containing `localhost`
- Improved styling of error message (see screenshot below)
- Missing import statement was fixed in [this PR](https://github.com/nylas/components/pull/11)
- `error.name` is used, so it wasn't removed in this PR

Before:
<img width="704" alt="Screen Shot 2021-08-03 at 6 35 12 PM" src="https://user-images.githubusercontent.com/55773810/128218805-d6726faa-9c1d-4acc-87ef-e8f22c52b141.png">

After:
<img width="1610" alt="Screen Shot 2021-08-04 at 3 38 26 PM" src="https://user-images.githubusercontent.com/55773810/128244292-4bd1b4e0-45b8-4f0d-a144-acbd1ac6abcc.png">


[ClubHouse Story](https://app.clubhouse.io/nylas/story/65026/fix-the-broken-nylas-error-custom-element-in-all-components)

# Readiness checklist

- [ ] Cypress tests passing?
- [ ] New cypress tests added?
- [ ] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
