### PR TITLE
[Mailbox]: Added the ability to mark as read/unread for a single thread + bulk actions

### DIFF
--- a/commons/src/store/threads.ts
+++ b/commons/src/store/threads.ts
@@ -41,13 +41,12 @@ function initializeThreads() {
       queryKey: string,
       updatedThread: Conversation,
     ) => {
-      await updateThread(threadQuery, updatedThread).then((thread) => {
-        threadsMap[queryKey] = threadsMap[queryKey].map((_thread) => {
-          if (_thread.id === thread.id) {
-            _thread = Object.assign(_thread, thread);
-          }
-          return _thread;
-        });
+      const thread = await updateThread(threadQuery, updatedThread);
+      threadsMap[queryKey] = threadsMap[queryKey].map((initialThread) => {
+        if (initialThread.id === thread.id) {
+          initialThread = Object.assign(initialThread, thread);
+        }
+        return initialThread;
       });
     },
     getThread: async (query: ConversationQuery) => {

--- a/commons/src/store/threads.ts
+++ b/commons/src/store/threads.ts
@@ -1,10 +1,15 @@
 import { derived, writable } from "svelte/store";
-import { fetchThread, fetchThreads } from "../connections/threads";
+import {
+  fetchThread,
+  fetchThreads,
+  updateThread,
+} from "../connections/threads";
 import type {
   Thread,
   MailboxQuery,
   ConversationQuery,
   Message,
+  Conversation,
 } from "@commons/types/Nylas";
 
 function initializeThreads() {
@@ -31,7 +36,20 @@ function initializeThreads() {
       });
       return threadsMap[queryKey];
     },
-
+    updateThread: async (
+      threadQuery: ConversationQuery,
+      queryKey: string,
+      updatedThread: Conversation,
+    ) => {
+      await updateThread(threadQuery, updatedThread).then((thread) => {
+        threadsMap[queryKey] = threadsMap[queryKey].map((_thread) => {
+          if (_thread.id === thread.id) {
+            _thread = Object.assign(_thread, thread);
+          }
+          return _thread;
+        });
+      });
+    },
     getThread: async (query: ConversationQuery) => {
       const queryKey = JSON.stringify(query);
       if (!threadsMap[queryKey] && (query.component_id || query.access_token)) {

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -232,7 +232,7 @@
   function handleThread(e: MouseEvent | KeyboardEvent) {
     if (click_action === "default" || click_action === "mailbox") {
       //#region read/unread
-      if (activeThread && activeThread.unread) {
+      if (activeThread && activeThread.unread && click_action !== "mailbox") {
         activeThread.unread = false;
         saveActiveThread();
       }
@@ -690,7 +690,7 @@
         .from-participants {
           max-width: 220px;
           display: grid;
-          grid-template-columns: 1fr 40px;
+          grid-template-columns: 1fr 60px;
           .participants-name {
             .from-sub-section.second {
               display: none;
@@ -754,7 +754,7 @@
               .from-sub-section.second {
                 display: inline-block;
               }
-              &::after {
+              &.condensed::after {
                 content: ".";
                 position: absolute;
                 bottom: 0;
@@ -1021,7 +1021,13 @@
                   </div>
                 {/if}
                 <div class="from-participants">
-                  <div class="participants-name">
+                  <div
+                    class="participants-name"
+                    class:condensed={showSecondFromParticipant(
+                      activeThread.messages,
+                      activeThread.participants,
+                    )}
+                  >
                     {#if showFirstFromParticipant(activeThread.messages)}
                       <span class="from-sub-section"
                         >{activeThread.messages[
@@ -1040,21 +1046,23 @@
                     {/if}
                   </div>
                   <div class="participants-count">
-                    <!-- If it is mobile, we only show 1 participant (latest from message), hence -1 -->
-                    {#if activeThread.participants.length >= 2}
-                      <span class="show-on-mobile"
-                        >&nbsp; &plus; {activeThread.participants.length -
-                          MAX_MOBILE_PARTICIPANTS}</span
-                      >
-                    {/if}
-                    <!-- If it is desktop, we only show upto 2 participants (latest from message), hence -2. 
+                    {#if showSecondFromParticipant(activeThread.messages, activeThread.participants)}
+                      <!-- If it is mobile, we only show 1 participant (latest from message), hence -1 -->
+                      {#if activeThread.participants.length >= 2}
+                        <span class="show-on-mobile"
+                          >&nbsp;&plus;{activeThread.participants.length -
+                            MAX_MOBILE_PARTICIPANTS}</span
+                        >
+                      {/if}
+                      <!-- If it is desktop, we only show upto 2 participants (latest from message), hence -2. 
                     Note that this might not be exactly correct if the name of the first participant is too long 
                     and occupies entire width -->
-                    {#if activeThread.participants.length > 2}
-                      <span class="show-on-desktop"
-                        >&nbsp; &plus; {activeThread.participants.length -
-                          MAX_DESKTOP_PARTICIPANTS}</span
-                      >
+                      {#if activeThread.participants.length > 2}
+                        <span class="show-on-desktop"
+                          >&nbsp; &plus; {activeThread.participants.length -
+                            MAX_DESKTOP_PARTICIPANTS}</span
+                        >
+                      {/if}
                     {/if}
                   </div>
                 </div>

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -719,7 +719,6 @@
                   {you}
                   {show_star}
                   click_action="mailbox"
-                  show_contact_avatar={true}
                   unread={unreadThreads.has(thread)}
                   on:threadClicked={threadClicked}
                   on:messageClicked={messageClicked}


### PR DESCRIPTION
- Added `updateThread` method to threads store
- Calling  `updateThread` method through MailboxStore in Mailbox component for both single thread & multiple threads status change of read/unread 

## Side-effect:
- Fixed show participants logic
- Fixed show participants style where the plus sign & additional participants count occupied 2 lines 

# Readiness checklist

- [X] Cypress tests passing?

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
