### PR TITLE
Availability component: Epochs, Partial Booking props, and design updates

### DIFF
--- a/commons/src/types/Availability.ts
+++ b/commons/src/types/Availability.ts
@@ -17,6 +17,10 @@ export interface Manifest extends Nylas.Manifest {
   dates_to_show: number;
   show_ticks: boolean;
   calendars: Calendar[];
+  email_ids: string[];
+  allow_booking: boolean;
+  max_bookable_slots: number;
+  participant_threshold: number;
 }
 
 export interface Calendar {

--- a/commons/src/types/Availability.ts
+++ b/commons/src/types/Availability.ts
@@ -55,9 +55,13 @@ export interface AvailabilityResponse {
 }
 
 export interface EventQuery {
-  participants?: [];
+  participants?: EventParticipant[];
   title?: string;
   location?: string;
   access_token?: string;
   component_id?: string;
+}
+
+export interface EventParticipant {
+  email_address: string;
 }

--- a/commons/src/types/Availability.ts
+++ b/commons/src/types/Availability.ts
@@ -20,7 +20,7 @@ export interface Manifest extends Nylas.Manifest {
   email_ids: string[];
   allow_booking: boolean;
   max_bookable_slots: number;
-  participant_threshold: number;
+  partial_bookable_ratio: number;
 }
 
 export interface Calendar {

--- a/commons/src/types/Availability.ts
+++ b/commons/src/types/Availability.ts
@@ -28,6 +28,7 @@ export interface Calendar {
 export interface TimeSlot {
   start_time: Date;
   end_time: Date;
+  available_calendars: string[];
 }
 
 export interface SelectableSlot extends TimeSlot {

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -327,12 +327,6 @@
   }, [] as TimeSlot[]);
 
   function toggleSelectedTimeSlots(selectedSlot: SelectableSlot) {
-    selectedSlot.selectionStatus =
-      selectedSlot.selectionStatus === SelectionStatus.SELECTED
-        ? SelectionStatus.UNSELECTED
-        : slotSelection.length < max_bookable_slots
-        ? SelectionStatus.SELECTED
-        : SelectionStatus.UNSELECTED;
     return (slotSelection =
       selectedSlot.selectionStatus === SelectionStatus.SELECTED
         ? [...slotSelection, selectedSlot]
@@ -605,6 +599,13 @@
               disabled={slot.availability === AvailabilityStatus.BUSY}
               on:click={() => {
                 if (allow_booking) {
+                  slot.selectionStatus =
+                    slot.selectionStatus === SelectionStatus.SELECTED
+                      ? SelectionStatus.UNSELECTED
+                      : slotSelection.length < max_bookable_slots
+                      ? SelectionStatus.SELECTED
+                      : SelectionStatus.UNSELECTED;
+
                   toggleSelectedTimeSlots(slot);
                 } else {
                   dispatchEvent("timeSlotChosen", { timeSlots: slot });

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -408,7 +408,7 @@
         grid-template-columns: auto 1fr;
         gap: 0.5rem;
         height: 30px;
-        line-height: 1.875rem;
+        line-height: 1.875;
         font-size: 1rem;
         font-weight: 300;
 
@@ -420,7 +420,7 @@
           display: block;
           width: 30px;
           height: 30px;
-          line-height: 1.875rem;
+          line-height: 1.875;
           text-align: center;
         }
       }
@@ -564,11 +564,6 @@
             <div
               class="epoch {epoch.status}"
               style="height: {epoch.height}%; top: {epoch.offset}%;"
-              aria-label="{new Date(
-                epoch.start_time,
-              ).toLocaleString()} to {new Date(
-                epoch.end_time,
-              ).toLocaleString()}; Free calendars: {epoch.available_calendars.toString()}"
               data-available-calendars={epoch.available_calendars.toString()}
               data-start-time={new Date(epoch.start_time).toLocaleString()}
               data-end-time={new Date(epoch.end_time).toLocaleString()}
@@ -592,7 +587,9 @@
               data-available-calendars={slot.available_calendars.toString()}
               aria-label="{new Date(
                 slot.start_time,
-              ).toLocaleString()} - {new Date(slot.end_time).toLocaleString()}}"
+              ).toLocaleString()} to {new Date(
+                slot.end_time,
+              ).toLocaleString()}}; Free calendars: {slot.available_calendars.toString()}"
               class="slot {slot.selectionStatus} {slot.availability}"
               data-start-time={new Date(slot.start_time).toLocaleString()}
               data-end-time={new Date(slot.end_time).toLocaleString()}

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -43,7 +43,7 @@
             availability: "free",
             timeslots: [
               {
-                start_time: new Date(new Date().setHours(5, 30, 0, 0)),
+                start_time: new Date(new Date().setHours(5, 15, 0, 0)),
                 end_time: new Date(new Date().setHours(16, 0, 0, 0)),
               },
             ],
