### PR TITLE
[Mailbox]: Added ability to filter emails using a keyword and/or query parameter

### DIFF
--- a/commons/src/connections/threads.ts
+++ b/commons/src/connections/threads.ts
@@ -35,25 +35,11 @@ export const fetchThreadsWithSearchKeyword = async (
 ): Promise<Thread[]> => {
   const queryString = `${getMiddlewareApiUrl(
     query.component_id,
-  )}/threads/search?q=${query.keyword_to_search}`;
+  )}/threads/search?q=${query.keyword_to_search}&view=expanded`;
   return await fetch(queryString, getFetchConfig(query))
     .then((response) => handleResponse<MiddlewareResponse<Thread[]>>(response))
     .then(async (json) => {
-      const expandedThreads: Thread[] = [];
-      if (json.response.length) {
-        for (const thread of json.response) {
-          expandedThreads.push(
-            await fetchThread({
-              component_id: query.component_id,
-              access_token: query.access_token,
-              thread_id: thread.id,
-            }),
-          );
-        }
-        return expandedThreads;
-      } else {
-        return json.response;
-      }
+      return json.response;
     })
     .catch((error) => handleError(query.component_id, error));
 };

--- a/commons/src/connections/threads.ts
+++ b/commons/src/connections/threads.ts
@@ -10,7 +10,7 @@ import type {
   ConversationQuery,
   Conversation,
   MiddlewareResponse,
-  ThreadsWithSearchKeywordQuery,
+  SearchResultThreadsQuery,
 } from "@commons/types/Nylas";
 
 export const fetchThreads = async (query: MailboxQuery): Promise<Thread[]> => {
@@ -30,8 +30,8 @@ export const fetchThreads = async (query: MailboxQuery): Promise<Thread[]> => {
     .catch((error) => handleError(query.component_id, error));
 };
 
-export const fetchThreadsWithSearchKeyword = async (
-  query: ThreadsWithSearchKeywordQuery,
+export const fetchSearchResultThreads = async (
+  query: SearchResultThreadsQuery,
 ): Promise<Thread[]> => {
   const queryString = `${getMiddlewareApiUrl(
     query.component_id,

--- a/commons/src/enums/Nylas.ts
+++ b/commons/src/enums/Nylas.ts
@@ -8,3 +8,16 @@ export enum AccountSyncState {
   PARTIAL = "partial",
   STOPPED = "stopped",
 }
+
+export enum EmailUnreadStatus {
+  READ = "read",
+  UNREAD = "unread",
+  DEFAULT = "default",
+}
+
+export enum MailboxActions {
+  SELECTALL = "selectall",
+  DELETE = "delete",
+  STAR = "star",
+  UNREAD = "unread",
+}

--- a/commons/src/store/threads.ts
+++ b/commons/src/store/threads.ts
@@ -2,7 +2,7 @@ import { derived, writable } from "svelte/store";
 import {
   fetchThread,
   fetchThreads,
-  fetchThreadsWithSearchKeyword,
+  fetchSearchResultThreads,
   updateThread,
 } from "../connections/threads";
 import type {
@@ -11,7 +11,7 @@ import type {
   ConversationQuery,
   Message,
   Conversation,
-  ThreadsWithSearchKeywordQuery,
+  SearchResultThreadsQuery,
 } from "@commons/types/Nylas";
 
 function initializeThreads() {
@@ -35,12 +35,10 @@ function initializeThreads() {
       });
       return threadsMap[queryKey];
     },
-    getThreadsWithSearchKeyword: async (
-      query: ThreadsWithSearchKeywordQuery,
-    ) => {
+    getThreadsWithSearchKeyword: async (query: SearchResultThreadsQuery) => {
       const queryKey = JSON.stringify(query);
       if (!threadsMap[queryKey] && (query.component_id || query.access_token)) {
-        threadsMap[queryKey] = (await fetchThreadsWithSearchKeyword(query)).map(
+        threadsMap[queryKey] = (await fetchSearchResultThreads(query)).map(
           (thread) => thread,
         );
       }

--- a/commons/src/store/threads.ts
+++ b/commons/src/store/threads.ts
@@ -2,6 +2,7 @@ import { derived, writable } from "svelte/store";
 import {
   fetchThread,
   fetchThreads,
+  fetchThreadsWithSearchKeyword,
   updateThread,
 } from "../connections/threads";
 import type {
@@ -10,6 +11,7 @@ import type {
   ConversationQuery,
   Message,
   Conversation,
+  ThreadsWithSearchKeywordQuery,
 } from "@commons/types/Nylas";
 
 function initializeThreads() {
@@ -26,6 +28,21 @@ function initializeThreads() {
         (query.component_id || query.access_token)
       ) {
         threadsMap[queryKey] = await fetchThreads(query);
+      }
+      update((threads) => {
+        threads[queryKey] = threadsMap[queryKey];
+        return { ...threads };
+      });
+      return threadsMap[queryKey];
+    },
+    getThreadsWithSearchKeyword: async (
+      query: ThreadsWithSearchKeywordQuery,
+    ) => {
+      const queryKey = JSON.stringify(query);
+      if (!threadsMap[queryKey] && (query.component_id || query.access_token)) {
+        threadsMap[queryKey] = (await fetchThreadsWithSearchKeyword(query)).map(
+          (thread) => thread,
+        );
       }
       update((threads) => {
         threads[queryKey] = threadsMap[queryKey];

--- a/commons/src/types/Nylas.ts
+++ b/commons/src/types/Nylas.ts
@@ -2,6 +2,8 @@ import type { HydratedContact } from "@commons/types/Contacts";
 import type {
   AccountOrganizationUnit,
   AccountSyncState,
+  EmailUnreadStatus,
+  MailboxActions,
 } from "@commons/enums/Nylas";
 export interface CommonQuery {
   component_id: string;
@@ -173,6 +175,23 @@ export interface EmailProperties extends Manifest {
   theme: "theme-1" | "theme-2" | "theme-3" | "theme-4" | "theme-5";
   show_contact_avatar: boolean;
   clean_conversation: boolean;
+  query_parameters: ThreadsQuery;
+  keyword_to_search: string;
+  show_star: boolean;
+  show_thread_checkbox: boolean;
+  unread_status: EmailUnreadStatus;
+}
+
+export interface MailboxProperties extends Manifest {
+  theme: "theme-1" | "theme-2" | "theme-3" | "theme-4" | "theme-5";
+  show_star: boolean;
+  show_thread_checkbox: boolean;
+  unread_status: EmailUnreadStatus;
+  actions_bar: MailboxActions[];
+  header: string;
+  keyword_to_search: string;
+  query_parameters: ThreadsQuery;
+  items_per_page: number;
 }
 
 export interface ComposerProperties extends Manifest {

--- a/commons/src/types/Nylas.ts
+++ b/commons/src/types/Nylas.ts
@@ -42,6 +42,12 @@ export interface ThreadsQuery {
   not_in?: string;
 }
 
+export interface ThreadsWithSearchKeywordQuery {
+  component_id: string;
+  access_token?: string;
+  keyword_to_search: string;
+}
+
 export interface MessagesQuery extends CommonQuery {
   received_before?: number;
   received_after?: number;

--- a/commons/src/types/Nylas.ts
+++ b/commons/src/types/Nylas.ts
@@ -42,7 +42,7 @@ export interface ThreadsQuery {
   not_in?: string;
 }
 
-export interface ThreadsWithSearchKeywordQuery {
+export interface SearchResultThreadsQuery {
   component_id: string;
   access_token?: string;
   keyword_to_search: string;

--- a/components/mailbox/README.md
+++ b/components/mailbox/README.md
@@ -1,5 +1,9 @@
 # Nylas Mailbox -- In Development
 
-Nylas Mailbox (`<nylas-mailbox>`) is part of the Nylas Components library that lets you build event/calendar applications in minutes. Use Nylas Mailbox with your Nylas account or by passing in your own JSON data.
+Nylas Mailbox (`<nylas-mailbox>`) is part of the Nylas Components library that lets you build email/mailbox applications in minutes. Use Nylas Mailbox with your Nylas account or by passing in your own JSON data.
 
 Nylas Mailbox is currently in active development. Want to contribute? [Find out how!](../../CONTRIBUTING.md)
+
+## Additonal documentation
+
+- [Allowed query parameters](https://developer.nylas.com/docs/api/#get/threads)

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -19,7 +19,6 @@
   import MarkReadIcon from "./assets/envelope-open-text.svg";
   import MarkUnreadIcon from "./assets/envelope.svg";
   import type {
-    EmailProperties,
     Thread,
     ThreadsQuery,
     MailboxQuery,
@@ -27,14 +26,16 @@
     Account,
     Label,
     Folder,
+    MailboxProperties,
   } from "@commons/types/Nylas";
-  import { AccountOrganizationUnit } from "@commons/enums/Nylas";
+  import {
+    AccountOrganizationUnit,
+    MailboxActions,
+  } from "@commons/enums/Nylas";
   import { LabelStore } from "@commons/store/labels";
   import { FolderStore } from "@commons/store/folders";
 
-  type MailboxActions = "selectall" | "delete" | "star" | "unread";
-
-  let manifest: Partial<EmailProperties> = {};
+  let manifest: Partial<MailboxProperties> = {};
 
   const dispatchEvent = getEventDispatcher(get_current_component());
   $: dispatchEvent("manifestLoaded", manifest);
@@ -48,7 +49,8 @@
   export let header: string | null;
   export let actions_bar: MailboxActions[];
   export let keyword_to_search: string | null;
-  export let query_parameters: ThreadsQuery | null;
+  export let query_parameters: ThreadsQuery | null; // Allowed query parameter list https://developer.nylas.com/docs/api/#get/threads
+  export let items_per_page: number = 13;
   export let onSelectThread: (event: MouseEvent, t: Thread) => void =
     onSelectOne;
 
@@ -60,7 +62,6 @@
   let paginatedThreads: Thread[] = [];
   let currentPage: number = 1;
   let lastPage: number = 1;
-  export let items_per_page: number = 13;
 
   onMount(async () => {
     await tick(); // https://github.com/sveltejs/svelte/issues/2227
@@ -70,7 +71,7 @@
 
     manifest = ((await $ManifestStore[
       JSON.stringify({ component_id: id, access_token })
-    ]) || {}) as EmailProperties;
+    ]) || {}) as MailboxProperties;
     internalProps = buildInternalProps(
       $$props,
       manifest,
@@ -134,7 +135,7 @@
     const rebuiltProps = buildInternalProps(
       $$props,
       manifest,
-    ) as Partial<SvelteAllProps>;
+    ) as Partial<MailboxProperties>;
     if (JSON.stringify(rebuiltProps) !== JSON.stringify(internalProps)) {
       internalProps = rebuiltProps;
     }
@@ -698,7 +699,7 @@
           aria-label="Bulk actions"
           aria-controls="mailboxlist"
         >
-          {#if show_thread_checkbox && actions_bar.includes("selectall")}<div
+          {#if show_thread_checkbox && actions_bar.includes(MailboxActions.SELECTALL)}<div
               class="thread-checkbox"
             >
               {#each [areAllSelected ? "Deselect all" : "Select all"] as selectAllTitle}
@@ -713,7 +714,7 @@
             </div>
           {/if}
           {#if selectedThreads.size}
-            {#if actions_bar.includes("delete")}
+            {#if actions_bar.includes(MailboxActions.DELETE)}
               <div class="delete">
                 <button
                   title="Delete selected email(s)"
@@ -722,7 +723,7 @@
                 >
               </div>
             {/if}
-            {#if show_star && actions_bar.includes("star")}
+            {#if show_star && actions_bar.includes(MailboxActions.STAR)}
               <div class="starred">
                 {#each [areAllSelectedStarred ? "Unstar selected email(s)" : "Star selected email(s)"] as starAllTitle}
                   <button
@@ -735,7 +736,7 @@
                   />
                 {/each}
               </div>{/if}
-            {#if actions_bar.includes("unread")}
+            {#if actions_bar.includes(MailboxActions.UNREAD)}
               <div class="read-status">
                 {#if areAllSelectedUnread}
                   <button

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -47,6 +47,7 @@
   export let unread_status: "read" | "unread" | "default";
   export let header: string | null;
   export let actions_bar: MailboxActions[];
+  export let keyword_to_search: string | null;
   export let onSelectThread: (event: MouseEvent, t: Thread) => void =
     onSelectOne;
 
@@ -88,6 +89,11 @@
 
     if (all_threads) {
       threads = all_threads as Thread[];
+    } else if (keyword_to_search) {
+      threads = await MailboxStore.getThreadsWithSearchKeyword({
+        ...accountOrganizationUnitQuery,
+        keyword_to_search,
+      });
     } else {
       threads = (await MailboxStore.getThreads(query)) || [];
     }
@@ -105,6 +111,9 @@
   });
 
   let inboxThreads: Thread[]; // threads currently in the inbox
+  $: if (threads) {
+    inboxThreads = threads;
+  }
   $: {
     if (!inboxThreads) {
       inboxThreads = threads;
@@ -248,7 +257,16 @@
   async function refreshClicked(event: MouseEvent) {
     dispatchEvent("refreshClicked", { event });
     if (!all_threads) {
-      threads = (await MailboxStore.getThreads(query, true)) || [];
+      keyword_to_search = "Hey";
+      if (keyword_to_search) {
+        threads = await MailboxStore.getThreadsWithSearchKeyword({
+          component_id: query.component_id,
+          access_token: query.access_token,
+          keyword_to_search,
+        });
+      } else {
+        threads = (await MailboxStore.getThreads(query, true)) || [];
+      }
     }
   }
 

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -48,6 +48,7 @@
   export let header: string | null;
   export let actions_bar: MailboxActions[];
   export let keyword_to_search: string | null;
+  export let query_parameters: ThreadsQuery | null;
   export let onSelectThread: (event: MouseEvent, t: Thread) => void =
     onSelectOne;
 
@@ -109,6 +110,8 @@
     lastPage = Math.ceil(inboxThreads?.length / items_per_page);
     hasComponentLoaded = true;
   });
+
+  $: queryParams = query_parameters || queryParams;
 
   let inboxThreads: Thread[]; // threads currently in the inbox
   $: if (threads) {

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -260,7 +260,6 @@
   async function refreshClicked(event: MouseEvent) {
     dispatchEvent("refreshClicked", { event });
     if (!all_threads) {
-      keyword_to_search = "Hey";
       if (keyword_to_search) {
         threads = await MailboxStore.getThreadsWithSearchKeyword({
           component_id: query.component_id,

--- a/components/mailbox/src/index.html
+++ b/components/mailbox/src/index.html
@@ -18,7 +18,10 @@
 
         // mailbox.all_threads = [thread1]; // enable to overwrite thread_id fetching
         mailbox.actions_bar = ["selectall", "star", "delete", "unread"];
-        mailbox.keyword_to_search = "Hi";
+        // mailbox.keyword_to_search = "Hi";
+        // mailbox.query_parameters = {
+        //   from: "tips@nylas.com"
+        // }
       });
     </script>
   </head>

--- a/components/mailbox/src/index.html
+++ b/components/mailbox/src/index.html
@@ -18,6 +18,7 @@
 
         // mailbox.all_threads = [thread1]; // enable to overwrite thread_id fetching
         mailbox.actions_bar = ["selectall", "star", "delete", "unread"];
+        mailbox.keyword_to_search = "Hi";
       });
     </script>
   </head>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cy:open": "cypress open",
     "cy:run": "cypress run",
     "dev": "lerna run --parallel dev --concurrency 8",
-    "dev:scoped": "concurrently 'live-server . --host=localhost --port=8000' 'lerna run --parallel dev --scope=@nylas/components-{mailbox}'",
+    "dev:scoped": "concurrently 'live-server . --host=localhost --port=8000' 'lerna run --parallel dev --scope=@nylas/components-{availability}'",
     "lerna": "lerna",
     "link": "lerna link convert",
     "lint": "eslint --ext .ts -f visualstudio .",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cy:open": "cypress open",
     "cy:run": "cypress run",
     "dev": "lerna run --parallel dev --concurrency 8",
-    "dev:scoped": "concurrently 'live-server . --host=localhost --port=8000' 'lerna run --parallel dev --scope=@nylas/components-{availability}'",
+    "dev:scoped": "concurrently 'live-server . --host=localhost --port=8000' 'lerna run --parallel dev --scope=@nylas/components-{mailbox}'",
     "lerna": "lerna",
     "link": "lerna link convert",
     "lint": "eslint --ext .ts -f visualstudio .",


### PR DESCRIPTION
# Implementation:
- Added props `keyword_to_search` & `query_parameters`
- `keyword_to_search` endpoint fetches threads using `/threads/search` endpoint
- Added `getThreadsWithSearchKeyword` method to threads store & `fetchThreadsWithSearchKeyword` endpoint to threads connection
- Added commented lines to index.html to show example of initializing these props

# Note:
- This PR/story required a change in cloud-core for `/thread/search` endpoint for supporting `view=exanpded` query param, which has been handled (merged & deployed).
- In the instance where both these props are being passed in, `keyword_to_search` prop will take precedence


# Readiness checklist
- [X] Cypress tests passing?

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
