### PR TITLE
[Mailbox]: Added bulk delete selected threads functionality

### DIFF
--- a/commons/src/connections/folders.ts
+++ b/commons/src/connections/folders.ts
@@ -1,0 +1,26 @@
+import { FolderStore } from "../store/folders";
+import {
+  getFetchConfig,
+  handleError,
+  handleResponse,
+  getMiddlewareApiUrl,
+} from "../methods/api";
+import type {
+  CommonQuery,
+  MiddlewareResponse,
+  Folder,
+} from "@commons/types/Nylas";
+
+export const fetchFolders = async (query: CommonQuery): Promise<Folder[]> => {
+  const queryString = `${getMiddlewareApiUrl(query.component_id)}/folders`;
+  return await fetch(queryString, getFetchConfig(query))
+    .then((response) => handleResponse<MiddlewareResponse<Folder[]>>(response))
+    .then((json) => {
+      FolderStore.addFolders({
+        queryKey: JSON.stringify(query),
+        data: json.response,
+      });
+      return json.response;
+    })
+    .catch((error) => handleError(query.component_id, error));
+};

--- a/commons/src/connections/labels.ts
+++ b/commons/src/connections/labels.ts
@@ -1,0 +1,26 @@
+import { LabelStore } from "../store/labels";
+import {
+  getFetchConfig,
+  handleError,
+  handleResponse,
+  getMiddlewareApiUrl,
+} from "../methods/api";
+import type {
+  CommonQuery,
+  MiddlewareResponse,
+  Label,
+} from "@commons/types/Nylas";
+
+export const fetchLabels = async (query: CommonQuery): Promise<Label[]> => {
+  const queryString = `${getMiddlewareApiUrl(query.component_id)}/labels`;
+  return await fetch(queryString, getFetchConfig(query))
+    .then((response) => handleResponse<MiddlewareResponse<Label[]>>(response))
+    .then((json) => {
+      LabelStore.addLabels({
+        queryKey: JSON.stringify(query),
+        data: json.response,
+      });
+      return json.response;
+    })
+    .catch((error) => handleError(query.component_id, error));
+};

