### PR TITLE
Fix: The Publish GHA was failing due to the default access not being set to "public".

### DIFF
--- a/.github/workflows/build-test-publish.yaml
+++ b/.github/workflows/build-test-publish.yaml
@@ -177,7 +177,7 @@ jobs:
           verbose: true
 
   publish:
-    needs: [build, lint, test-unit, test-cypress]
+    needs: [build, lint, test-unit, type-check, test-cypress]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
@@ -200,6 +200,7 @@ jobs:
 
       - name: Configure Git CI User
         run: |
+          npm config set access public
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@users.noreply.github.com"
 


### PR DESCRIPTION
- Setting the default access for our components to "public".
- Fixed the the fact that publish step did not wait for the type-check step to complete.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
