### PR TITLE
Availability Component: Get calendars using the access token

### DIFF
--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -1,7 +1,11 @@
 <svelte:options tag="nylas-availability" />
 
 <script lang="ts">
-  import { ManifestStore, AvailabilityStore } from "../../../commons/src";
+  import {
+    ManifestStore,
+    AvailabilityStore,
+    CalendarStore,
+  } from "../../../commons/src";
   import { onMount, tick } from "svelte";
   import { get_current_component } from "svelte/internal";
   import { getEventDispatcher } from "@commons/methods/component";

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -12,6 +12,7 @@
   import type { TimeInterval } from "d3-time";
   import { timeDay, timeHour, timeMinute } from "d3-time";
   import { scaleTime } from "d3-scale";
+  import type { CalendarQuery } from "@commons/types/Events";
 
   import {
     SelectionStatus,
@@ -43,11 +44,20 @@
 
   //#region mount
   let manifest: Partial<Manifest> = {};
+  $: calendarID = "";
   onMount(async () => {
     await tick();
     clientHeight = main?.getBoundingClientRect().height;
     const storeKey = JSON.stringify({ component_id: id, access_token });
     manifest = (await $ManifestStore[storeKey]) || {};
+    const calendarQuery: CalendarQuery = {
+      access_token,
+      component_id: id,
+      calendarIDs: [], // empty array will fetch all calendars
+    };
+    const calendarsList = await CalendarStore.getCalendars(calendarQuery);
+    calendarID = calendarsList.find((cal) => cal.is_primary)?.id || "";
+    console.log(calendarID);
   });
   //#endregion mount
 

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -121,6 +121,7 @@
       }
     </style>
   </head>
+
   <body>
     <aside class="controls">
       <label>
@@ -207,9 +208,7 @@
 
     <main>
       <div class="demo-box">
-        <nylas-availability
-          id="b41befb2-30c5-4957-9f8c-699044c59faf"
-        ></nylas-availability>
+        <nylas-availability id="demo-availability"></nylas-availability>
       </div>
     </main>
   </body>

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -50,9 +50,9 @@
           },
         ];
 
-        // component.calendars = calendars;
+        component.calendars = calendars;
 
-        component.email_ids = ["pooja.g@nylas.com", "phil.r@nylas.com"];
+        // component.email_ids = ["pooja.g@nylas.com", "phil.r@nylas.com"];
         component.addEventListener("timeSlotChosen", (event) => {
           console.log(event.detail.timeSlots);
         });

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -50,9 +50,9 @@
           },
         ];
 
-        component.calendars = calendars;
+        // component.calendars = calendars;
 
-        // component.email_ids = ["pooja.g@nylas.com", "phil.r@nylas.com"];
+        component.email_ids = ["pooja.g@nylas.com", "phil.r@nylas.com"];
         component.addEventListener("timeSlotChosen", (event) => {
           console.log(event.detail.timeSlots);
         });
@@ -207,7 +207,9 @@
 
     <main>
       <div class="demo-box">
-        <nylas-availability id="demo-availability"></nylas-availability>
+        <nylas-availability
+          id="b41befb2-30c5-4957-9f8c-699044c59faf"
+        ></nylas-availability>
       </div>
     </main>
   </body>


### PR DESCRIPTION
Get calendars using the access token. Search for is_primary: true and use the id associated with that object. Making this GET request in onMount to get calendar_id for POST /events, so there's no lag for user

# Readiness checklist

- [] Cypress tests passing?
- [] New cypress tests added?
- [] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