--- a/commons/src/connections/threads.ts
+++ b/commons/src/connections/threads.ts
@@ -15,7 +15,7 @@ import type {
 export const fetchThreads = async (query: MailboxQuery): Promise<Thread[]> => {
   let queryString = `${getMiddlewareApiUrl(
     query.component_id,
-  )}/threads?view=expanded`;
+  )}/threads?view=expanded&not_in=trash`;
   if (query.query) {
     Object.entries(query.query).forEach(
       (param) => (queryString = queryString.concat(`&${param[0]}=${param[1]}`)),
@@ -65,6 +65,8 @@ export const updateThread = async (
       body: {
         unread: updatedThread.unread,
         starred: updatedThread.starred,
+        folder_id: updatedThread.folder_id,
+        label_ids: updatedThread.label_ids,
       },
     }),
   )

--- a/commons/src/enums/Nylas.ts
+++ b/commons/src/enums/Nylas.ts
@@ -1,0 +1,10 @@
+export enum AccountOrganizationUnit {
+  Label = "label",
+  Folder = "folder",
+}
+
+export enum AccountSyncState {
+  RUNNING = "running",
+  PARTIAL = "partial",
+  STOPPED = "stopped",
+}

--- a/commons/src/store/folders.ts
+++ b/commons/src/store/folders.ts
@@ -1,0 +1,38 @@
+import { writable } from "svelte/store";
+import type { CommonQuery, Folder, StoredFolders } from "@commons/types/Nylas";
+import { fetchFolders } from "@commons/connections/folders";
+
+function initializeFolders() {
+  const { subscribe, set, update } = writable<Record<string, Folder[]>>({});
+  const foldersMap: Record<string, Folder[]> = {};
+
+  return {
+    subscribe,
+    addFolders: (incomingFolders: StoredFolders) => {
+      update((folders) => {
+        folders[incomingFolders.queryKey] = incomingFolders.data;
+        return { ...folders };
+      });
+    },
+    getFolders: async (query: CommonQuery, forceRefresh = false) => {
+      const queryKey = JSON.stringify(query);
+      if (
+        (!foldersMap[queryKey] || forceRefresh) &&
+        (query.component_id || query.access_token)
+      ) {
+        foldersMap[queryKey] = (await fetchFolders(query)).map((folder) => {
+          folder.toString = () => folder.id;
+          return folder;
+        });
+      }
+      update((folders) => {
+        folders[queryKey] = foldersMap[queryKey];
+        return { ...folders };
+      });
+      return foldersMap[queryKey];
+    },
+    reset: () => set({}),
+  };
+}
+
+export const FolderStore = initializeFolders();

--- a/commons/src/store/labels.ts
+++ b/commons/src/store/labels.ts
@@ -1,0 +1,38 @@
+import { writable } from "svelte/store";
+import type { CommonQuery, Label, StoredLabels } from "@commons/types/Nylas";
+import { fetchLabels } from "@commons/connections/labels";
+
+function initializeLabels() {
+  const { subscribe, set, update } = writable<Record<string, Label[]>>({});
+  const labelsMap: Record<string, Label[]> = {};
+
+  return {
+    subscribe,
+    addLabels: (incomingLabels: StoredLabels) => {
+      update((labels) => {
+        labels[incomingLabels.queryKey] = incomingLabels.data;
+        return { ...labels };
+      });
+    },
+    getLabels: async (query: CommonQuery, forceRefresh = false) => {
+      const queryKey = JSON.stringify(query);
+      if (
+        (!labelsMap[queryKey] || forceRefresh) &&
+        (query.component_id || query.access_token)
+      ) {
+        labelsMap[queryKey] = (await fetchLabels(query)).map((label) => {
+          label.toString = () => label.id;
+          return label;
+        });
+      }
+      update((labels) => {
+        labels[queryKey] = labelsMap[queryKey];
+        return { ...labels };
+      });
+      return labelsMap[queryKey];
+    },
+    reset: () => set({}),
+  };
+}
+
+export const LabelStore = initializeLabels();

--- a/commons/src/types/Nylas.ts
+++ b/commons/src/types/Nylas.ts
@@ -1,5 +1,8 @@
 import type { HydratedContact } from "@commons/types/Contacts";
-
+import type {
+  AccountOrganizationUnit,
+  AccountSyncState,
+} from "@commons/enums/Nylas";
 export interface CommonQuery {
   component_id: string;
   access_token?: string;
@@ -206,19 +209,13 @@ export interface DayProperties extends Manifest {
   day: number;
   calendar_ids?: string;
 }
-export interface Folder {
-  object?: "folder";
-  display_name: string;
-  id: string;
-  name: string;
-}
 export interface Thread {
   account_id: string;
   draft_ids: string[];
   first_message_timestamp: number;
   has_attachments: boolean;
   id: string;
-  labels: unknown[];
+  labels?: Label[];
   last_message_received_timestamp: number;
   last_message_sent_timestamp: number;
   last_message_timestamp: number;
@@ -232,7 +229,9 @@ export interface Thread {
   unread: boolean;
   version: number;
   expanded?: boolean;
-  folders?: string[]; //to be changed to Folder[];
+  folders?: Folder[]; //to be changed to Folder[];
+  folder_id?: string;
+  label_ids?: string[];
 }
 export interface Conversation extends Thread {
   messages: Message[];
@@ -245,9 +244,9 @@ export interface Account {
   name?: string;
   linked_at: number;
   object: "account";
-  organization_unit: "label" | "folder";
+  organization_unit: AccountOrganizationUnit;
   provider: string;
-  sync_state: "running" | "partial" | "stopped";
+  sync_state: AccountSyncState;
 }
 
 export interface ComponentProperty<T> {
@@ -259,4 +258,30 @@ export interface ComponentProperty<T> {
   description?: string;
   type?: string;
   validation_message?: any;
+}
+
+export interface Label {
+  account_id: string;
+  display_name: string;
+  id: string;
+  name: string;
+  object: "label";
+}
+
+export interface StoredLabels {
+  queryKey: string;
+  data: Label[];
+}
+
+export interface Folder {
+  account_id: string;
+  display_name: string;
+  id: string;
+  name: string;
+  object: "folder";
+}
+
+export interface StoredFolders {
+  queryKey: string;
+  data: Folder[];
 }


### PR DESCRIPTION
# Background:
Currently, bulk deleting threads in the Mailbox component do not perform any network requests to actually delete threads. So upon refreshing, everything is reset. This PR addresses this.

# Implementation:
- Added `folders` & `labels` stores
- Added `folders` & `labels` connections to handle fetching folders & labels respectively
- On mounting Mailbox component, initializing labels & folders and reactively updating `trashLabelID` & `trashFolderID`
- Updated `onDeleteSelected` function to update the thread using thread store
- Updated `fetchThreads` endpoint to include an additional queryParameter `not_in=trash` 
- Added enums `AccountOrganizationUnit` & `AccountSyncState` to `enums/Nylas.ts`
- Added types `Label`, `StoredLabels`, `Folder`, `StoredFolders` to `types/Nylas.ts`

# Readiness checklist

- [X] Cypress tests passing?

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
