### PR TITLE
Make actionsBar actions_bar to follow snakecase convention for props

### DIFF
--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -40,7 +40,7 @@
   export let show_thread_checkbox: boolean = true;
   export let unread_status: "read" | "unread" | "default";
   export let header: string | null;
-  export let actionsBar: MailboxActions[];
+  export let actions_bar: MailboxActions[];
   export let onSelectThread: (event: MouseEvent, t: Thread) => void =
     onSelectOne;
 
@@ -126,7 +126,7 @@
       13,
     );
     header = getPropertyValue(internalProps.header, header, null);
-    actionsBar = getPropertyValue(internalProps.actionsBar, actionsBar, []);
+    actions_bar = getPropertyValue(internalProps.actions_bar, actions_bar, []);
   }
 
   // Reactive statement to continuously fetch all_threads
@@ -612,13 +612,13 @@
           <h1>{header}</h1>
         </header>
       {/if}
-      {#if actionsBar.length}
+      {#if actions_bar.length}
         <div
           role="toolbar"
           aria-label="Bulk actions"
           aria-controls="mailboxlist"
         >
-          {#if show_thread_checkbox && actionsBar.includes("selectall")}<div
+          {#if show_thread_checkbox && actions_bar.includes("selectall")}<div
               class="thread-checkbox"
             >
               {#each [areAllSelected ? "Deselect all" : "Select all"] as selectAllTitle}
@@ -633,7 +633,7 @@
             </div>
           {/if}
           {#if selectedThreads.size}
-            {#if actionsBar.includes("delete")}
+            {#if actions_bar.includes("delete")}
               <div class="delete">
                 <button
                   title="Delete selected email(s)"
@@ -642,7 +642,7 @@
                 >
               </div>
             {/if}
-            {#if show_star && actionsBar.includes("star")}
+            {#if show_star && actions_bar.includes("star")}
               <div class="starred">
                 {#each [areAllSelectedStarred ? "Unstar selected email(s)" : "Star selected email(s)"] as starAllTitle}
                   <button
@@ -655,7 +655,7 @@
                   />
                 {/each}
               </div>{/if}
-            {#if actionsBar.includes("unread")}
+            {#if actions_bar.includes("unread")}
               <div class="read-status">
                 {#if areAllSelectedUnread}
                   <button

--- a/components/mailbox/src/index.html
+++ b/components/mailbox/src/index.html
@@ -17,7 +17,7 @@
         // });
 
         // mailbox.all_threads = [thread1]; // enable to overwrite thread_id fetching
-        mailbox.actionsBar = ["selectall", "star", "delete", "unread"];
+        mailbox.actions_bar = ["selectall", "star", "delete", "unread"];
       });
     </script>
   </head>

--- a/components/mailbox/src/init.spec.js
+++ b/components/mailbox/src/init.spec.js
@@ -232,12 +232,12 @@ describe("MailBox  component", () => {
 
     it("Shows and hides Mailbox actions bar", () => {
       cy.get("nylas-mailbox").then(([el]) => {
-        el.actionsBar = ["selectall", "star", "delete", "unread"];
+        el.actions_bar = ["selectall", "star", "delete", "unread"];
         cy.get(el).find("div[role='toolbar']").should("exist");
       });
 
       cy.get("nylas-mailbox").then(([el]) => {
-        el.actionsBar = [];
+        el.actions_bar = [];
         cy.get(el).find("div[role='toolbar']").should("not.exist");
       });
     });
@@ -307,7 +307,7 @@ describe("MailBox  component", () => {
         .then((element) => {
           const component = element[0];
           component.all_threads = threads;
-          component.actionsBar = ["delete"];
+          component.actions_bar = ["delete"];
           cy.get("nylas-email").should("have.length", threads.length);
           cy.get(component)
             .find("div.checkbox-container")
@@ -330,7 +330,7 @@ describe("MailBox  component", () => {
         .then((element) => {
           const component = element[0];
           component.all_threads = threads;
-          component.actionsBar = ["selectall", "unread", "delete", "star"];
+          component.actions_bar = ["selectall", "unread", "delete", "star"];
           cy.get(component)
             .get("div[role='toolbar']")
             .find("div")
@@ -354,7 +354,7 @@ describe("MailBox  component", () => {
         .then((element) => {
           const component = element[0];
           component.all_threads = threads;
-          component.actionsBar = ["selectall", "unread"];
+          component.actions_bar = ["selectall", "unread"];
 
           cy.get(component)
             .find("div[role='toolbar']")
@@ -411,7 +411,7 @@ describe("MailBox  component", () => {
         .then((element) => {
           const component = element[0];
           component.all_threads = threads;
-          component.actionsBar = ["selectall", "star"];
+          component.actions_bar = ["selectall", "star"];
           cy.get(component)
             .find("div[role='toolbar']")
             .find("div.thread-checkbox")
@@ -467,7 +467,7 @@ describe("MailBox  component", () => {
         .then((element) => {
           const component = element[0];
           component.all_threads = threads;
-          component.actionsBar = ["selectall", "delete"];
+          component.actions_bar = ["selectall", "delete"];
           cy.get(component)
             .find("div[role='toolbar']")
             .find("div.thread-checkbox")


### PR DESCRIPTION
- All our component props follow snake_case convention. In order to align with that, changing `actionsBar` to `actions_bar`.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
