### PR TITLE
Add contact pictures for email thread participants

### DIFF
--- a/commons/src/components/ContactImage/ContactImage.svelte
+++ b/commons/src/components/ContactImage/ContactImage.svelte
@@ -1,19 +1,18 @@
 <svelte:options tag="nylas-contact-image" />
 
 <script>
-  import { onMount } from "svelte/internal";
+  import { beforeUpdate } from "svelte/internal";
   import { fetchContactImage } from "@commons";
   export let contact;
+  export let contactQuery;
   export let height = "32px";
   export let width = "32px";
 
   let image;
 
-  onMount(async (contact) => {
+  beforeUpdate(async () => {
     if (contact?.picture_url) {
-      return (image = await fetchContactImage(contactQuery, contact.id));
-    } else {
-      return contact;
+      image = await fetchContactImage(contactQuery, contact?.id);
     }
   });
 </script>
@@ -21,13 +20,15 @@
 {#if image}
   <img
     alt=""
-    style="height: {height}; width: {width}"
+    style="height: {height}; width: {width}; border-radius: 50%;"
     src="data:image/jpg;base64,{image}"
   />
 {:else}
-  {contact?.given_name && contact?.surname
-    ? contact?.given_name.charAt(0) + contact?.surname.charAt(0)
-    : contact?.name
-    ? contact?.name.charAt(0)
-    : "?"}
+  <p>
+    {contact?.given_name && contact?.surname
+      ? contact?.given_name.charAt(0) + contact?.surname.charAt(0)
+      : contact?.name
+      ? contact?.name.charAt(0)
+      : "?"}
+  </p>
 {/if}

--- a/commons/src/components/ContactImage/ContactImage.svelte
+++ b/commons/src/components/ContactImage/ContactImage.svelte
@@ -1,6 +1,6 @@
-<svelte:options tag="nylas-contact-image" immutable={true} />
+<svelte:options tag="nylas-contact-image" />
 
-<script lang="ts">
+<script>
   import { onMount } from "svelte/internal";
   import { fetchContactImage } from "@commons";
   export let contact;
@@ -10,8 +10,10 @@
   let image;
 
   onMount(async (contact) => {
-    if (contact.picture_url) {
-      image = await fetchContactImage(contactQuery, contact.id);
+    if (contact?.picture_url) {
+      return (image = await fetchContactImage(contactQuery, contact.id));
+    } else {
+      return contact;
     }
   });
 </script>
@@ -23,9 +25,9 @@
     src="data:image/jpg;base64,{image}"
   />
 {:else}
-  {contact.given_name && contact.surname
-    ? contact.given_name.charAt(0) + contact.surname.charAt(0)
-    : contact.name
-    ? contact.name.charAt(0)
+  {contact?.given_name && contact?.surname
+    ? contact?.given_name.charAt(0) + contact?.surname.charAt(0)
+    : contact?.name
+    ? contact?.name.charAt(0)
     : "?"}
 {/if}

--- a/commons/src/components/ContactImage/ContactImage.svelte
+++ b/commons/src/components/ContactImage/ContactImage.svelte
@@ -4,15 +4,15 @@
   import { beforeUpdate } from "svelte/internal";
   import { fetchContactImage } from "@commons";
   export let contact;
-  export let contactQuery;
+  export let contact_query;
   export let height = "32px";
   export let width = "32px";
 
   let image;
 
   beforeUpdate(async () => {
-    if (contact?.picture_url) {
-      image = await fetchContactImage(contactQuery, contact?.id);
+    if (contact && contact.picture_url) {
+      image = await fetchContactImage(contact_query, contact.id);
     }
   });
 </script>
@@ -23,12 +23,12 @@
     style="height: {height}; width: {width}; border-radius: 50%;"
     src="data:image/jpg;base64,{image}"
   />
-{:else}
-  <p>
-    {contact?.given_name && contact?.surname
-      ? contact?.given_name.charAt(0) + contact?.surname.charAt(0)
-      : contact?.name
-      ? contact?.name.charAt(0)
+{:else if contact}
+  <p style="margin: 0;">
+    {contact.given_name && contact.surname
+      ? contact.given_name.charAt(0) + contact.surname.charAt(0)
+      : contact.name
+      ? contact.name.charAt(0)
       : "?"}
   </p>
 {/if}

--- a/commons/src/components/ContactImage/ContactImage.svelte
+++ b/commons/src/components/ContactImage/ContactImage.svelte
@@ -1,0 +1,31 @@
+<svelte:options tag="nylas-contact-image" immutable={true} />
+
+<script lang="ts">
+  import { onMount } from "svelte/internal";
+  import { fetchContactImage } from "@commons";
+  export let contact;
+  export let height = "32px";
+  export let width = "32px";
+
+  let image;
+
+  onMount(async (contact) => {
+    if (contact.picture_url) {
+      image = await fetchContactImage(contactQuery, contact.id);
+    }
+  });
+</script>
+
+{#if image}
+  <img
+    alt=""
+    style="height: {height}; width: {width}"
+    src="data:image/jpg;base64,{image}"
+  />
+{:else}
+  {contact.given_name && contact.surname
+    ? contact.given_name.charAt(0) + contact.surname.charAt(0)
+    : contact.name
+    ? contact.name.charAt(0)
+    : "?"}
+{/if}

--- a/commons/src/types/Nylas.ts
+++ b/commons/src/types/Nylas.ts
@@ -162,6 +162,7 @@ export interface EmailProperties extends Manifest {
   is_clean_conversation_enabled: boolean;
   thread_id: string;
   theme: "theme-1" | "theme-2" | "theme-3" | "theme-4" | "theme-5";
+  show_contact_avatar: boolean;
 }
 
 export interface ComposerProperties extends Manifest {

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -11,8 +11,9 @@
     fetchEmail,
     fetchContactImage,
     fetchContactsByQuery,
+    ContactStore,
   } from "@commons";
-  import type { ContactsQuery } from "@commons/types/Contacts";
+  import type { ContactSearchQuery } from "@commons/types/Contacts";
   import { get_current_component, onMount, tick } from "svelte/internal";
   import {
     buildInternalProps,
@@ -190,7 +191,7 @@
   }
 
   // #region get contact for ContactImage
-  let contactQuery: ContactsQuery;
+  let contactQuery: ContactSearchQuery;
   $: contactQuery = {
     component_id: id,
     access_token,
@@ -201,20 +202,14 @@
   */
   async function getContact(account) {
     contactQuery["query"] = `?email=${account.email}`;
-    try {
-      const contact = await fetchContactsByQuery(contactQuery)
-        .then((res) => {
-          if (res.length) {
-            return res[0];
-          } else {
-            return { name: account.name };
-          }
-        })
-        .catch((err) => ({ name: account.name }));
-
-      return contact;
-    } catch (err) {
-      return { account };
+    if (id) {
+      let contact = $ContactStore[JSON.stringify(contactQuery)];
+      if (!contact) {
+        contact = await ContactStore.addContact(contactQuery);
+      }
+      return contact[0] ? contact[0] : { name: account.name };
+    } else {
+      return { name: account.name };
     }
   }
   // #endregion get contact for ContactImage

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -47,7 +47,7 @@
   export let unread: boolean | null = null;
   export let you: Partial<Account> = {};
   export let is_starred: boolean;
-  export let show_contact_avatar: boolean = true;
+  export let show_contact_avatar: boolean;
 
   onMount(async () => {
     await tick(); // https://github.com/sveltejs/svelte/issues/2227
@@ -96,6 +96,11 @@
       "default",
     );
     is_starred = getPropertyValue(internalProps.is_starred, is_starred, false);
+    show_contact_avatar = getPropertyValue(
+      internalProps.show_contact_avatar,
+      show_contact_avatar,
+      true,
+    );
     if (activeThread && click_action === "mailbox") {
       // enables bulk starring action in mailbox to immediately reflect visually
       activeThread = activeThread;

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -63,7 +63,7 @@
 
   let contact;
   $: (async () => {
-    if (show_contact_avatar) {
+    if (!contact) {
       if (thread) {
         contact = await getContact(
           thread.messages[thread.messages.length - 1].from[
@@ -126,7 +126,7 @@
     show_contact_avatar = getPropertyValue(
       internalProps.show_contact_avatar,
       show_contact_avatar,
-      false, // setting this to false for now, so mailbox can load
+      true,
     );
     if (activeThread && click_action === "mailbox") {
       // enables bulk starring action in mailbox to immediately reflect visually

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -30,7 +30,7 @@
     Message,
     Account,
   } from "@commons/types/Nylas";
-  import ContactImage from "@commons/components/ContactImage/ContactImage.svelte";
+  import "@commons/components/ContactImage/ContactImage.svelte";
 
   let manifest: Partial<EmailProperties> = {};
 
@@ -63,21 +63,23 @@
 
   let contact;
   $: (async () => {
-    if (thread) {
-      contact = await getContact(
-        thread.messages[thread.messages.length - 1].from[
-          thread.messages[thread.messages.length - 1].from.length - 1
-        ],
-      );
-    } else if (activeThread) {
-      contact = await getContact(
-        activeThread.messages[activeThread.messages.length - 1].from[
-          activeThread.messages[activeThread.messages.length - 1].from.length -
-            1
-        ],
-      );
-    } else if (message) {
-      contact = await getContact(message.from[message.from.length - 1]);
+    if (show_contact_avatar) {
+      if (thread) {
+        contact = await getContact(
+          thread.messages[thread.messages.length - 1].from[
+            thread.messages[thread.messages.length - 1].from.length - 1
+          ],
+        );
+      } else if (activeThread) {
+        contact = await getContact(
+          activeThread.messages[activeThread.messages.length - 1].from[
+            activeThread.messages[activeThread.messages.length - 1].from
+              .length - 1
+          ],
+        );
+      } else if (message) {
+        contact = await getContact(message.from[message.from.length - 1]);
+      }
     }
   })();
 
@@ -191,8 +193,8 @@
   }
 
   // #region get contact for ContactImage
-  let contactQuery: ContactSearchQuery;
-  $: contactQuery = {
+  let contact_query: ContactSearchQuery;
+  $: contact_query = {
     component_id: id,
     access_token,
   };
@@ -201,11 +203,11 @@
     Fetches contact for ContactImage component
   */
   async function getContact(account) {
-    contactQuery["query"] = `?email=${account.email}`;
+    contact_query["query"] = `?email=${account.email}`;
     if (id) {
-      let contact = $ContactStore[JSON.stringify(contactQuery)];
+      let contact = $ContactStore[JSON.stringify(contact_query)];
       if (!contact) {
-        contact = await ContactStore.addContact(contactQuery);
+        contact = await ContactStore.addContact(contact_query);
       }
       return contact[0] ? contact[0] : { name: account.name };
     } else {
@@ -954,7 +956,7 @@
               <div class="from-message-count">
                 {#if show_contact_avatar}
                   <div class="default-avatar">
-                    <ContactImage {contactQuery} {contact} />
+                    <nylas-contact-image {contact_query} {contact} />
                   </div>
                 {/if}
                 <div class="from-participants">
@@ -1016,7 +1018,7 @@
       <div class="email-row expanded singular">
         {#if show_contact_avatar}
           <div class="default-avatar">
-            <ContactImage {contactQuery} {contact} />
+            <nylas-contact-image {contact_query} {contact} />
           </div>
         {/if}
         <header>{message.subject}</header>

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -11,6 +11,7 @@
     fetchEmail,
     fetchContactImage,
     fetchContactsByQuery,
+    ContactStore,
   } from "@commons";
   import type {
     // HydratedContact,
@@ -40,7 +41,7 @@
   $: dispatchEvent("manifestLoaded", manifest);
 
   export let id: string = "";
-  export let access_token: string = "HArPnlBL6mvLAru5Ng3S4erkpygxPr";
+  export let access_token: string = "";
   export let thread_id: string = "";
   // export let messages: Message[] = [];
   export let message_id: string = "";
@@ -55,6 +56,8 @@
   export let you: Partial<Account> = {};
   export let is_starred: boolean;
   export let show_contact_avatar: boolean;
+  $: console.log({ thread });
+  $: console.log({ message });
 
   onMount(async () => {
     await tick(); // https://github.com/sveltejs/svelte/issues/2227
@@ -176,12 +179,12 @@
   let contactQuery: ContactsQuery;
   $: contactQuery = {
     component_id: id,
-    access_token: "uvLCbxCbfAUuCzGzhoagDVTzNY1JgR",
+    access_token,
   };
 
-  // let contactQueryKey: string;
+  let contactQueryKey: string;
 
-  // $: contactQueryKey = JSON.stringify(contactQuery)
+  $: contactQueryKey = JSON.stringify(contactQuery);
   /*
   Fetches contact
   */
@@ -191,7 +194,7 @@
     console.log({ contactQuery });
     fetchContactsByQuery(contactQuery).then((results) => {
       if (results.length) {
-        // hydratedContacts = $ContactStore[queryKey];
+        return $ContactStore[queryKey];
         console.log({ results });
         return results;
       }
@@ -931,11 +934,14 @@
               {/if}
               <div class="from-message-count">
                 {#if show_contact_avatar}
-                  <img
-                    alt=""
-                    class="avatar"
-                    src="https://via.placeholder.com/32"
-                  />
+                  {#await getContact(activeThread.messages[activeThread.messages.length - 1].from[activeThread.messages[activeThread.messages.length - 1].from.length - 1].email) then contact}
+                    {JSON.stringify(contact)}
+                    <img
+                      alt=""
+                      class="avatar"
+                      src="https://via.placeholder.com/32"
+                    />
+                  {/await}
                 {/if}
                 <div class="from-participants">
                   {#if activeThread.messages.length >= 1 && activeThread.messages[activeThread.messages.length - 1].from.length}

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -124,7 +124,7 @@
     show_contact_avatar = getPropertyValue(
       internalProps.show_contact_avatar,
       show_contact_avatar,
-      true,
+      false, // setting this to false for now, so mailbox can load
     );
     if (activeThread && click_action === "mailbox") {
       // enables bulk starring action in mailbox to immediately reflect visually

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -418,6 +418,13 @@
     .email-row {
       background: var(--nylas-email-background, var(--grey-lightest));
       border: var(--nylas-email-border, #{$border-style});
+
+      img.avatar {
+        border-radius: 50%;
+        max-height: 32px;
+        max-width: 32px;
+        width: 100%;
+      }
       header {
         font-size: 1.2rem;
         font-weight: 700;
@@ -465,7 +472,6 @@
         }
 
         .thread-message-count {
-          margin-left: 1rem;
           color: var(--grey-light);
           font-size: 12px;
           align-self: center;
@@ -641,14 +647,16 @@
         cursor: pointer;
       }
       .from-message-count {
+        align-items: center;
         display: grid;
-        grid-template-columns: auto auto auto;
+        grid-template-columns: repeat(4, auto);
+        grid-gap: $spacing-m;
         justify-content: flex-start;
-        margin-right: $spacing-s;
+        max-width: 300px;
 
         .from-participants {
           overflow: hidden;
-          max-width: 120px;
+          max-width: 180px;
           white-space: nowrap;
           text-overflow: ellipsis;
         }
@@ -705,7 +713,7 @@
           display: grid;
           column-gap: $spacing-m;
           height: $collapsed-height;
-          grid-template-columns: 200px auto;
+          grid-template-columns: 300px auto;
           justify-content: initial;
 
           div.starred {
@@ -898,13 +906,6 @@
                 </div>
               {/each}
             {:else}
-              <!-- // if the email matches that of the last .from array, then get contact -->
-              <!-- {#await getContact("nylascypresstest@gmail.com") then contact} -->
-              <!-- {#await getContact(thread.messages[thread.messages.length-1].from[thread.messages.from.length-1].email) then contact} -->
-              <!-- {JSON.stringify(contact)} -->
-              <!-- {#await fetchContactImage(query, contact.id).then((image) => (contact.picture = image))}
-                {(contact.picture = "Loading")}-->
-              <!-- {/await} -->
               <span class="snippet">{thread.snippet}</span>
             {/if}
           </div>
@@ -929,6 +930,13 @@
                 </div>
               {/if}
               <div class="from-message-count">
+                {#if show_contact_avatar}
+                  <img
+                    alt=""
+                    class="avatar"
+                    src="https://via.placeholder.com/32"
+                  />
+                {/if}
                 <div class="from-participants">
                   {#if activeThread.messages.length >= 1 && activeThread.messages[activeThread.messages.length - 1].from.length}
                     <span class="from-sub-section"

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -13,11 +13,7 @@
     fetchContactsByQuery,
     ContactStore,
   } from "@commons";
-  import type {
-    // HydratedContact,
-    // Contact,
-    ContactsQuery,
-  } from "@commons/types/Contacts";
+  import type { ContactsQuery } from "@commons/types/Contacts";
   import { get_current_component, onMount, tick } from "svelte/internal";
   import {
     buildInternalProps,
@@ -189,8 +185,6 @@
   async function getContact(account) {
     contactQuery["query"] = `?email=${account.email}`;
 
-    let account_id = "";
-    let avatar;
     const contact = await fetchContactsByQuery(contactQuery)
       .then((res) => {
         if (res.length) {
@@ -199,8 +193,9 @@
           return { name: account.name };
         }
       })
-      .catch((err) => ({ name: account.name }));
+      .catch(() => ({ name: account.name }));
 
+    console.log({ contact });
     return contact;
   }
   // #endregion get contacts for avatars
@@ -947,7 +942,7 @@
                 {#if show_contact_avatar}
                   <div class="avatar default">
                     {#await getContact(activeThread.messages[activeThread.messages.length - 1].from[activeThread.messages[activeThread.messages.length - 1].from.length - 1]) then contact}
-                      <ContactImage {contact} />
+                      <ContactImage {contact} height="34px" width="34px" />
                     {/await}
                   </div>
                 {/if}
@@ -1012,6 +1007,9 @@
         <div class="individual-message expanded">
           <div class="message-head">
             <div class="message-from-to">
+              {#await getContact(message.from[0]) then contact}
+                <ContactImage {contact} height="34px" width="34px" />
+              {/await}
               <div class="message-from">
                 <span class="name"
                   >{message.from[0].name || message.from[0].email}</span

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -47,6 +47,7 @@
   export let unread: boolean | null = null;
   export let you: Partial<Account> = {};
   export let is_starred: boolean;
+  export let show_contact_avatar: boolean = true;
 
   onMount(async () => {
     await tick(); // https://github.com/sveltejs/svelte/issues/2227

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -9,7 +9,14 @@
     updateThread,
     fetchMessage,
     fetchEmail,
+    fetchContactImage,
+    fetchContactsByQuery,
   } from "@commons";
+  import type {
+    // HydratedContact,
+    // Contact,
+    ContactsQuery,
+  } from "@commons/types/Contacts";
   import { get_current_component, onMount, tick } from "svelte/internal";
   import {
     buildInternalProps,
@@ -33,7 +40,7 @@
   $: dispatchEvent("manifestLoaded", manifest);
 
   export let id: string = "";
-  export let access_token: string = "";
+  export let access_token: string = "HArPnlBL6mvLAru5Ng3S4erkpygxPr";
   export let thread_id: string = "";
   // export let messages: Message[] = [];
   export let message_id: string = "";
@@ -165,6 +172,33 @@
     );
   }
 
+  // #region get contacts for avatars
+  let contactQuery: ContactsQuery;
+  $: contactQuery = {
+    component_id: id,
+    access_token: "uvLCbxCbfAUuCzGzhoagDVTzNY1JgR",
+  };
+
+  // let contactQueryKey: string;
+
+  // $: contactQueryKey = JSON.stringify(contactQuery)
+  /*
+  Fetches contact
+  */
+  async function getContact(email) {
+    // status = "loading";
+    contactQuery["query"] = `?email=${email}`;
+    console.log({ contactQuery });
+    fetchContactsByQuery(contactQuery).then((results) => {
+      if (results.length) {
+        // hydratedContacts = $ContactStore[queryKey];
+        console.log({ results });
+        return results;
+      }
+      // status = "loaded";
+    });
+  }
+  // #endregion get contacts for avatars
   function saveActiveThread() {
     // if thread and if component_id (security)
     if (activeThread && query.component_id && thread_id) {
@@ -864,6 +898,13 @@
                 </div>
               {/each}
             {:else}
+              <!-- // if the email matches that of the last .from array, then get contact -->
+              <!-- {#await getContact("nylascypresstest@gmail.com") then contact} -->
+              <!-- {#await getContact(thread.messages[thread.messages.length-1].from[thread.messages.from.length-1].email) then contact} -->
+              <!-- {JSON.stringify(contact)} -->
+              <!-- {#await fetchContactImage(query, contact.id).then((image) => (contact.picture = image))}
+                {(contact.picture = "Loading")}-->
+              <!-- {/await} -->
               <span class="snippet">{thread.snippet}</span>
             {/if}
           </div>

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -11,7 +11,6 @@
     fetchEmail,
     fetchContactImage,
     fetchContactsByQuery,
-    ContactStore,
   } from "@commons";
   import type { ContactsQuery } from "@commons/types/Contacts";
   import { get_current_component, onMount, tick } from "svelte/internal";
@@ -211,7 +210,7 @@
             return { name: account.name };
           }
         })
-        .catch(() => ({ name: account.name }));
+        .catch((err) => ({ name: account.name }));
 
       return contact;
     } catch (err) {
@@ -440,20 +439,18 @@
       background: var(--nylas-email-background, var(--grey-lightest));
       border: var(--nylas-email-border, #{$border-style});
 
-      .avatar {
+      .default-avatar {
+        background: #002db4;
         border-radius: 50%;
+        color: #fff;
+        font-family: sans-serif;
+        font-size: 1rem;
+        font-weight: bold;
         height: 32px;
+        line-height: 35px;
+        text-align: center;
+        text-transform: uppercase;
         width: 32px;
-        &.default {
-          background: #002db4;
-          color: #fff;
-          font-size: 1rem;
-          font-weight: bold;
-          text-transform: uppercase;
-          font-family: sans-serif;
-          text-align: center;
-          line-height: 35px;
-        }
       }
       header {
         font-size: 1.2rem;
@@ -961,7 +958,7 @@
               {/if}
               <div class="from-message-count">
                 {#if show_contact_avatar}
-                  <div class="avatar default">
+                  <div class="default-avatar">
                     <ContactImage {contactQuery} {contact} />
                   </div>
                 {/if}
@@ -1022,14 +1019,14 @@
   {:else if message}
     {#if Object.keys(message).length > 0}
       <div class="email-row expanded singular">
+        {#if show_contact_avatar}
+          <div class="default-avatar">
+            <ContactImage {contactQuery} {contact} />
+          </div>
+        {/if}
         <header>{message.subject}</header>
         <div class="individual-message expanded">
           <div class="message-head">
-            {#if show_contact_avatar}
-              <div class="avatar default">
-                <ContactImage {contactQuery} {contact} />
-              </div>
-            {/if}
             <div class="message-from-to">
               <div class="message-from">
                 <span class="name"


### PR DESCRIPTION

# Changes

- Created a `ContactImage` component that accepts a contact object and will render either an image for the avatar or the contact's initials. If there is no contact, it will show the first letter of their name

- **Note:** Since there are significant design changes to the mailbox and email components, I am leaving that for another PR

## Before
<img width="816" alt="Screen Shot 2021-08-12 at 11 01 39 AM" src="https://user-images.githubusercontent.com/55773810/129220184-a0f6529d-b163-43b7-a8c1-22fa98228f30.png">

## After
<img width="821" alt="Screen Shot 2021-08-12 at 10 54 14 AM" src="https://user-images.githubusercontent.com/55773810/129219559-1680fd12-e1c1-4e2b-b656-78096341fc9f.png">

# Readiness checklist

- [ ] Cypress tests passing?
- [ ] New cypress tests added?
- [x] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
