### PR TITLE
Clean Conversations in <nylas-email>

### DIFF
--- a/commons/src/types/Nylas.ts
+++ b/commons/src/types/Nylas.ts
@@ -163,6 +163,7 @@ export interface EmailProperties extends Manifest {
   thread_id: string;
   theme: "theme-1" | "theme-2" | "theme-3" | "theme-4" | "theme-5";
   show_contact_avatar: boolean;
+  clean_conversation: boolean;
 }
 
 export interface ComposerProperties extends Manifest {


### PR DESCRIPTION
- Allows the passing of prop `clean_conversation` to `<nylas-email>`
- if present, will hit the Nylas Neural API and return message.body cleaned up
- If not present, fails silently in the background

TODO:
- Add to `<nylas-mailbox>` as well
- add as an option for Nylas Dashboard-created components

## Demo:
https://user-images.githubusercontent.com/713991/130689245-af5ef4ff-d105-433f-9411-4f0ed5826abe.mov

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
