### PR TITLE
Nylas Availability: End user can change date range

### DIFF
--- a/commons/src/types/Availability.ts
+++ b/commons/src/types/Availability.ts
@@ -18,6 +18,7 @@ export interface Manifest extends NylasManifest {
   show_as_week: boolean;
   show_weekends: boolean;
   attendees_to_show: number;
+  allow_date_change: boolean;
 }
 
 export interface Calendar {

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -139,7 +139,9 @@
       allow_date_change,
       true,
     );
+  }
 
+  $: {
     if (
       $$props.hasOwnProperty("start_date") &&
       $$props.start_date !== startDate

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -35,6 +35,8 @@
   import "@commons/components/ContactImage/ContactImage.svelte";
   import AvailableIcon from "./assets/available.svg";
   import UnavailableIcon from "./assets/unavailable.svg";
+  import BackIcon from "./assets/left-arrow.svg";
+  import NextIcon from "./assets/right-arrow.svg";
 
   //#region props
   export let id: string = "";
@@ -171,12 +173,14 @@
   let endDay: Date;
   let startDate: Date; // internally-settable start_date
 
-  $: dayRange = generateDayRange(
-    startDay,
-    show_as_week
-      ? timeDay.offset(startDay, 6)
-      : timeDay.offset(startDay, dates_to_show - 1),
-  );
+  $: dayRange =
+    (show_weekends || !show_weekends) &&
+    generateDayRange(
+      startDay, // TODO: weird just to get show_weekends passed in
+      show_as_week
+        ? timeDay.offset(startDay, 6)
+        : timeDay.offset(startDay, dates_to_show - 1),
+    );
 
   $: startDay = show_as_week
     ? timeWeek.floor(startDate)
@@ -371,7 +375,7 @@
           return timestamp.getDay() !== 6 && timestamp.getDay() !== 0;
         }
       });
