### PR TITLE
Allow free-busy connection to be access_token based if provided

### DIFF
--- a/commons/src/connections/availability.ts
+++ b/commons/src/connections/availability.ts
@@ -18,6 +18,7 @@ export const fetchAvailability = async (
     getFetchConfig({
       method: "POST",
       component_id: query.component_id,
+      access_token: query.access_token,
       body: query.body,
     }),
   )

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -314,6 +314,7 @@
           new Date(new Date(endDay).setHours(end_hour)).getTime() / 1000,
       },
       component_id: id,
+      access_token: access_token,
     };
     // Free-Busy endpoint returns busy timeslots for given email_ids between start_time & end_time
     const consolidatedAvailabilityForGivenDay = await AvailabilityStore.getAvailability(


### PR DESCRIPTION
Realized we weren't handling this use-case for availability yet.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