@@ -51,12 +51,14 @@
         ];
 
         //component.calendars = calendars;
+        //component.email_ids = ["phil.r@nylas.com"];
 
         component.email_ids = [
-          "hazik.a@nylas.com",
           "phil.r@nylas.com",
-          "mike@nylas.com",
-          "david@nylas.com",
+          "david.t@nylas.com",
+          "hazik.a@nylas.com",
+          "chantal.l@nylas.com",
+          "shashaank.s@nylas.com",
         ];
         component.addEventListener("timeSlotChosen", (event) => {
           console.log(event.detail.timeSlots);
@@ -92,9 +94,23 @@
           .querySelectorAll('input[name="allow-booking"]')
           .forEach((elem) => {
             elem.addEventListener("input", function (event) {
-              component.allow_booking = event.target.value;
+              component.allow_booking = JSON.parse(event.target.value);
             });
           });
+
+        document
+          .querySelectorAll('input[id="participant-threshold"]')
+          .forEach((elem) => {
+            elem.addEventListener("input", function (event) {
+              component.participant_threshold = JSON.parse(event.target.value);
+            });
+          });
+
+        document.querySelectorAll('input[name="max-slots"]').forEach((elem) => {
+          elem.addEventListener("input", function (event) {
+            component.max_bookable_slots = JSON.parse(event.target.value);
+          });
+        });
       });
     </script>
     <style>
@@ -119,7 +135,7 @@
       }
 
       .demo-box {
-        width: 80vw;
+        width: calc(80vw - 250px);
         margin-left: 10vw;
         height: 80vh;
         margin-top: 10vh;
@@ -207,6 +223,26 @@
           <input checked type="radio" name="allow-booking" value="false" />
           False
         </label>
+      </fieldset>
+
+      <fieldset>
+        <legend>Max Bookable Slots</legend>
+        <label>
+          <input type="number" name="max-slots" value="1" />
+        </label>
+      </fieldset>
+
+      <fieldset>
+        <legend>Participant Threshold</legend>
+        <input
+          id="participant-threshold"
+          class="end"
+          type="range"
+          min="0"
+          max="100"
+          step="1"
+          value="1"
+        />
       </fieldset>
     </aside>
 

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -53,9 +53,10 @@
         //component.calendars = calendars;
 
         component.email_ids = [
-          "pooja.g@nylas.com",
-          "aaron.d@nylas.com",
+          "hazik.a@nylas.com",
           "phil.r@nylas.com",
+          "mike@nylas.com",
+          "david@nylas.com",
         ];
         component.addEventListener("timeSlotChosen", (event) => {
           console.log(event.detail.timeSlots);

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -91,10 +91,10 @@
           });
 
         document
-          .querySelectorAll('input[id="participant-threshold"]')
+          .querySelectorAll('input[id="partial_bookable_ratio"]')
           .forEach((elem) => {
             elem.addEventListener("input", function (event) {
-              component.participant_threshold = JSON.parse(event.target.value);
+              component.partial_bookable_ratio = JSON.parse(event.target.value);
             });
           });
 
@@ -218,23 +218,25 @@
       </fieldset>
 
       <fieldset>
-        <legend>Max Bookable Slots</legend>
         <label>
-          <input type="number" name="max-slots" value="1" />
+          Max Bookable Slots
+          <input type="number" name="max-slots" min="1" value="1" />
         </label>
       </fieldset>
 
       <fieldset>
-        <legend>Participant Threshold</legend>
-        <input
-          id="participant-threshold"
-          class="end"
-          type="range"
-          min="0"
-          max="100"
-          step="1"
-          value="1"
-        />
+        <label>
+          Participant Threshold
+          <input
+            id="partial_bookable_ratio"
+            class="end"
+            type="range"
+            min="0"
+            max="1"
+            step="0.01"
+            value="0"
+          />
+        </label>
       </fieldset>
     </aside>
 

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -50,16 +50,8 @@
           },
         ];
 
-        //component.calendars = calendars;
-        //component.email_ids = ["phil.r@nylas.com"];
+        component.calendars = calendars;
 
-        component.email_ids = [
-          "phil.r@nylas.com",
-          "david.t@nylas.com",
-          "hazik.a@nylas.com",
-          "chantal.l@nylas.com",
-          "shashaank.s@nylas.com",
-        ];
         component.addEventListener("timeSlotChosen", (event) => {
           console.log(event.detail.timeSlots);
         });