-    if (!show_weekends) {
+    if (!show_as_week && !show_weekends) {
       if (range.length < dates_to_show) {
         if (reverse) {
           return generateDayRange(timeDay.offset(startDay, -1), endDay, true);
@@ -639,8 +643,21 @@
 
     &.dated {
       grid-template-rows: auto 1fr;
-      header {
+      gap: 1rem;
+      header.change-dates {
         grid-column: -1 / 1;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 1rem;
+
+        button {
+          background-color: #f7f7f8;
+          border: 1px solid #e3e8ee;
+          cursor: pointer;
+          &:hover {
+            background-color: #e3e8ee;
+          }
+        }
       }
     }
 
@@ -903,8 +920,12 @@
 >
   {#if allow_date_change}
     <header class="change-dates">
-      <button on:click={goToPreviousDate} aria-label="Previous date">‹</button>
-      <button on:click={goToNextDate} aria-label="Next date">›</button>
+      <button on:click={goToPreviousDate} aria-label="Previous date"
+        ><BackIcon style="height:32px;width:32px;" /></button
+      >
+      <button on:click={goToNextDate} aria-label="Next date"
+        ><NextIcon style="height:32px;width:32px;" /></button
+      >
     </header>
   {/if}
   {#if show_ticks}

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -165,18 +165,42 @@
   $: {
     if (datesToShow && !show_weekends) {
       let weekendDates = scaleTime()
-        .domain([startDay, timeDay.offset(start_date, datesToShow - 1)])
+        .domain([startDay, timeDay.offset(start_date, dates_to_show - 1)])
         .ticks(timeDay)
-        .filter((date) => {
-          console.log("DATE", date, timeSaturday(date), timeSunday(date));
-          return (
-            date.toString() === timeSaturday(date).toString() ||
-            date.toString() === timeSunday(date).toString()
-          );
-        });
-      datesToShow = dates_to_show + weekendDates.length;
+        .filter((date) => date.getDay() === 6 || date.getDay() === 0);
+
+      console.log(
+        "midway check",
+        start_date,
+        dates_to_show,
+        timeDay.offset(start_date, dates_to_show - 1),
+      );
+
+      // The above fails in the following case:
+      // dates_to_show = 1
+      // !show_weekends
+      // current date is a sturday
+      // It'll try to bump the date by 1, which is a Sunday. Let's bump it one further if that's the case.
+      if (weekendDates[weekendDates.length - 1]?.getDay() === 6) {
+        console.log("YES, the LAST DAY TO SHOW is SATURDAY");
+        datesToShow = datesToShow + weekendDates.length + 1;
+      } else {
+        console.log("NO, NOT THE CASE");
+        datesToShow = dates_to_show + weekendDates.length;
+      }
+      console.log(
+        "reactive calc",
+        dates_to_show,
+        datesToShow,
+        startDay,
+        weekendDates,
+      );
+    } else {
+      datesToShow = dates_to_show;
     }
   }
+
+  $: console.log("----", days[0].timestamp);
 
   // You can have as few as 1, and as many as 7, days shown
   // start_date dates_to_show gets overruled by show_as_week (always shows 5 or 7 dates that include your start_date instead)
@@ -578,15 +602,15 @@
 
   // #region Date Change
   function goToNextDate() {
-    console.log(
-      { start_date },
-      { startDay },
-      { datesToShow },
-      { show_as_week },
-    );
+    // console.log(
+    //   { start_date },
+    //   { startDay },
+    //   { datesToShow },
+    //   { show_as_week },
+    // );
     if (!show_as_week) {
       start_date = timeDay.offset(start_date, datesToShow);
-      console.log("so start date becomes", start_date);
+      // console.log("so start date becomes", start_date);
     }
   }
   function goToPreviousDate() {

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -169,12 +169,12 @@
         .ticks(timeDay)
         .filter((date) => date.getDay() === 6 || date.getDay() === 0);
 
-      console.log(
-        "midway check",
-        start_date,
-        dates_to_show,
-        timeDay.offset(start_date, dates_to_show - 1),
-      );
+      // console.log(
+      //   "midway check",
+      //   start_date,
+      //   dates_to_show,
+      //   timeDay.offset(start_date, dates_to_show - 1),
+      // );
 
       // The above fails in the following case:
       // dates_to_show = 1
@@ -183,16 +183,16 @@
       // It'll try to bump the date by 1, which is a Sunday. Let's bump it one further if that's the case.
       if (weekendDates[weekendDates.length - 1]?.getDay() === 6) {
         console.log("YES, the LAST DAY TO SHOW is SATURDAY");
-        datesToShow = datesToShow + weekendDates.length + 1;
+        datesToShow = dates_to_show + weekendDates.length + 1;
       } else {
         console.log("NO, NOT THE CASE");
         datesToShow = dates_to_show + weekendDates.length;
       }
       console.log(
         "reactive calc",
+        startDay,
         dates_to_show,
         datesToShow,
-        startDay,
         weekendDates,
       );
     } else {

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -139,6 +139,19 @@
       allow_date_change,
       true,
     );
+
+    if (
+      $$props.hasOwnProperty("start_date") &&
+      $$props.start_date !== startDate
+    ) {
+      startDate = getPropertyValue(
+        internalProps.start_date,
+        new Date(),
+        new Date(),
+      );
+    } else if (!startDate) {
+      startDate = start_date;
+    }
   }
 
   //#endregion mount and prop initialization
@@ -152,8 +165,9 @@
 
   // You can have as few as 1, and as many as 7, days shown
   // start_date and dates_to_show get overruled by show_as_week (always shows 5 or 7 dates that include your start_date instead)
-  let startDay: Date;
+  let startDay: Date; // the first day column shown; depends on show_as_week
   let endDay: Date;
+  let startDate: Date; // internally-settable start_date
 
   $: dayRange = generateDayRange(
     startDay,
@@ -163,8 +177,8 @@
   );
 
   $: startDay = show_as_week
-    ? timeWeek.floor(start_date)
-    : timeDay.floor(start_date);
+    ? timeWeek.floor(startDate)
+    : timeDay.floor(startDate);
 
   $: endDay = dayRange[dayRange.length - 1];
 
@@ -573,15 +587,21 @@
 
   // #region Date Change
   function goToNextDate() {
+    if ($$props.start_date) {
+      delete $$props.start_date;
+    }
     if (show_as_week) {
-      start_date = timeWeek.offset(endDay, 1);
+      startDate = timeWeek.offset(endDay, 1);
     } else {
-      start_date = timeDay.offset(endDay, 1);
+      startDate = timeDay.offset(endDay, 1);
     }
   }
   function goToPreviousDate() {
+    if ($$props.start_date) {
+      delete $$props.start_date;
+    }
     if (show_as_week) {
-      start_date = timeWeek.offset(startDay, -1);
+      startDate = timeWeek.offset(startDay, -1);
     } else {
       // Can't do something as simple as `start_date = timeDay.offset(startDay, -dates_to_show)` here;
       // broken case: !show_weekends, start_date = a monday, dates_to_show = 3; go backwards. You'll get fri-mon-tues, rather than wed-thu-fri.
@@ -591,7 +611,7 @@
         timeDay.offset(endDay, -dates_to_show),
         true,
       );
-      start_date = previousRange[0];
+      startDate = previousRange[0];
     }
   }
   // #endregion Date Change

--- a/components/availability/src/assets/left-arrow.svg
+++ b/components/availability/src/assets/left-arrow.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14 16L9.77612 12.0014L14 8" stroke="#6A7285" stroke-width="1.5" stroke-miterlimit="10"/>
+</svg>

--- a/components/availability/src/assets/right-arrow.svg
+++ b/components/availability/src/assets/right-arrow.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 8L14.2239 11.9986L10 16" stroke="#6A7285" stroke-width="1.5" stroke-miterlimit="10"/>
+</svg>

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -103,6 +103,7 @@
           .forEach((elem) => {
             elem.addEventListener("input", function (event) {
               component.allow_booking = JSON.parse(event.target.value);
+              component.start_date = new Date();
             });
           });
 

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -66,7 +66,12 @@
           },
         ];
 
-        component.calendars = calendars;
+        //component.calendars = calendars;
+        component.email_ids = [
+          "phil.r@nylas.com",
+          "aaron.d@nylas.com",
+          "hazik.a@nylas.com",
+        ];
 
         component.addEventListener("timeSlotChosen", (event) => {
           console.log(event.detail.timeSlots);
@@ -131,6 +136,14 @@
           .forEach((elem) => {
             elem.addEventListener("input", function (event) {
               component.show_weekends = JSON.parse(event.target.value);
+            });
+          });
+
+        document
+          .querySelectorAll('input[name="allow-date-change"]')
+          .forEach((elem) => {
+            elem.addEventListener("input", function (event) {
+              component.allow_date_change = JSON.parse(event.target.value);
             });
           });
       });
@@ -293,11 +306,23 @@
           Do not include weekends
         </label>
       </fieldset>
+
+      <fieldset>
+        <legend>Date Change</legend>
+        <label>
+          <input checked type="radio" name="allow-date-change" value="true" />
+          Allowed
+        </label>
+        <label>
+          <input type="radio" name="allow-date-change" value="false" />
+          Not allowed
+        </label>
+      </fieldset>
     </aside>
 
     <main>
       <div class="demo-box">
-        <nylas-availability id="demo-availability"></nylas-availability>
+        <nylas-availability id="phils-availability"></nylas-availability>
       </div>
     </main>
   </body>

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -103,7 +103,6 @@
           .forEach((elem) => {
             elem.addEventListener("input", function (event) {
               component.allow_booking = JSON.parse(event.target.value);
-              component.start_date = new Date();
             });
           });
 

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -187,7 +187,7 @@
           class="days"
           type="range"
           min="1"
-          max="7"
+          max="21"
           step="1"
           value="1"
         />

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -66,12 +66,7 @@
           },
         ];
 
-        //component.calendars = calendars;
-        component.email_ids = [
-          "phil.r@nylas.com",
-          "aaron.d@nylas.com",
-          "hazik.a@nylas.com",
-        ];
+        component.calendars = calendars;
 
         component.addEventListener("timeSlotChosen", (event) => {
           console.log(event.detail.timeSlots);
@@ -187,7 +182,7 @@
           class="days"
           type="range"
           min="1"
-          max="21"
+          max="7"
           step="1"
           value="1"
         />
@@ -306,7 +301,6 @@
           Do not include weekends
         </label>
       </fieldset>
-
       <fieldset>
         <legend>Date Change</legend>
         <label>
@@ -322,7 +316,7 @@
 
     <main>
       <div class="demo-box">
-        <nylas-availability id="phils-availability"></nylas-availability>
+        <nylas-availability id="demo-availability"></nylas-availability>
       </div>
     </main>
   </body>

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -500,7 +500,7 @@ describe("availability component", () => {
     });
   });
 
-  describe.only("date changes", () => {
+  describe("date changes", () => {
     it("Shows date change header by default", () => {
       cy.get("header.change-dates").should("exist");
     });
@@ -539,6 +539,77 @@ describe("availability component", () => {
               component.show_weekends = false;
               cy.get(".change-dates button:eq(1)").click();
               cy.get("header h2").contains(17);
+            });
+        });
+    });
+    it("Moves me from Monday to Friday on prev click when weekends are disallowed", () => {
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.allow_date_change = true;
+          component.show_weekends = true;
+          const monday = new Date("May 17 2021");
+          component.start_date = monday;
+          cy.get("header.change-dates").should("exist");
+          cy.get(".change-dates button:eq(0)").click();
+          cy.get("header h2")
+            .contains(16)
+            .then(() => {
+              component.show_weekends = false;
+              cy.get(".change-dates button:eq(0)").click();
+              cy.get("header h2").contains(14);
+            });
+        });
+    });
+    it("Moves multiple-shown-dates when weekends are disallowed", () => {
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.allow_date_change = true;
+          component.show_weekends = false;
+          component.dates_to_show = 3;
+          const monday = new Date("May 17 2021");
+          component.start_date = monday;
+          cy.get("header.change-dates").should("exist");
+          cy.get(".change-dates button:eq(1)").click();
+          cy.get(".day:eq(0) header h2").contains("Thursday");
+          cy.get(".day:eq(1) header h2").contains("Friday");
+          cy.get(".day:eq(2) header h2")
+            .contains("Monday")
+            .then(() => {
+              cy.get(".change-dates button:eq(1)").click();
+              cy.get(".day:eq(0) header h2").contains("Tuesday");
+              cy.get(".day:eq(1) header h2").contains("Wednesday");
+              cy.get(".day:eq(2) header h2").contains("Thursday");
+            });
+        });
+    });
+    it("Moves a full week on prev/next push", () => {
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.allow_date_change = true;
+          component.show_weekends = false;
+          component.show_as_week = true;
+          const monday = new Date("May 17 2021");
+          component.start_date = monday;
+          cy.get("header.change-dates").should("exist");
+          cy.get(".change-dates button:eq(1)").click();
+          cy.get(".day").should("have.length", 5);
+          cy.get(".day:eq(0) header h2").contains("Monday");
+          cy.get(".day:eq(0) header h2").contains("24");
+          cy.get(".day:eq(1) header h2").contains("Tuesday");
+          cy.get(".day:eq(4) header h2")
+            .contains("Friday")
+            .then(() => {
+              cy.get(".change-dates button:eq(0)").click();
+              cy.get(".change-dates button:eq(0)").click();
+              cy.get(".day:eq(0) header h2").contains("Monday");
+              cy.get(".day:eq(0) header h2").contains("10");
+              cy.get(".day:eq(4) header h2").contains("Friday");
             });
         });
     });

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -500,7 +500,7 @@ describe("availability component", () => {
     });
   });
 
