### PR TITLE
Removes lighthouse from our on push github actions

### DIFF
--- a/.github/workflows/build-test-publish.yaml
+++ b/.github/workflows/build-test-publish.yaml
@@ -6,7 +6,6 @@ on:
   pull_request:
     types: [opened, synchronize]
 env:
-  LIGHTHOUSE_CHECK_GITHUB_ACCESS_TOKEN: ${{secrets.LIGHTHOUSE_CHECK_GITHUB_ACCESS_TOKEN}}
   API_GATEWAY: ${{secrets.API_GATEWAY}}
   CYPRESS_RECORD_KEY: ${{secrets.CYPRESS_RECORD_KEY}}
   PERCY_TOKEN: ${{secrets.PERCY_TOKEN}}
@@ -144,37 +143,6 @@ jobs:
           start: npm run start:ci
           wait-on: http://localhost:8000
           wait-on-timeout: 30
-
-  test-lighthouse:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-    needs: [build, test-cypress]
-    if: github.ref != 'refs/heads/main'
-    steps:
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: "14"
-      - uses: actions/cache@v2
-        id: restore-build
-        with:
-          path: ./*
-          key: ${{ github.sha }}
-      - name: Run server
-        run: npm run start:ci &
-      - name: Run lighthouse
-        uses: foo-software/lighthouse-check-action@master
-        with:
-          accessToken: ${{ secrets.LIGHTHOUSE_CHECK_GITHUB_ACCESS_TOKEN }}
-          author: ${{ github.actor }}
-          branch: ${{ github.ref }}
-          outputDirectory: .
-          urls: "http://localhost:8000/components/agenda/src/index.html,http://localhost:8000/components/composer/src/index.html"
-          sha: ${{ github.sha }}
-          prCommentEnabled: true
-          prCommentSaveOld: false
-          verbose: true
 
   publish:
     needs: [build, lint, test-unit, type-check, test-cypress]


### PR DESCRIPTION
Removes the lighthouse check on Components PRs -- it was acting inconsistently, and we have better means of checking for all the attributes it checks for.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
