### PR TITLE
[Email] sender/receiver's email appears when dropdown is clicked

### DIFF
--- a/commons/src/components/Tooltip.svelte
+++ b/commons/src/components/Tooltip.svelte
@@ -66,7 +66,7 @@
 <button
   class="tooltip-trigger"
   aria-expanded={isTooltipVisible ? "true" : "false"}
-  id={`button-${id?.slice(0, 3)}`}
+  id={id ? `button-${id.slice(0, 3)}` : ""}
   aria-describedby={id}
   aria-label={isTooltipVisible ? "hide email" : "show email"}
   on:click|stopPropagation={(e) => toggleTooltipVisibility(e)}

--- a/commons/src/components/Tooltip.svelte
+++ b/commons/src/components/Tooltip.svelte
@@ -1,40 +1,28 @@
 <svelte:options tag="nylas-tooltip" />
 
 <script>
+  import { get_current_component } from "svelte/internal";
+  import { getEventDispatcher } from "@commons/methods/component";
+  const dispatchEvent = getEventDispatcher(get_current_component());
+
+  // #region tooltip props
+  export let currentTooltipID; // tooltip of currently open tooltip; this closes other tooltips
+  $: currentTooltipID; // tooltip of currently open tooltip; this closes other tooltips
   export let message;
   $: message;
   export let id;
+  $: id;
+  export let icon;
+  // #endregion tooltip props
 
-  let currentTrigger, currentTooltip, previousTrigger, previousTooltip;
-  let toggleTooltip = false;
-  // function toggleTooltip(e) {
-  //   currentTrigger = e.target;
-  //   currentTooltip = currentTrigger.querySelector(".tooltip");
+  $: isTooltipVisible =
+    currentTooltipID && currentTooltipID === id ? true : false;
 
-  //   if (
-  //     currentTooltip &&
-  //     currentTrigger.getAttribute("aria-expanded") === "false"
-  //   ) {
-  //     currentTrigger.setAttribute("aria-expanded", "true");
-  //     currentTrigger.setAttribute("aria-label", "hide email");
-  //     currentTooltip.style.visibility = "visible";
-  //     if (previousTrigger && previousTrigger.id !== currentTrigger.id) {
-  //       previousTooltip = previousTrigger.querySelector(".tooltip");
-  //       previousTrigger.setAttribute("aria-expanded", "false");
-  //       previousTrigger.setAttribute("aria-label", "show email");
-  //       previousTooltip.style.visibility = "hidden";
-  //     }
-  //   } else if (
-  //     currentTooltip &&
-  //     currentTrigger.getAttribute("aria-expanded") === "true"
-  //   ) {
-  //     currentTooltip = currentTrigger.querySelector(".tooltip");
-  //     currentTrigger.setAttribute("aria-expanded", "false");
-  //     currentTrigger.setAttribute("aria-label", "show email");
-  //     currentTooltip.style.visibility = "hidden";
-  //   }
-  //   previousTrigger = currentTrigger;
-  // }
+  function dispatchTooltip() {
+    dispatchEvent("toggleTooltip", {
+      tooltipID: id,
+    });
+  }
 </script>
 
 <style lang="scss">
@@ -42,17 +30,15 @@
   $spacing-s: 0.5rem;
 
   button.tooltip-trigger {
-    // position: relative;
-    // display: inline-block;
-    // background: transparent;
-    background: red !important;
+    position: relative;
+    display: inline-block;
+    background: transparent;
     height: 24px;
     width: 24px;
-    // width: min-content;
+    padding: 12px;
   }
   p.tooltip {
-    // position: absolute;
-    // visibility: hidden;
+    position: absolute;
     width: min-content;
     z-index: 1;
     top: 125%;
@@ -62,27 +48,21 @@
     box-shadow: 0px 3px 2px rgba(0, 0, 0, 0.25);
     border-radius: 2px;
   }
-
-  // &:hover {
-  //   p.tooltip {
-  //     visibility: visible;
-  //   }
-  // }
 </style>
 
 <button
   class="tooltip-trigger"
-  aria-expanded="false"
-  id={`button-${message?.id.slice(0, 2)}`}
+  aria-expanded={isTooltipVisible ? "true" : "false"}
+  id={`button-${message?.id.slice(0, 3)}`}
   aria-describedby={id}
-  aria-label="show email"
-  on:click|stopPropagation={() => {
-    toggleTooltip = !toggleTooltip;
-  }}
+  aria-label={isTooltipVisible ? "hide email" : "show email"}
+  on:click={dispatchTooltip}
 >