-  describe("date changes", () => {
+  describe.only("date changes", () => {
     it("Shows date change header by default", () => {
       cy.get("header.change-dates").should("exist");
     });
@@ -520,6 +520,26 @@ describe("availability component", () => {
           const component = element[0];
           component.allow_date_change = true;
           cy.get("header.change-dates").should("exist");
+        });
+    });
+    it("Moves me from Friday to Monday when weekends are disallowed", () => {
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.allow_date_change = true;
+          component.show_weekends = true;
+          const friday = new Date("May 14 2021");
+          component.start_date = friday;
+          cy.get("header.change-dates").should("exist");
+          cy.get(".change-dates button:eq(1)").click();
+          cy.get("header h2")
+            .contains(15)
+            .then(() => {
+              component.show_weekends = false;
+              cy.get(".change-dates button:eq(1)").click();
+              cy.get("header h2").contains(17);
+            });
         });
     });
   });

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -500,7 +500,7 @@ describe("availability component", () => {
     });
   });
 
-  describe.only("date changes", () => {
+  describe("date changes", () => {
     it("Shows date change header by default", () => {
       cy.get("header.change-dates").should("exist");
     });

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -481,7 +481,7 @@ describe("availability component", () => {
           component.show_weekends = false;
           cy.get("div.day:eq(0) header h2").contains("Tuesday");
           cy.get("div.day:eq(4) header h2").contains("Monday");
-          cy.get("div.day:eq(5) header h2").should("not.exist");
+          cy.get("div.day:eq(5) header h2").contains("Tuesday");
         });
     });
 
@@ -491,6 +491,7 @@ describe("availability component", () => {
         .then((element) => {
           const component = element[0];
           component.start_date = new Date("2021-04-06 00:00");
+          component.dates_to_show = 7;
           component.show_as_week = true;
           component.show_weekends = false;
           cy.get("div.day:eq(0) header h2").contains("Monday");
@@ -537,7 +538,6 @@ describe("availability component", () => {
             .contains(15)
             .then(() => {
               component.show_weekends = false;
-              cy.get(".change-dates button:eq(1)").click();
               cy.get("header h2").contains(17);
             });
         });

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -499,4 +499,28 @@ describe("availability component", () => {
         });
     });
   });
+
+  describe.only("date changes", () => {
+    it("Shows date change header by default", () => {
+      cy.get("header.change-dates").should("exist");
+    });
+    it("Does not show date change header when date change is disallowed", () => {
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.allow_date_change = false;
+          cy.get("header.change-dates").should("not.exist");
+        });
+    });
+    it("Does not show date change header when date change is allowed", () => {
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.allow_date_change = true;
+          cy.get("header.change-dates").should("exist");
+        });
+    });
+  });
 });


### PR DESCRIPTION
- adds an `allow_date_change` prop that populates prev/next buttons if true
- In order to correctly skip weekends when going to next/prev dates, created a `generateDayRange()` function that recursively strips out weekend days.

There were several edge cases here; some of which I documented in code comments, that made this trickier than it needed to be. I could have set some restraints on usage, notably a max `dates_to_show` of 7, that would have made this easier, but I think the end-user experience would have suffered for it.

A notable decision that I think is the correct UX here:
If if it Sunday and you have `dates_to_show = 3`, thus you're showing Sun/Mon/Tues, and you hit "Next", what should happen?
A: you go to Mon/Tues/Weds (move forward 1 day)
B: you go to Weds/Thurs/Fri (move forward to the next series of days)

I've opted for `B`, but spent a bit of time debating it, and would love some feedback.