### PR TITLE
[Mailbox]: Added the ability to mark as starred/ununstarred for a single thread + bulk actions

### DIFF
--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -212,7 +212,7 @@
       openedEmailData = event.detail.thread;
       if (event.detail.thread.unread) {
         event.detail.thread.unread = false;
-        updateThreadStatus(event.detail.thread);
+        await updateThreadStatus(event.detail.thread);
       }
       let message = await fetchIndividualMessage(
         event.detail.thread.messages[event.detail.thread.messages.length - 1],
@@ -256,7 +256,7 @@
       starredThreads.add(event.detail.thread);
       event.detail.thread.starred = true;
     }
-    updateThreadStatus(event.detail.thread);
+    await updateThreadStatus(event.detail.thread);
     return (starredThreads = starredThreads);
   }
 
@@ -272,19 +272,19 @@
     }
   }
 
-  function onStarSelected(event: MouseEvent) {
+  async function onStarSelected(event: MouseEvent) {
     dispatchEvent("onStarSelected", { event });
     if (areAllSelectedStarred) {
       selectedThreads.forEach((t) => {
         starredThreads.delete(t);
         t.starred = false;
-        updateThreadStatus(t);
+        await updateThreadStatus(t);
       });
     } else {
       selectedThreads.forEach((t) => {
         starredThreads.add(t);
         t.starred = true;
-        updateThreadStatus(t);
+        await updateThreadStatus(t);
       });
     }
     return (starredThreads = starredThreads);
@@ -309,19 +309,19 @@
     return true;
   }
 
-  function onChangeSelectedReadStatus(event: MouseEvent) {
+  async function onChangeSelectedReadStatus(event: MouseEvent) {
     dispatchEvent("onChangeSelectedReadStatus", { event });
     if (areAllSelectedUnread) {
       selectedThreads.forEach((t) => {
         unreadThreads.delete(t);
         t.unread = false;
-        updateThreadStatus(t);
+        await updateThreadStatus(t);
       });
     } else {
       selectedThreads.forEach((t) => {
         unreadThreads.add(t);
         t.unread = true;
-        updateThreadStatus(t);
+        await updateThreadStatus(t);
       });
     }
     return (unreadThreads = unreadThreads), (selectedThreads = selectedThreads);

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -272,16 +272,16 @@
     }
   }
 
-  async function onStarSelected(event: MouseEvent) {
+  function onStarSelected(event: MouseEvent) {
     dispatchEvent("onStarSelected", { event });
     if (areAllSelectedStarred) {
-      selectedThreads.forEach((t) => {
+      selectedThreads.forEach(async (t) => {
         starredThreads.delete(t);
         t.starred = false;
         await updateThreadStatus(t);
       });
     } else {
-      selectedThreads.forEach((t) => {
+      selectedThreads.forEach(async (t) => {
         starredThreads.add(t);
         t.starred = true;
         await updateThreadStatus(t);
@@ -309,16 +309,16 @@
     return true;
   }
 
-  async function onChangeSelectedReadStatus(event: MouseEvent) {
+  function onChangeSelectedReadStatus(event: MouseEvent) {
     dispatchEvent("onChangeSelectedReadStatus", { event });
     if (areAllSelectedUnread) {
-      selectedThreads.forEach((t) => {
+      selectedThreads.forEach(async (t) => {
         unreadThreads.delete(t);
         t.unread = false;
         await updateThreadStatus(t);
       });
     } else {
-      selectedThreads.forEach((t) => {
+      selectedThreads.forEach(async (t) => {
         unreadThreads.add(t);
         t.unread = true;
         await updateThreadStatus(t);

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -196,7 +196,7 @@
     }
   }
 
-  async function updateThreadUnreadStatus(updatedThread: any) {
+  async function updateThreadStatus(updatedThread: any) {
     if (id && updatedThread && updatedThread.id) {
       const threadQuery = {
         component_id: id,
@@ -205,13 +205,14 @@
       await MailboxStore.updateThread(threadQuery, queryKey, updatedThread);
     }
   }
+
   async function threadClicked(event: CustomEvent) {
     console.debug("thread clicked from mailbox", event.detail);
     if (event.detail.thread?.expanded) {
       openedEmailData = event.detail.thread;
       if (event.detail.thread.unread) {
         event.detail.thread.unread = false;
-        updateThreadUnreadStatus(event.detail.thread);
+        updateThreadStatus(event.detail.thread);
       }
       let message = await fetchIndividualMessage(
         event.detail.thread.messages[event.detail.thread.messages.length - 1],
@@ -250,9 +251,12 @@
   async function threadStarred(event: CustomEvent) {
     if (starredThreads.has(event.detail.thread)) {
       starredThreads.delete(event.detail.thread);
+      event.detail.thread.starred = false;
     } else {
       starredThreads.add(event.detail.thread);
+      event.detail.thread.starred = true;
     }
+    updateThreadStatus(event.detail.thread);
     return (starredThreads = starredThreads);
   }
 
@@ -274,11 +278,13 @@
       selectedThreads.forEach((t) => {
         starredThreads.delete(t);
         t.starred = false;
+        updateThreadStatus(t);
       });
     } else {
       selectedThreads.forEach((t) => {
         starredThreads.add(t);
         t.starred = true;
+        updateThreadStatus(t);
       });
     }
     return (starredThreads = starredThreads);
@@ -309,13 +315,13 @@
       selectedThreads.forEach((t) => {
         unreadThreads.delete(t);
         t.unread = false;
-        updateThreadUnreadStatus(t);
+        updateThreadStatus(t);
       });
     } else {
       selectedThreads.forEach((t) => {
         unreadThreads.add(t);
         t.unread = true;
-        updateThreadUnreadStatus(t);
+        updateThreadStatus(t);
       });
     }
     return (unreadThreads = unreadThreads), (selectedThreads = selectedThreads);


### PR DESCRIPTION
- Calling updateThread method through MailboxStore in Mailbox component for both single thread & multiple threads status change of star/unstar

Please note that this branch is based off of `https://github.com/nylas/components/pull/43` and will be merged into this, before merging to main.

# Readiness checklist

- [X] Cypress tests passing?

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
