### PR TITLE
Availability Component: Week view and Show/Hide Weekends

### DIFF
--- a/commons/src/types/Availability.ts
+++ b/commons/src/types/Availability.ts
@@ -15,6 +15,8 @@ export interface Manifest extends NylasManifest {
   allow_booking: boolean;
   max_bookable_slots: number;
   partial_bookable_ratio: number;
+  show_as_week: boolean;
+  show_weekends: boolean;
 }
 
 export interface Calendar {

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -50,8 +50,7 @@
           },
         ];
 
-        //component.calendars = calendars;
-        component.email_ids = ["phil.r@nylas.com", "chantal.l@nylas.com"];
+        component.calendars = calendars;
 
         component.addEventListener("timeSlotChosen", (event) => {
           console.log(event.detail.timeSlots);
@@ -282,7 +281,7 @@
 
     <main>
       <div class="demo-box">
-        <nylas-availability id="phils-availability"></nylas-availability>
+        <nylas-availability id="demo-availability"></nylas-availability>
       </div>
     </main>
   </body>

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -50,7 +50,8 @@
           },
         ];
 
-        component.calendars = calendars;
+        //component.calendars = calendars;
+        component.email_ids = ["phil.r@nylas.com", "chantal.l@nylas.com"];
 
         component.addEventListener("timeSlotChosen", (event) => {
           console.log(event.detail.timeSlots);
@@ -103,6 +104,20 @@
             component.max_bookable_slots = JSON.parse(event.target.value);
           });
         });
+
+        document.querySelectorAll('input[name="week-view"]').forEach((elem) => {
+          elem.addEventListener("input", function (event) {
+            component.show_as_week = JSON.parse(event.target.value);
+          });
+        });
+
+        document
+          .querySelectorAll('input[name="show-weekends"]')
+          .forEach((elem) => {
+            elem.addEventListener("input", function (event) {
+              component.show_weekends = JSON.parse(event.target.value);
+            });
+          });
       });
     </script>
     <style>
@@ -239,11 +254,35 @@
           />
         </label>
       </fieldset>
+
+      <fieldset>
+        <legend>Week View</legend>
+        <label>
+          <input checked type="radio" name="week-view" value="false" />
+          Start from Today
+        </label>
+        <label>
+          <input type="radio" name="week-view" value="true" />
+          Start with Week
+        </label>
+      </fieldset>
+
+      <fieldset>
+        <legend>Weekends</legend>
+        <label>
+          <input checked type="radio" name="show-weekends" value="true" />
+          Include weekends
+        </label>
+        <label>
+          <input type="radio" name="show-weekends" value="false" />
+          Do not include weekends
+        </label>
+      </fieldset>
     </aside>
 
     <main>
       <div class="demo-box">
-        <nylas-availability id="demo-availability"></nylas-availability>
+        <nylas-availability id="phils-availability"></nylas-availability>
       </div>
     </main>
   </body>

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -412,4 +412,59 @@ describe("availability component", () => {
       cy.get("button.confirm").click();
     });
   });
+
+  describe("weeks and weekends", () => {
+    it("Handles week_view false", () => {
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.start_date = new Date("2021-04-06 00:00");
+          component.show_as_week = false;
+          cy.get("div.day:eq(0) header h2").contains("Tuesday");
+          cy.get("div.day:eq(2)").should("not.exist");
+        });
+    });
+
+    it("Handles week_view true", () => {
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.start_date = new Date("2021-04-06 00:00");
+          component.show_as_week = true;
+          cy.get("div.day:eq(0) header h2").contains("Sunday");
+          cy.get("div.day:eq(6) header h2").contains("Saturday");
+        });
+    });
+
+    it("Drops weekends like a bad habit: today view", () => {
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.start_date = new Date("2021-04-06 00:00");
+          component.dates_to_show = 7;
+          component.show_as_week = false;
+          component.show_weekends = false;
+          cy.get("div.day:eq(0) header h2").contains("Tuesday");
+          cy.get("div.day:eq(4) header h2").contains("Monday");
+          cy.get("div.day:eq(5) header h2").should("not.exist");
+        });
+    });
+
+    it("Drops weekends like a bad habit: week view", () => {
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.start_date = new Date("2021-04-06 00:00");
+          component.show_as_week = true;
+          component.show_weekends = false;
+          cy.get("div.day:eq(0) header h2").contains("Monday");
+          cy.get("div.day:eq(4) header h2").contains("Friday");
+          cy.get("div.day:eq(5) header h2").should("not.exist");
+        });
+    });
+  });
 });


### PR DESCRIPTION
Lets you easily get Sun-Sat weeks, Mon-Fri weeks, X-day periods that include weekends, and X-day periods that skip weekends.

## Show 7 days, today view, include weekends
![CleanShot 2021-08-06 at 01 32 38](https://user-images.githubusercontent.com/713991/128461065-01141cce-3ecd-477c-9190-4a18198f0db2.png)

## Show 7 days, today view, do not include weekends
![CleanShot 2021-08-06 at 01 33 11](https://user-images.githubusercontent.com/713991/128461104-5d77ef7d-0dcd-4326-858d-e058ee5bc404.png)

## Show as week, include weekends
![CleanShot 2021-08-06 at 01 33 45](https://user-images.githubusercontent.com/713991/128461157-0ea40267-f379-4375-a699-422023ae9fa4.png)

## Show as week, do not include weekends
![CleanShot 2021-08-06 at 01 33 57](https://user-images.githubusercontent.com/713991/128461186-e3db3e69-41a8-4797-ad8d-0d9084926f41.png)


# Readiness checklist

- [x] Cypress tests passing?
- [x] New cypress tests added?
- [x] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