-  <slot name="icon" />
+  {#if icon}
+    <svelte:component this={icon} class="icon-container" aria-hidden="true" />
+  {/if}
 </button>
-{#if toggleTooltip}
+{#if isTooltipVisible}
   <p {id} role="tooltip" tabindex="0" class="tooltip">
     {message?.from[0].email}
   </p>

--- a/commons/src/components/Tooltip.svelte
+++ b/commons/src/components/Tooltip.svelte
@@ -1,23 +1,21 @@
 <svelte:options tag="nylas-tooltip" />
 
-<script>
+<script lang="ts">
   import { get_current_component } from "svelte/internal";
   import { getEventDispatcher } from "@commons/methods/component";
   const dispatchEvent = getEventDispatcher(get_current_component());
 
   // #region tooltip props
-  export let currentTooltipID; // tooltip of currently open tooltip; this closes other tooltips
-  $: currentTooltipID; // tooltip of currently open tooltip; this closes other tooltips
-  export let message;
-  $: message;
+  export let current_tooltip_id; // tooltip of currently open tooltip; this toggles other tooltips
+  export let content;
   export let id;
-  $: id;
   export let icon;
   // #endregion tooltip props
 
   $: isTooltipVisible =
-    currentTooltipID && currentTooltipID === id ? true : false;
+    current_tooltip_id && current_tooltip_id === id ? true : false;
 
+  // send tooltipID to parent component, so it updates the current_tooltip_id prop
   function dispatchTooltip() {
     dispatchEvent("toggleTooltip", {
       tooltipID: id,
@@ -30,18 +28,22 @@
   $spacing-s: 0.5rem;
 
   button.tooltip-trigger {
-    position: relative;
-    display: inline-block;
     background: transparent;
+    border: none;
+    box-shadow: none;
     height: 24px;
     width: 24px;
-    padding: 12px;
   }
+
+  button.tooltip-trigger :global(svg) {
+    width: 24px;
+  }
+
   p.tooltip {
     position: absolute;
     width: min-content;
     z-index: 1;
-    top: 125%;
+    bottom: 0;
     background: var(--grey-lightest);
     color: var(--grey-dark);
     padding: $spacing-s;
@@ -53,10 +55,10 @@
 <button
   class="tooltip-trigger"
   aria-expanded={isTooltipVisible ? "true" : "false"}
-  id={`button-${message?.id.slice(0, 3)}`}
+  id={`button-${id?.slice(0, 3)}`}
   aria-describedby={id}
   aria-label={isTooltipVisible ? "hide email" : "show email"}
-  on:click={dispatchTooltip}
+  on:click|stopPropagation={(e) => dispatchTooltip(e)}
 >
   {#if icon}
     <svelte:component this={icon} class="icon-container" aria-hidden="true" />
@@ -64,6 +66,6 @@
 </button>
 {#if isTooltipVisible}
   <p {id} role="tooltip" tabindex="0" class="tooltip">
-    {message?.from[0].email}
+    {content}
   </p>
 {/if}

--- a/commons/src/components/Tooltip.svelte
+++ b/commons/src/components/Tooltip.svelte
@@ -1,0 +1,89 @@
+<svelte:options tag="nylas-tooltip" />
+
+<script>
+  export let message;
+  $: message;
+  export let id;
+
+  let currentTrigger, currentTooltip, previousTrigger, previousTooltip;
+  let toggleTooltip = false;
+  // function toggleTooltip(e) {
+  //   currentTrigger = e.target;
+  //   currentTooltip = currentTrigger.querySelector(".tooltip");
+
+  //   if (
+  //     currentTooltip &&
+  //     currentTrigger.getAttribute("aria-expanded") === "false"
+  //   ) {
+  //     currentTrigger.setAttribute("aria-expanded", "true");
+  //     currentTrigger.setAttribute("aria-label", "hide email");
+  //     currentTooltip.style.visibility = "visible";
+  //     if (previousTrigger && previousTrigger.id !== currentTrigger.id) {
+  //       previousTooltip = previousTrigger.querySelector(".tooltip");
+  //       previousTrigger.setAttribute("aria-expanded", "false");
+  //       previousTrigger.setAttribute("aria-label", "show email");
+  //       previousTooltip.style.visibility = "hidden";
+  //     }
+  //   } else if (
+  //     currentTooltip &&
+  //     currentTrigger.getAttribute("aria-expanded") === "true"
+  //   ) {
+  //     currentTooltip = currentTrigger.querySelector(".tooltip");
+  //     currentTrigger.setAttribute("aria-expanded", "false");
+  //     currentTrigger.setAttribute("aria-label", "show email");
+  //     currentTooltip.style.visibility = "hidden";
+  //   }
+  //   previousTrigger = currentTrigger;
+  // }
+</script>
+
+<style lang="scss">
+  @import "../../../components/theming/variables.scss";
+  $spacing-s: 0.5rem;
+
+  button.tooltip-trigger {
+    // position: relative;
+    // display: inline-block;
+    // background: transparent;
+    background: red !important;
+    height: 24px;
+    width: 24px;
+    // width: min-content;
+  }
+  p.tooltip {
+    // position: absolute;
+    // visibility: hidden;
+    width: min-content;
+    z-index: 1;
+    top: 125%;
+    background: var(--grey-lightest);
+    color: var(--grey-dark);
+    padding: $spacing-s;
+    box-shadow: 0px 3px 2px rgba(0, 0, 0, 0.25);
+    border-radius: 2px;
+  }
+
+  // &:hover {
+  //   p.tooltip {
+  //     visibility: visible;
+  //   }
+  // }
+</style>
+
+<button
+  class="tooltip-trigger"
+  aria-expanded="false"
+  id={`button-${message?.id.slice(0, 2)}`}
+  aria-describedby={id}
+  aria-label="show email"
+  on:click|stopPropagation={() => {
+    toggleTooltip = !toggleTooltip;
+  }}
+>
+  <slot name="icon" />
+</button>
+{#if toggleTooltip}
+  <p {id} role="tooltip" tabindex="0" class="tooltip">
+    {message?.from[0].email}
+  </p>
+{/if}

--- a/commons/src/components/Tooltip.svelte
+++ b/commons/src/components/Tooltip.svelte
@@ -5,8 +5,13 @@
   import { getEventDispatcher } from "@commons/methods/component";
   const dispatchEvent = getEventDispatcher(get_current_component());
 
+  /**
+   * Add this CSS to the parent component: nylas-tooltip { position: relative; }
+   * This ensures the tooltip is positioned absolutely to the tooltip component rather than the page
+   **/
+
   // #region tooltip props
-  export let current_tooltip_id; // tooltip of currently open tooltip; this toggles other tooltips
+  export let current_tooltip_id; // id of visible tooltip in parent component
   export let content;
   export let id;
   export let icon;
@@ -16,17 +21,21 @@
     current_tooltip_id && current_tooltip_id === id ? true : false;
 
   // send tooltipID to parent component, so it updates the current_tooltip_id prop
-  function dispatchTooltip() {
-    dispatchEvent("toggleTooltip", {
-      tooltipID: id,
-    });
+  function toggleTooltipVisibility() {
+    if (current_tooltip_id !== id) {
+      dispatchEvent("toggleTooltip", {
+        tooltipID: id,
+      });
+    } else {
+      // close the tooltip if user clicks tooltip button again
+      isTooltipVisible = !isTooltipVisible;
+    }
   }
 </script>
 
 <style lang="scss">
   @import "../../../components/theming/variables.scss";
   $spacing-s: 0.5rem;
-
   button.tooltip-trigger {
     background: transparent;
     border: none;
@@ -40,15 +49,17 @@
   }
 
   p.tooltip {
-    position: absolute;
-    width: min-content;
-    z-index: 1;
-    bottom: 0;
     background: var(--grey-lightest);
-    color: var(--grey-dark);
-    padding: $spacing-s;
-    box-shadow: 0px 3px 2px rgba(0, 0, 0, 0.25);
     border-radius: 2px;
+    color: var(--grey-dark);
+    box-shadow: 0px 3px 2px rgba(0, 0, 0, 0.25);
+    left: 50%;
+    padding: $spacing-s;
+    position: absolute;
+    top: 8px;
+    transform: translate(-50%, 0);
+    width: max-content;
+    z-index: 1;
   }
 </style>
 
@@ -58,7 +69,7 @@
   id={`button-${id?.slice(0, 3)}`}
   aria-describedby={id}
   aria-label={isTooltipVisible ? "hide email" : "show email"}
-  on:click|stopPropagation={(e) => dispatchTooltip(e)}
+  on:click|stopPropagation={(e) => toggleTooltipVisibility(e)}
 >
   {#if icon}
     <svelte:component this={icon} class="icon-container" aria-hidden="true" />

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -446,6 +446,19 @@
       nylas-tooltip {
         position: relative;
       }
+      .default-avatar {
+        background: #002db4;
+        border-radius: 50%;
+        color: #fff;
+        font-family: sans-serif;
+        font-size: 1rem;
+        font-weight: bold;
+        height: 32px;
+        line-height: 35px;
+        text-align: center;
+        text-transform: uppercase;
+        width: 32px;
+      }
       header {
         font-size: 1.2rem;
         font-weight: 700;

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -910,7 +910,7 @@
                           <button
                             class="email-tooltip-btn"
                             id={`button-${msgIndex}`}
-                            aria-describedby={message.id + msgIndex}
+                            aria-describedby={message.id.slice(0, 3)}
                             aria-expanded="false"
                             aria-label="show email"
                             on:click|stopPropagation={toggleTooltip}
@@ -919,7 +919,7 @@
                               <DropdownSymbol />
                             </span>
                             <span
-                              id={message.id + msgIndex}
+                              id={message.id.slice(0, 3)}
                               role="tooltip"
                               tabindex="0"
                               class="email-tooltip"
@@ -940,7 +940,7 @@
                                 <button
                                   class="email-tooltip-btn"
                                   id={`button-${i}`}
-                                  aria-describedby={message.id + i}
+                                  aria-describedby={message.id.slice(0, 4)}
                                   aria-expanded="false"
                                   aria-label="show email"
                                   on:click|stopPropagation={toggleTooltip}
@@ -952,7 +952,7 @@
                                     <DropdownSymbol />
                                   </span>
                                   <span
-                                    id={message.id + i}
+                                    id={message.id.slice(0, 4)}
                                     role="tooltip"
                                     tabindex="0"
                                     class="email-tooltip"
@@ -989,14 +989,14 @@
                           class="email-tooltip-btn"
                           aria-expanded="false"
                           id={`button-${message.id.slice(0, 2)}`}
-                          aria-describedby={message.id}
+                          aria-describedby={message.id.slice(0, 3)}
                           aria-label="show email"
                           on:click|stopPropagation={toggleTooltip}
                           ><span class="icon-container" aria-hidden="true">
                             <DropdownSymbol />
                           </span>
                           <span
-                            id={message.id}
+                            id={message.id.slice(0, 3)}
                             role="tooltip"
                             tabindex="0"
                             class="email-tooltip">{message.from[0].email}</span
@@ -1150,7 +1150,7 @@
                         class="email-tooltip-btn"
                         aria-expanded="false"
                         id={`button-${i}`}
-                        aria-describedby={message.id}
+                        aria-describedby={message.id.slice(0, 3)}
                         aria-label="show email"
                         on:click|stopPropagation={toggleTooltip}
                       >
@@ -1158,7 +1158,7 @@
                           <DropdownSymbol />
                         </span>
                         <span
-                          id={message.id}
+                          id={message.id.slice(0, 3)}
                           role="tooltip"
                           tabindex="0"
                           class="email-tooltip">{message.to[0].email}</span

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -417,12 +417,7 @@
   function toggleTooltip(e) {
     currentTrigger = e.target;
     currentTooltip = currentTrigger.querySelector(".email-tooltip");
-    console.log(
-      "onclick aria-expanded attr of currentTrigger: ",
-      currentTrigger.getAttribute("aria-expanded"),
-    );
-    console.log({ currentTrigger }, { currentTooltip });
-    // if tooltipTrigger is not previousTrigger then change aria-expanded and aria-label
+
     if (
       currentTooltip &&
       currentTrigger.getAttribute("aria-expanded") === "false"
@@ -430,18 +425,22 @@
       currentTrigger.setAttribute("aria-expanded", "true");
       currentTrigger.setAttribute("aria-label", "hide email");
       currentTooltip.style.visibility = "visible";
-    } else if (previousTrigger) {
-      previousTooltip = previousTrigger.querySelector(".email-tooltip");
-      previousTrigger.setAttribute("aria-expanded", "false");
-      previousTrigger.setAttribute("aria-label", "show email");
-      previousTooltip.style.visibility = "hidden";
+      if (previousTrigger && previousTrigger.id !== currentTrigger.id) {
+        previousTooltip = previousTrigger.querySelector(".email-tooltip");
+        previousTrigger.setAttribute("aria-expanded", "false");
+        previousTrigger.setAttribute("aria-label", "show email");
+        previousTooltip.style.visibility = "hidden";
+      }
+    } else if (
+      currentTooltip &&
+      currentTrigger.getAttribute("aria-expanded") === "true"
+    ) {
+      currentTooltip = currentTrigger.querySelector(".email-tooltip");
+      currentTrigger.setAttribute("aria-expanded", "false");
+      currentTrigger.setAttribute("aria-label", "show email");
+      currentTooltip.style.visibility = "hidden";
     }
     previousTrigger = currentTrigger;
-    console.log(
-      "after click aria-expanded attr of currentTrigger: ",
-      currentTrigger.getAttribute("aria-expanded"),
-    );
-    console.log({ previousTrigger });
   }
 </script>
 

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -31,6 +31,7 @@
     Account,
   } from "@commons/types/Nylas";
   import "@commons/components/ContactImage/ContactImage.svelte";
+  import Tooltip from "@commons/components/Tooltip.svelte";
 
   let manifest: Partial<EmailProperties> = {};
 
@@ -411,37 +412,6 @@
       })
     );
   }
-
-  let currentTrigger, currentTooltip, previousTrigger, previousTooltip;
-
-  function toggleTooltip(e) {
-    currentTrigger = e.target;
-    currentTooltip = currentTrigger.querySelector(".email-tooltip");
-
-    if (
-      currentTooltip &&
-      currentTrigger.getAttribute("aria-expanded") === "false"
-    ) {
-      currentTrigger.setAttribute("aria-expanded", "true");
-      currentTrigger.setAttribute("aria-label", "hide email");
-      currentTooltip.style.visibility = "visible";
-      if (previousTrigger && previousTrigger.id !== currentTrigger.id) {
-        previousTooltip = previousTrigger.querySelector(".email-tooltip");
-        previousTrigger.setAttribute("aria-expanded", "false");
-        previousTrigger.setAttribute("aria-label", "show email");
-        previousTooltip.style.visibility = "hidden";
-      }
-    } else if (
-      currentTooltip &&
-      currentTrigger.getAttribute("aria-expanded") === "true"
-    ) {
-      currentTooltip = currentTrigger.querySelector(".email-tooltip");
-      currentTrigger.setAttribute("aria-expanded", "false");
-      currentTrigger.setAttribute("aria-label", "show email");
-      currentTooltip.style.visibility = "hidden";
-    }
-    previousTrigger = currentTrigger;
-  }
 </script>
 
 <style lang="scss">
@@ -572,7 +542,10 @@
       &.expanded {
         background: var(--white);
         padding: 0;
-
+        .icon-container,
+        .icon-container > * {
+          pointer-events: none;
+        }
         &.expanded-mailbox-thread {
           .message-from {
             .name {
@@ -584,38 +557,6 @@
           width: 100%;
           box-sizing: border-box;
           padding: $spacing-s;
-
-          button.email-tooltip-btn {
-            position: relative;
-            display: inline-block;
-            background: transparent;
-            min-height: 24px;
-            min-width: 24px;
-            width: min-content;
-            .icon-container,
-            .icon-container > * {
-              pointer-events: none;
-            }
-
-            span.email-tooltip {
-              position: absolute;
-              visibility: hidden;
-              width: min-content;
-              z-index: 1;
-              top: 125%;
-              background: var(--grey-lightest);
-              color: var(--grey-dark);
-              padding: $spacing-s;
-              box-shadow: 0px 3px 2px rgba(0, 0, 0, 0.25);
-              border-radius: 2px;
-            }
-
-            &:hover {
-              span.email-tooltip {
-                visibility: visible;
-              }
-            }
-          }
 
           &.condensed {
             div.snippet {
@@ -902,25 +843,15 @@
                             >{message.from[0].name ||
                               message.from[0].email}</span
                           >
-                          <button
-                            class="email-tooltip-btn"
-                            id={`button-${msgIndex}`}
-                            aria-describedby={message.id.slice(0, 3)}
-                            aria-expanded="false"
-                            aria-label="show email"
-                            on:click|stopPropagation={toggleTooltip}
-                          >
-                            <span class="icon-container" aria-hidden="true">
-                              <DropdownSymbol />
+
+                          <Tooltip {message} id={message.id.slice(0, 3)}>
+                            <span slot="icon">
+                              <DropdownSymbol
+                                class="icon-container"
+                                aria-hidden="true"
+                              />
                             </span>
-                            <span
-                              id={message.id.slice(0, 3)}
-                              role="tooltip"
-                              tabindex="0"
-                              class="email-tooltip"
-                              >{message.from[0].email}</span
-                            >
-                          </button>
+                          </Tooltip>
                         </div>
                         <div class="message-to">
                           {#each message.to as to, i}
@@ -932,29 +863,16 @@
                                 {#if i !== message.to.length - 1}
                                   &nbsp;&comma;
                                 {/if}
-                                <button
-                                  class="email-tooltip-btn"
-                                  id={`button-${i}`}
-                                  aria-describedby={message.id.slice(0, 4)}
-                                  aria-expanded="false"
-                                  aria-label="show email"
-                                  on:click|stopPropagation={toggleTooltip}
-                                >
-                                  <span
+                              {/if}
+
+                              <Tooltip {message} id={message.id.slice(0, 4)}>
+                                <span slot="icon">
+                                  <DropdownSymbol
                                     class="icon-container"
                                     aria-hidden="true"
-                                  >
-                                    <DropdownSymbol />
-                                  </span>
-                                  <span
-                                    id={message.id.slice(0, 4)}
-                                    role="tooltip"
-                                    tabindex="0"
-                                    class="email-tooltip"
-                                    >{message.to[0].email}</span
-                                  >
-                                </button>
-                              {/if}
+                                  />
+                                </span>
+                              </Tooltip>
                             </span>
                           {/each}
                         </div>
@@ -980,23 +898,15 @@
                         <span class="name"
                           >{message.from[0].name || message.from[0].email}</span
                         >
-                        <button
-                          class="email-tooltip-btn"
-                          aria-expanded="false"
-                          id={`button-${message.id.slice(0, 2)}`}
-                          aria-describedby={message.id.slice(0, 3)}
-                          aria-label="show email"
-                          on:click|stopPropagation={toggleTooltip}
-                          ><span class="icon-container" aria-hidden="true">
-                            <DropdownSymbol />
+
+                        <Tooltip {message} id={message.id.slice(0, 3)}>
+                          <span slot="icon">
+                            <DropdownSymbol
+                              class="icon-container"
+                              aria-hidden="true"
+                            />
                           </span>
-                          <span
-                            id={message.id.slice(0, 3)}
-                            role="tooltip"
-                            tabindex="0"
-                            class="email-tooltip">{message.from[0].email}</span
-                          >
-                        </button>
+                        </Tooltip>
                       </div>
                       <div class="message-date">
                         <span>
@@ -1112,57 +1022,34 @@
                 <span class="name"
                   >{message.from[0].name || message.from[0].email}</span
                 >
-                <button
-                  class="email-tooltip-btn"
-                  aria-expanded="false"
-                  id={`button-${message.id.slice(0, 2)}`}
-                  aria-describedby={message.id}
-                  aria-label="show email"
-                  on:click|stopPropagation={toggleTooltip}
-                >
-                  <span class="icon-container" aria-hidden="true">
-                    <DropdownSymbol />
+
+                <Tooltip {message} id={message.id}>
+                  <span slot="icon">
+                    <DropdownSymbol class="icon-container" aria-hidden="true" />
                   </span>
-                  <span
-                    id={message.id}
-                    role="tooltip"
-                    tabindex="0"
-                    class="email-tooltip">{message.from[0].email}</span
-                  >
-                </button>
+                </Tooltip>
               </div>
-              <div class="message-to">
-                {#each message.to as to, i}
-                  <span>
-                    {#if to.name || to.email || you.email_address}
-                      to&colon;&nbsp;{to.email === you.email_address
-                        ? "me"
-                        : to.name || to.email}
-                      {#if i !== message.to.length - 1}
-                        &nbsp;&comma;
-                      {/if}
-                      <button
-                        class="email-tooltip-btn"
-                        aria-expanded="false"
-                        id={`button-${i}`}
-                        aria-describedby={message.id.slice(0, 3)}
-                        aria-label="show email"
-                        on:click|stopPropagation={toggleTooltip}
-                      >
-                        <span class="icon-container" aria-hidden="true">
-                          <DropdownSymbol />
-                        </span>
-                        <span
-                          id={message.id.slice(0, 3)}
-                          role="tooltip"
-                          tabindex="0"
-                          class="email-tooltip">{message.to[0].email}</span
-                        >
-                      </button>
+              {#each message.to as to, i}
+                <span>
+                  {#if to.name || to.email || you.email_address}
+                    to&colon;&nbsp;{to.email === you.email_address
+                      ? "me"
+                      : to.name || to.email}
+                    {#if i !== message.to.length - 1}
+                      &nbsp;&comma;
                     {/if}
-                  </span>
-                {/each}
-              </div>
+
+                    <Tooltip {message} id={message.id.slice(0, 3)}>
+                      <span slot="icon">
+                        <DropdownSymbol
+                          class="icon-container"
+                          aria-hidden="true"
+                        />
+                      </span>
+                    </Tooltip>
+                  {/if}
+                </span>
+              {/each}
             </div>
             <div class="message-date">
               <span> {formatPreviewDate(new Date(message.date * 1000))}</span>

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -411,6 +411,38 @@
       })
     );
   }
+
+  let currentTrigger, currentTooltip, previousTrigger, previousTooltip;
+
+  function toggleTooltip(e) {
+    currentTrigger = e.target;
+    currentTooltip = currentTrigger.querySelector(".email-tooltip");
+    console.log(
+      "onclick aria-expanded attr of currentTrigger: ",
+      currentTrigger.getAttribute("aria-expanded"),
+    );
+    console.log({ currentTrigger }, { currentTooltip });
+    // if tooltipTrigger is not previousTrigger then change aria-expanded and aria-label
+    if (
+      currentTooltip &&
+      currentTrigger.getAttribute("aria-expanded") === "false"
+    ) {
+      currentTrigger.setAttribute("aria-expanded", "true");
+      currentTrigger.setAttribute("aria-label", "hide email");
+      currentTooltip.style.visibility = "visible";
+    } else if (previousTrigger) {
+      previousTooltip = previousTrigger.querySelector(".email-tooltip");
+      previousTrigger.setAttribute("aria-expanded", "false");
+      previousTrigger.setAttribute("aria-label", "show email");
+      previousTooltip.style.visibility = "hidden";
+    }
+    previousTrigger = currentTrigger;
+    console.log(
+      "after click aria-expanded attr of currentTrigger: ",
+      currentTrigger.getAttribute("aria-expanded"),
+    );
+    console.log({ previousTrigger });
+  }
 </script>
 
 <style lang="scss">
@@ -558,6 +590,13 @@
             position: relative;
             display: inline-block;
             background: transparent;
+            min-height: 24px;
+            min-width: 24px;
+            width: min-content;
+            .icon-container,
+            .icon-container > * {
+              pointer-events: none;
+            }
 
             span.email-tooltip {
               position: absolute;
@@ -570,6 +609,11 @@
               padding: $spacing-s;
               box-shadow: 0px 3px 2px rgba(0, 0, 0, 0.25);
               border-radius: 2px;
+            }
+            span.email-tooltip.active {
+              z-index: 2;
+              border: 2px solid red;
+              visibility: visible !important;
             }
 
             &:hover {
@@ -863,11 +907,26 @@
                           <span class="name"
                             >{message.from[0].name ||
                               message.from[0].email}</span
-                          ><button class="email-tooltip-btn"
-                            ><DropdownSymbol /><span class="email-tooltip"
-                              >{message.from[0].email}</span
-                            ></button
                           >
+                          <button
+                            class="email-tooltip-btn"
+                            id={`button-${msgIndex}`}
+                            aria-describedby={message.id + msgIndex}
+                            aria-expanded="false"
+                            aria-label="show email"
+                            on:click|stopPropagation={toggleTooltip}
+                          >
+                            <span class="icon-container" aria-hidden="true">
+                              <DropdownSymbol />
+                            </span>
+                            <span
+                              id={message.id + msgIndex}
+                              role="tooltip"
+                              tabindex="0"
+                              class="email-tooltip"
+                              >{message.from[0].email}</span
+                            >
+                          </button>
                         </div>
                         <div class="message-to">
                           {#each message.to as to, i}
@@ -878,11 +937,29 @@
                                   : to.name || to.email}
                                 {#if i !== message.to.length - 1}
                                   &nbsp;&comma;
-                                {/if}<button class="email-tooltip-btn"
-                                  ><DropdownSymbol /><span class="email-tooltip"
-                                    >{message.to[0].email}</span
-                                  ></button
+                                {/if}
+                                <button
+                                  class="email-tooltip-btn"
+                                  id={`button-${i}`}
+                                  aria-describedby={message.id + i}
+                                  aria-expanded="false"
+                                  aria-label="show email"
+                                  on:click|stopPropagation={toggleTooltip}
                                 >
+                                  <span
+                                    class="icon-container"
+                                    aria-hidden="true"
+                                  >
+                                    <DropdownSymbol />
+                                  </span>
+                                  <span
+                                    id={message.id + i}
+                                    role="tooltip"
+                                    tabindex="0"
+                                    class="email-tooltip"
+                                    >{message.to[0].email}</span
+                                  >
+                                </button>
                               {/if}
                             </span>
                           {/each}
@@ -908,12 +985,24 @@
                       <div class="message-from">
                         <span class="name"
                           >{message.from[0].name || message.from[0].email}</span
-                        ><button class="email-tooltip-btn"
-                          ><DropdownSymbol />
-                          <span class="email-tooltip"
-                            >{message.from[0].email}</span
-                          ></button
                         >
+                        <button
+                          class="email-tooltip-btn"
+                          aria-expanded="false"
+                          id={`button-${message.id.slice(0, 2)}`}
+                          aria-describedby={message.id}
+                          aria-label="show email"
+                          on:click|stopPropagation={toggleTooltip}
+                          ><span class="icon-container" aria-hidden="true">
+                            <DropdownSymbol />
+                          </span>
+                          <span
+                            id={message.id}
+                            role="tooltip"
+                            tabindex="0"
+                            class="email-tooltip">{message.from[0].email}</span
+                          >
+                        </button>
                       </div>
                       <div class="message-date">
                         <span>
@@ -1029,11 +1118,24 @@
                 <span class="name"
                   >{message.from[0].name || message.from[0].email}</span
                 >
-                <button class="email-tooltip-btn"
-                  ><DropdownSymbol />
-                  <span class="email-tooltip">{message.from[0].email}</span
-                  ></button
+                <button
+                  class="email-tooltip-btn"
+                  aria-expanded="false"
+                  id={`button-${message.id.slice(0, 2)}`}
+                  aria-describedby={message.id}
+                  aria-label="show email"
+                  on:click|stopPropagation={toggleTooltip}
                 >
+                  <span class="icon-container" aria-hidden="true">
+                    <DropdownSymbol />
+                  </span>
+                  <span
+                    id={message.id}
+                    role="tooltip"
+                    tabindex="0"
+                    class="email-tooltip">{message.from[0].email}</span
+                  >
+                </button>
               </div>
               <div class="message-to">
                 {#each message.to as to, i}
@@ -1045,11 +1147,24 @@
                       {#if i !== message.to.length - 1}
                         &nbsp;&comma;
                       {/if}
-                      <button class="email-tooltip-btn"
-                        ><DropdownSymbol />
-                        <span class="email-tooltip">{message.to[0].email}</span
-                        ></button
+                      <button
+                        class="email-tooltip-btn"
+                        aria-expanded="false"
+                        id={`button-${i}`}
+                        aria-describedby={message.id}
+                        aria-label="show email"
+                        on:click|stopPropagation={toggleTooltip}
                       >
+                        <span class="icon-container" aria-hidden="true">
+                          <DropdownSymbol />
+                        </span>
+                        <span
+                          id={message.id}
+                          role="tooltip"
+                          tabindex="0"
+                          class="email-tooltip">{message.to[0].email}</span
+                        >
+                      </button>
                     {/if}
                   </span>
                 {/each}

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -871,15 +871,15 @@
                                 {#if i !== message.to.length - 1}
                                   &nbsp;&comma;
                                 {/if}
+                                <!-- tooltip component -->
+                                <nylas-tooltip
+                                  on:toggleTooltip={setTooltip}
+                                  id={message.id.slice(0, 4)}
+                                  {current_tooltip_id}
+                                  icon={DropdownSymbol}
+                                  content={to.email}
+                                />
                               {/if}
-                              <!-- tooltip component -->
-                              <nylas-tooltip
-                                on:toggleTooltip={setTooltip}
-                                id={message.id.slice(0, 4)}
-                                {current_tooltip_id}
-                                icon={DropdownSymbol}
-                                content={to.email}
-                              />
                             </span>
                           {/each}
                         </div>
@@ -1037,26 +1037,28 @@
                   content={message.from[0].email}
                 />
               </div>
-              {#each message.to as to, i}
-                <span>
-                  {#if to.name || to.email || you.email_address}
-                    to&colon;&nbsp;{to.email === you.email_address
-                      ? "me"
-                      : to.name || to.email}
-                    {#if i !== message.to.length - 1}
-                      &nbsp;&comma;
+              <div class="message-to">
+                {#each message.to as to, i}
+                  <span>
+                    {#if to.name || to.email || you.email_address}
+                      to&colon;&nbsp;{to.email === you.email_address
+                        ? "me"
+                        : to.name || to.email}
+                      {#if i !== message.to.length - 1}
+                        &nbsp;&comma;
+                      {/if}
+                      <!-- tooltip component -->
+                      <nylas-tooltip
+                        on:toggleTooltip={setTooltip}
+                        id={message.id.slice(0, 3)}
+                        {current_tooltip_id}
+                        icon={DropdownSymbol}
+                        content={to.email}
+                      />
                     {/if}
-                    <!-- tooltip component -->
-                    <nylas-tooltip
-                      on:toggleTooltip={setTooltip}
-                      id={message.id.slice(0, 3)}
-                      {current_tooltip_id}
-                      icon={DropdownSymbol}
-                      content={to.email}
-                    />
-                  {/if}
-                </span>
-              {/each}
+                  </span>
+                {/each}
+              </div>
             </div>
             <div class="message-date">
               <span> {formatPreviewDate(new Date(message.date * 1000))}</span>

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -272,6 +272,7 @@
     if (message && (!thread_id || !thread)) return;
     e.preventDefault();
     handleThread(e);
+    current_tooltip_id = "";
   }
 
   function handleThreadKeypress(e: KeyboardEvent) {
@@ -442,18 +443,8 @@
       background: var(--nylas-email-background, var(--grey-lightest));
       border: var(--nylas-email-border, #{$border-style});
 
-      .default-avatar {
-        background: #002db4;
-        border-radius: 50%;
-        color: #fff;
-        font-family: sans-serif;
-        font-size: 1rem;
-        font-weight: bold;
-        height: 32px;
-        line-height: 35px;
-        text-align: center;
-        text-transform: uppercase;
-        width: 32px;
+      nylas-tooltip {
+        position: relative;
       }
       header {
         font-size: 1.2rem;

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -413,11 +413,9 @@
     );
   }
 
-  $: currentTooltipID = "";
-  $: console.log("Email component: ", { currentTooltipID });
-
+  let current_tooltip_id: string = "";
   function setTooltip(e) {
-    currentTooltipID = e.detail.tooltipID;
+    current_tooltip_id = e.detail.tooltipID;
   }
 </script>
 
@@ -853,10 +851,10 @@
                           <!-- tooltip component -->
                           <nylas-tooltip
                             on:toggleTooltip={setTooltip}
-                            {message}
                             id={message.id.slice(0, 3)}
-                            {currentTooltipID}
+                            {current_tooltip_id}
                             icon={DropdownSymbol}
+                            content={message.from[0].email}
                           />
                         </div>
                         <div class="message-to">
@@ -873,10 +871,10 @@
                               <!-- tooltip component -->
                               <nylas-tooltip
                                 on:toggleTooltip={setTooltip}
-                                {message}
                                 id={message.id.slice(0, 4)}
-                                {currentTooltipID}
+                                {current_tooltip_id}
                                 icon={DropdownSymbol}
+                                content={to.email}
                               />
                             </span>
                           {/each}
@@ -906,10 +904,10 @@
                         <!-- tooltip component -->
                         <nylas-tooltip
                           on:toggleTooltip={setTooltip}
-                          {message}
                           id={message.id.slice(0, 3)}
-                          {currentTooltipID}
+                          {current_tooltip_id}
                           icon={DropdownSymbol}
+                          content={message.from[0].email}
                         />
                       </div>
                       <div class="message-date">
@@ -1029,10 +1027,10 @@
                 <!-- tooltip component -->
                 <nylas-tooltip
                   on:toggleTooltip={setTooltip}
-                  {message}
                   id={message.id}
-                  {currentTooltipID}
+                  {current_tooltip_id}
                   icon={DropdownSymbol}
+                  content={message.from[0].email}
                 />
               </div>
               {#each message.to as to, i}
@@ -1047,10 +1045,10 @@
                     <!-- tooltip component -->
                     <nylas-tooltip
                       on:toggleTooltip={setTooltip}
-                      {message}
                       id={message.id.slice(0, 3)}
-                      {currentTooltipID}
+                      {current_tooltip_id}
                       icon={DropdownSymbol}
+                      content={to.email}
                     />
                   {/if}
                 </span>

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -412,6 +412,13 @@
       })
     );
   }
+
+  $: currentTooltipID = "";
+  $: console.log("Email component: ", { currentTooltipID });
+
+  function setTooltip(e) {
+    currentTooltipID = e.detail.tooltipID;
+  }
 </script>
 
 <style lang="scss">
@@ -843,15 +850,14 @@
                             >{message.from[0].name ||
                               message.from[0].email}</span
                           >
-
-                          <Tooltip {message} id={message.id.slice(0, 3)}>
-                            <span slot="icon">
-                              <DropdownSymbol
-                                class="icon-container"
-                                aria-hidden="true"
-                              />
-                            </span>
-                          </Tooltip>
+                          <!-- tooltip component -->
+                          <nylas-tooltip
+                            on:toggleTooltip={setTooltip}
+                            {message}
+                            id={message.id.slice(0, 3)}
+                            {currentTooltipID}
+                            icon={DropdownSymbol}
+                          />
                         </div>
                         <div class="message-to">
                           {#each message.to as to, i}
@@ -864,15 +870,14 @@
                                   &nbsp;&comma;
                                 {/if}
                               {/if}
-
-                              <Tooltip {message} id={message.id.slice(0, 4)}>
-                                <span slot="icon">
-                                  <DropdownSymbol
-                                    class="icon-container"
-                                    aria-hidden="true"
-                                  />
-                                </span>
-                              </Tooltip>
+                              <!-- tooltip component -->
+                              <nylas-tooltip
+                                on:toggleTooltip={setTooltip}
+                                {message}
+                                id={message.id.slice(0, 4)}
+                                {currentTooltipID}
+                                icon={DropdownSymbol}
+                              />
                             </span>
                           {/each}
                         </div>
@@ -898,15 +903,14 @@
                         <span class="name"
                           >{message.from[0].name || message.from[0].email}</span
                         >
-
-                        <Tooltip {message} id={message.id.slice(0, 3)}>
-                          <span slot="icon">
-                            <DropdownSymbol
-                              class="icon-container"
-                              aria-hidden="true"
-                            />
-                          </span>
-                        </Tooltip>
+                        <!-- tooltip component -->
+                        <nylas-tooltip
+                          on:toggleTooltip={setTooltip}
+                          {message}
+                          id={message.id.slice(0, 3)}
+                          {currentTooltipID}
+                          icon={DropdownSymbol}
+                        />
                       </div>
                       <div class="message-date">
                         <span>
@@ -1022,12 +1026,14 @@
                 <span class="name"
                   >{message.from[0].name || message.from[0].email}</span
                 >
-
-                <Tooltip {message} id={message.id}>
-                  <span slot="icon">
-                    <DropdownSymbol class="icon-container" aria-hidden="true" />
-                  </span>
-                </Tooltip>
+                <!-- tooltip component -->
+                <nylas-tooltip
+                  on:toggleTooltip={setTooltip}
+                  {message}
+                  id={message.id}
+                  {currentTooltipID}
+                  icon={DropdownSymbol}
+                />
               </div>
               {#each message.to as to, i}
                 <span>
@@ -1038,15 +1044,14 @@
                     {#if i !== message.to.length - 1}
                       &nbsp;&comma;
                     {/if}
-
-                    <Tooltip {message} id={message.id.slice(0, 3)}>
-                      <span slot="icon">
-                        <DropdownSymbol
-                          class="icon-container"
-                          aria-hidden="true"
-                        />
-                      </span>
-                    </Tooltip>
+                    <!-- tooltip component -->
+                    <nylas-tooltip
+                      on:toggleTooltip={setTooltip}
+                      {message}
+                      id={message.id.slice(0, 3)}
+                      {currentTooltipID}
+                      icon={DropdownSymbol}
+                    />
                   {/if}
                 </span>
               {/each}

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -266,13 +266,13 @@
       event: e,
       thread: activeThread,
     });
+    current_tooltip_id = "";
   }
 
   function handleThreadClick(e: MouseEvent) {
     if (message && (!thread_id || !thread)) return;
     e.preventDefault();
     handleThread(e);
-    current_tooltip_id = "";
   }
 
   function handleThreadKeypress(e: KeyboardEvent) {

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -609,11 +609,6 @@
               box-shadow: 0px 3px 2px rgba(0, 0, 0, 0.25);
               border-radius: 2px;
             }
-            span.email-tooltip.active {
-              z-index: 2;
-              border: 2px solid red;
-              visibility: visible !important;
-            }
 
             &:hover {
               span.email-tooltip {

--- a/components/email/src/init.spec.js
+++ b/components/email/src/init.spec.js
@@ -220,17 +220,25 @@ describe("Email component", () => {
         cy.get(component).find(".message-body").should("contain", "Bye!");
         cy.get(component).find(".name").should("exist");
         cy.get(component).find(".name").should("contain", "Test User");
-        cy.get(component).find(".email-tooltip").should("exist");
+        cy.get(component).find(".email-row.expanded.singular header").click();
         cy.get(component)
-          .find(".email-tooltip")
-          .should("contain", "nylascypresstest@gmail.com");
+          .find("nylas-tooltip")
+          .then((element) => {
+            const tooltip = element[0];
+            cy.get(tooltip).find(".tooltip-trigger").should("exist");
+            cy.get(tooltip).find(".tooltip-trigger").click();
+            cy.get(tooltip)
+              .find(".tooltip")
+              .should("contain", "nylascypresstest@gmail.com");
+            cy.get(tooltip).find(".tooltip-trigger").click();
+            cy.get(tooltip).find(".tooltip").should("not.exist");
+          });
         cy.get(component).find(".message-date span").should("exist");
         cy.get(component)
           .find(".message-date span")
           .should("contain", "July 7");
-        cy.get(component).find(".message-to span").should("exist");
         cy.get(component)
-          .find(".message-to span")
+          .find(".message-from-to span")
           .should("contain", "Pooja Guggari");
       });
   });
@@ -323,74 +331,80 @@ describe("Email component", () => {
 
   describe("Toggle email of sender/recipient", () => {
     it("When tooltip trigger is clicked", () => {
-      cy.get("nylas-email")
-        .as("email")
-        .then((element) => {
-          const component = element[2];
-          cy.get(component)
-            .find(".email-tooltip")
-            .first()
-            .should("not.be.visible");
-          cy.get(component).find(".email-tooltip-btn").first().should("exist");
-          cy.get(component).find(".email-tooltip-btn").first().click();
-          cy.get(component).find(".email-tooltip").first().should("be.visible");
-          cy.get(component).find(".email-tooltip-btn").first().click();
-          cy.get(component)
-            .find(".email-tooltip")
-            .first()
-            .should("not.be.visible");
-        });
+      cy.get("nylas-email").then((element) => {
+        const component = element[2];
+        cy.get(component)
+          .find("nylas-tooltip")
+          .then((element) => {
+            const firstTooltip = element[0];
+            cy.get(firstTooltip).find(".tooltip-trigger").should("exist");
+            cy.get(firstTooltip).find(".tooltip-trigger").click();
+            cy.get(firstTooltip).find(".tooltip").should("exist");
+            cy.get(firstTooltip)
+              .find(".tooltip")
+              .should("contain", "nylascypresstest@gmail.com");
+            cy.get(firstTooltip).find(".tooltip-trigger").click();
+            cy.get(firstTooltip).find(".tooltip").should("not.exist");
+          });
+      });
     });
     it("Does not show more than one tooltip", () => {
-      cy.get("nylas-email")
-        .as("email")
-        .then((element) => {
-          const component = element[2];
-          cy.get(component).find(".email-tooltip-btn").last().click();
-          cy.get(component).find(".email-tooltip").last().should("be.visible");
-          cy.get(component).find(".email-tooltip-btn").first().click();
-          cy.get(component).find(".email-tooltip").first().should("be.visible");
-          cy.get(component)
-            .find(".email-tooltip")
-            .last()
-            .should("not.be.visible");
-        });
+      cy.get("nylas-email").then((element) => {
+        const component = element[2];
+        cy.get(component)
+          .find("nylas-tooltip")
+          .then((element) => {
+            const firstTooltip = element[0];
+            const secondTooltip = element[1];
+            cy.get(secondTooltip).find(".tooltip").should("not.exist");
+            cy.get(secondTooltip).find(".tooltip-trigger").click();
+            cy.get(secondTooltip).find(".tooltip").should("exist");
+            cy.get(secondTooltip)
+              .find(".tooltip")
+              .should("contain", "pooja.g@nylas.com");
+            cy.get(firstTooltip).find(".tooltip-trigger").click();
+            cy.get(firstTooltip).find(".tooltip").should("exist");
+            cy.get(firstTooltip)
+              .find(".tooltip")
+              .should("contain", "nylascypresstest@gmail.com");
+            cy.get(secondTooltip).find(".tooltip").should("not.exist");
+          });
+      });
     });
-    it("when tooltip trigger is clicked twice", () => {
-      cy.get("nylas-email")
-        .as("email")
-        .then((element) => {
-          const component = element[2];
-          cy.get(component)
-            .find(".email-tooltip")
-            .first()
-            .should("not.be.visible");
-          cy.get(component).find(".email-tooltip-btn").first().should("exist");
-          // first toggle
-          cy.get(component).find(".email-tooltip-btn").first().click();
-          cy.get(component).find(".email-tooltip").first().should("be.visible");
-          cy.get(component).find(".email-tooltip-btn").first().click();
-          cy.get(component)
-            .find(".email-tooltip")
-            .first()
-            .should("not.be.visible");
-          // second toggle
-          cy.get(component).find(".email-tooltip-btn").first().click();
-          cy.get(component).find(".email-tooltip").first().should("be.visible");
-          cy.get(component).find(".email-tooltip-btn").first().click();
-          cy.get(component)
-            .find(".email-tooltip")
-            .first()
-            .should("not.be.visible");
-          // third toggle
-          cy.get(component).find(".email-tooltip-btn").first().click();
-          cy.get(component).find(".email-tooltip").first().should("be.visible");
-          cy.get(component).find(".email-tooltip-btn").first().click();
-          cy.get(component)
-            .find(".email-tooltip")
-            .first()
-            .should("not.be.visible");
-        });
+    it("when tooltip trigger is clicked multiple times", () => {
+      cy.get("nylas-email").then((element) => {
+        const component = element[3];
+        cy.get(component)
+          .find("nylas-tooltip")
+          .then((element) => {
+            const firstTooltip = element[0];
+            cy.get(firstTooltip).find(".tooltip-trigger").should("exist");
+            // first toggle
+            cy.get(firstTooltip).find(".tooltip-trigger").click();
+            cy.get(firstTooltip).find(".tooltip").should("exist");
+            cy.get(firstTooltip)
+              .find(".tooltip")
+              .should("contain", "notifications@github.com");
+            cy.get(firstTooltip).find(".tooltip-trigger").click();
+            cy.get(firstTooltip).find(".tooltip").should("not.exist");
+            // second toggle
+            cy.get(firstTooltip).find(".tooltip-trigger").click();
+            cy.get(firstTooltip).find(".tooltip").should("exist");
+            cy.get(firstTooltip)
+              .find(".tooltip")
+              .should("contain", "notifications@github.com");
+            cy.get(firstTooltip).find(".tooltip-trigger").click();
+            cy.get(firstTooltip).find(".tooltip").should("not.exist");
+            // third toggle
+            cy.get(firstTooltip).find(".tooltip-trigger").click();
+            cy.get(firstTooltip).find(".tooltip").should("exist");
+            cy.get(firstTooltip)
+              .find(".tooltip")
+              .should("contain", "notifications@github.com");
+            cy.get(firstTooltip).find(".tooltip-trigger").click();
+            cy.get(firstTooltip).find(".tooltip").should("not.exist");
+          });
+      });
     });
   });
 });

--- a/components/email/src/init.spec.js
+++ b/components/email/src/init.spec.js
@@ -371,7 +371,7 @@ describe("Email component", () => {
           });
       });
     });
-    it("when tooltip trigger is clicked multiple times", () => {
+    it("When tooltip trigger is clicked multiple times", () => {
       cy.get("nylas-email").then((element) => {
         const component = element[3];
         cy.get(component)
@@ -403,6 +403,80 @@ describe("Email component", () => {
               .should("contain", "notifications@github.com");
             cy.get(firstTooltip).find(".tooltip-trigger").click();
             cy.get(firstTooltip).find(".tooltip").should("not.exist");
+          });
+      });
+    });
+    it("Accessibility attributes are set by default", () => {
+      cy.get("nylas-email").then((element) => {
+        const component = element[2];
+        cy.get(component)
+          .find("nylas-tooltip")
+          .then((element) => {
+            const tooltip = element[0];
+            cy.get(tooltip)
+              .find(".tooltip-trigger")
+              .invoke("attr", "aria-expanded")
+              .should("eq", "false");
+            cy.get(tooltip)
+              .find(".tooltip-trigger")
+              .invoke("attr", "aria-label")
+              .should("eq", "show email");
+            cy.get(tooltip)
+              .find(".tooltip-trigger")
+              .invoke("attr", "aria-describedby")
+              .should("exist");
+            cy.get(tooltip)
+              .find(".tooltip-trigger svg")
+              .invoke("attr", "aria-hidden")
+              .should("eq", "true");
+          });
+      });
+    });
+    it("Accessibility attributes change when tooltip trigger is clicked", () => {
+      cy.get("nylas-email").then((element) => {
+        const component = element[2];
+        cy.get(component)
+          .find("nylas-tooltip")
+          .then((element) => {
+            const tooltip = element[0];
+
+            cy.get(tooltip).find(".tooltip-trigger").click();
+            cy.get(tooltip)
+              .find(".tooltip")
+              .invoke("attr", "tabindex")
+              .should("eq", "0");
+            cy.get(tooltip)
+              .find(".tooltip")
+              .invoke("attr", "role")
+              .should("eq", "tooltip");
+            cy.get(tooltip)
+              .find(".tooltip")
+              .invoke("attr", "id")
+              .then(($tooltipID) => {
+                cy.get(tooltip)
+                  .find(".tooltip-trigger")
+                  .invoke("attr", "aria-describedby")
+                  .then(($ariaDescribedby) => {
+                    expect($tooltipID).to.be.equal($ariaDescribedby);
+                  });
+              });
+            cy.get(tooltip)
+              .find(".tooltip-trigger")
+              .invoke("attr", "aria-expanded")
+              .should("eq", "true");
+            cy.get(tooltip)
+              .find(".tooltip-trigger")
+              .invoke("attr", "aria-label")
+              .should("eq", "hide email");
+            cy.get(tooltip).find(".tooltip-trigger").click();
+            cy.get(tooltip)
+              .find(".tooltip-trigger")
+              .invoke("attr", "aria-expanded")
+              .should("eq", "false");
+            cy.get(tooltip)
+              .find(".tooltip-trigger")
+              .invoke("attr", "aria-label")
+              .should("eq", "show email");
           });
       });
     });

--- a/components/email/src/init.spec.js
+++ b/components/email/src/init.spec.js
@@ -322,7 +322,7 @@ describe("Email component", () => {
   });
 
   describe("Toggle email of sender/recipient", () => {
-    it("On click", () => {
+    it("When tooltip trigger is clicked", () => {
       cy.get("nylas-email")
         .as("email")
         .then((element) => {
@@ -356,7 +356,7 @@ describe("Email component", () => {
             .should("not.be.visible");
         });
     });
-    it("When clicked multiple times", () => {
+    it("when tooltip trigger is clicked twice", () => {
       cy.get("nylas-email")
         .as("email")
         .then((element) => {
@@ -375,6 +375,14 @@ describe("Email component", () => {
             .first()
             .should("not.be.visible");
           // second toggle
+          cy.get(component).find(".email-tooltip-btn").first().click();
+          cy.get(component).find(".email-tooltip").first().should("be.visible");
+          cy.get(component).find(".email-tooltip-btn").first().click();
+          cy.get(component)
+            .find(".email-tooltip")
+            .first()
+            .should("not.be.visible");
+          // third toggle
           cy.get(component).find(".email-tooltip-btn").first().click();
           cy.get(component).find(".email-tooltip").first().should("be.visible");
           cy.get(component).find(".email-tooltip-btn").first().click();

--- a/components/email/src/init.spec.js
+++ b/components/email/src/init.spec.js
@@ -320,4 +320,69 @@ describe("Email component", () => {
         });
     });
   });
+
+  describe("Toggle email of sender/recipient", () => {
+    it("On click", () => {
+      cy.get("nylas-email")
+        .as("email")
+        .then((element) => {
+          const component = element[2];
+          cy.get(component)
+            .find(".email-tooltip")
+            .first()
+            .should("not.be.visible");
+          cy.get(component).find(".email-tooltip-btn").first().should("exist");
+          cy.get(component).find(".email-tooltip-btn").first().click();
+          cy.get(component).find(".email-tooltip").first().should("be.visible");
+          cy.get(component).find(".email-tooltip-btn").first().click();
+          cy.get(component)
+            .find(".email-tooltip")
+            .first()
+            .should("not.be.visible");
+        });
+    });
+    it("Does not show more than one tooltip", () => {
+      cy.get("nylas-email")
+        .as("email")
+        .then((element) => {
+          const component = element[2];
+          cy.get(component).find(".email-tooltip-btn").last().click();
+          cy.get(component).find(".email-tooltip").last().should("be.visible");
+          cy.get(component).find(".email-tooltip-btn").first().click();
+          cy.get(component).find(".email-tooltip").first().should("be.visible");
+          cy.get(component)
+            .find(".email-tooltip")
+            .last()
+            .should("not.be.visible");
+        });
+    });
+    it("When clicked multiple times", () => {
+      cy.get("nylas-email")
+        .as("email")
+        .then((element) => {
+          const component = element[2];
+          cy.get(component)
+            .find(".email-tooltip")
+            .first()
+            .should("not.be.visible");
+          cy.get(component).find(".email-tooltip-btn").first().should("exist");
+          // first toggle
+          cy.get(component).find(".email-tooltip-btn").first().click();
+          cy.get(component).find(".email-tooltip").first().should("be.visible");
+          cy.get(component).find(".email-tooltip-btn").first().click();
+          cy.get(component)
+            .find(".email-tooltip")
+            .first()
+            .should("not.be.visible");
+          // second toggle
+          cy.get(component).find(".email-tooltip-btn").first().click();
+          cy.get(component).find(".email-tooltip").first().should("be.visible");
+          cy.get(component).find(".email-tooltip-btn").first().click();
+          cy.get(component)
+            .find(".email-tooltip")
+            .first()
+            .should("not.be.visible");
+        });
+    });
+  });
 });

--- a/components/email/src/init.spec.js
+++ b/components/email/src/init.spec.js
@@ -238,7 +238,7 @@ describe("Email component", () => {
           .find(".message-date span")
           .should("contain", "July 7");
         cy.get(component)
-          .find(".message-from-to span")
+          .find(".message-to span")
           .should("contain", "Pooja Guggari");
       });
   });


### PR DESCRIPTION
Tooltip changes:
- Added `role="tooltip"`, `id` and `tabindex="0"` to make it accessible to keyboard users

Tooltip trigger button (referred to as the "dropdown") changes:
- Dynamic `aria-expanded` and `aria-label` attributes
- `aria-describedby` attribute that matches the `id` of the tooltip
- Functionality to toggle `aria-expanded` and `aria-label` attributes on click
- Functionality that prevents more than one tooltip being visible at a time in a thread/message


# Readiness checklist

- [x] Cypress tests passing?
- [x] New cypress tests added?

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