@@ -248,7 +240,7 @@
 
     <main>
       <div class="demo-box">
-        <nylas-availability id="phils-availability"></nylas-availability>
+        <nylas-availability id="demo-availability"></nylas-availability>
       </div>
     </main>
   </body>

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -50,9 +50,13 @@
           },
         ];
 
-        component.calendars = calendars;
+        //component.calendars = calendars;
 
-        // component.email_ids = ["pooja.g@nylas.com", "phil.r@nylas.com"];
+        component.email_ids = [
+          "pooja.g@nylas.com",
+          "aaron.d@nylas.com",
+          "phil.r@nylas.com",
+        ];
         component.addEventListener("timeSlotChosen", (event) => {
           console.log(event.detail.timeSlots);
         });
@@ -207,7 +211,7 @@
 
     <main>
       <div class="demo-box">
-        <nylas-availability id="demo-availability"></nylas-availability>
+        <nylas-availability id="phils-availability"></nylas-availability>
       </div>
     </main>
   </body>

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -49,9 +49,15 @@ describe("availability component", () => {
     });
 
     it("available time slot toggles (un)selected class", () => {
-      cy.get(".slot.free").first().should("have.class", "unselected");
-      cy.get(".slot.free").first().click();
-      cy.get(".slot.free").first().should("have.class", "selected");
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.allow_booking = true;
+          cy.get(".slot.free").first().should("have.class", "unselected");
+          cy.get(".slot.free").first().click();
+          cy.get(".slot.free").first().should("have.class", "selected");
+        });
     });
 
     it("should not show confirm button when multiple time slots are selected", () => {
@@ -236,7 +242,11 @@ describe("availability component", () => {
       cy.get("div.day")
         .first()
         .get("header h2")
-        .contains(new Date().toLocaleDateString());
+        .contains(
+          new Date().toLocaleString("default", {
+            day: "numeric",
+          }),
+        );
     });
 
     it("Updates start_date via component prop", () => {
@@ -250,7 +260,11 @@ describe("availability component", () => {
           cy.get("div.day")
             .first()
             .get("header h2")
-            .contains(nextWeek.toLocaleDateString());
+            .contains(
+              nextWeek.toLocaleString("default", {
+                day: "numeric",
+              }),
+            );
         });
     });
   });
@@ -327,6 +341,7 @@ describe("availability component", () => {
       cy.get("nylas-availability").then((element) => {
         const component = element[0];
         component.allow_booking = true;
+        component.max_bookable_slots = 5;
         component.calendars = [
           {
             emailAddress: "person@name.com",

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -341,7 +341,7 @@ describe("availability component", () => {
       cy.get("nylas-availability").then((element) => {
         const component = element[0];
         component.allow_booking = true;
-        component.max_bookable_slots = 5;
+        component.max_bookable_slots = 3;
         component.calendars = [
           {
             emailAddress: "person@name.com",


### PR DESCRIPTION
## Before
![CleanShot 2021-08-05 at 00 43 24](https://user-images.githubusercontent.com/713991/128292089-86012fa3-7ee3-4223-b88c-ecc3407c4087.png)

## After
![CleanShot 2021-08-05 at 00 07 16](https://user-images.githubusercontent.com/713991/128289310-240dc20a-bbab-41f4-a938-c7f65ffd1d35.png)

## Epochs
- Visual representation of blocks of time where a calendar is considered available or not
- Groups of same-calendar-availability timeslots.
- Represented as `free`, `busy`, or `partial`, just like timeSlots.
- Can be up to 96 slots long (15mins x 24h) or as few as 1 long (a single timeSlot)

## Partial Booking / Participant Threshold
- Originally considered having an "allow partial booking" boolean, but realized we would eventually want to support something more nuanced.
- `participant_threshold` introduced. A number, 0-100 that defaults to `1`, that indicates what % of participants must be available in order for a timeSlot to be considered `partial`.
- if the threshold isn't met, drop `partial` timeSlot status to `busy`

## Design Updates
- Dates now in `Day | Weekday` format
- Tick lines reduced in emphasis
- timeSlot borders removed
- "selected" state (temporarily) set to purple + dropshadow
- main visual emphasis is now on epochs

## Prop changes
- timeSlots only selectable now if `allow_booking` is set to true (won't highlight on click if set to false)
- `max_bookable_slots` introduced, defaults to `1`. Allows the dev to limit the number of bookings a user can create in one session.

## Demo video
https://user-images.githubusercontent.com/713991/128290513-9437e5c1-0a6a-4523-bfec-46bf8cdda3a6.mov


# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
