### PR TITLE
Nylas Availability: required_participants

### DIFF
--- a/commons/src/types/Availability.ts
+++ b/commons/src/types/Availability.ts
@@ -19,6 +19,7 @@ export interface Manifest extends NylasManifest {
   show_weekends: boolean;
   attendees_to_show: number;
   allow_date_change: boolean;
+  required_participants: string[];
 }
 
 export interface Calendar {

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -194,6 +194,12 @@
 
   $: endDay = dayRange[dayRange.length - 1];
 
+  const allRequiredParticipantsIncluded = (calendars: string[]) => {
+    return required_participants.every((participant) =>
+      calendars.includes(participant),
+    );
+  };
+
   // map over the ticks() of the time scale between your start day and end day
   // populate them with as many slots as your start_hour, end_hour, and slot_size dictate
   $: generateDaySlots = function (
@@ -257,11 +263,7 @@
           availability === AvailabilityStatus.PARTIAL &&
           required_participants.length
         ) {
-          if (
-            !required_participants.every((participant) =>
-              freeCalendars.includes(participant),
-            )
-          ) {
+          if (!allRequiredParticipantsIncluded(freeCalendars)) {
             availability = AvailabilityStatus.BUSY;
           }
         }
@@ -351,14 +353,14 @@
       .map((epoch) => {
         let status = "free";
         const numFreeCalendars = epoch[0].available_calendars.length;
+        const fewerCalendarsThanRatio =
+          numFreeCalendars !== allCalendars.length &&
+          numFreeCalendars < allCalendars.length * partial_bookable_ratio;
         if (
           numFreeCalendars === 0 ||
-          (numFreeCalendars !== allCalendars.length &&
-            numFreeCalendars < allCalendars.length * partial_bookable_ratio) ||
+          fewerCalendarsThanRatio ||
           (required_participants.length &&
-            !required_participants.every((participant) =>
-              epoch[0].available_calendars.includes(participant),
-            ))
+            !allRequiredParticipantsIncluded(epoch[0].available_calendars))
         ) {
           status = "busy";
         } else if (

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -267,12 +267,6 @@
           }
         }
 
-        // if (
-        //   required_participants.length && availability === AvailabilityStatus.PARTIAL
-        // ) {
-        //   availability = AvailabilityStatus.BUSY;
-        // }
-
         return {
           selectionStatus: SelectionStatus.UNSELECTED,
           calendar_id: calendarID,

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -56,6 +56,7 @@
   export let show_weekends: boolean;
   export let attendees_to_show: number;
   export let allow_date_change: boolean;
+  export let required_participants: string[];
   //#endregion props
 
   //#region mount and prop initialization
@@ -140,6 +141,11 @@
       internalProps.allow_date_change,
       allow_date_change,
       true,
+    );
+    required_participants = getPropertyValue(
+      internalProps.required_participants,
+      required_participants,
+      [],
     );
   }
 
@@ -247,6 +253,26 @@
           availability = AvailabilityStatus.BUSY;
         }
 
+        if (
+          availability === AvailabilityStatus.PARTIAL &&
+          required_participants.length &&
+          availability === AvailabilityStatus.PARTIAL
+        ) {
+          if (
+            !required_participants.every((participant) =>
+              freeCalendars.includes(participant),
+            )
+          ) {
+            availability = AvailabilityStatus.BUSY;
+          }
+        }
+
+        // if (
+        //   required_participants.length && availability === AvailabilityStatus.PARTIAL
+        // ) {
+        //   availability = AvailabilityStatus.BUSY;
+        // }
+
         return {
           selectionStatus: SelectionStatus.UNSELECTED,
           calendar_id: calendarID,
@@ -335,7 +361,11 @@
         if (
           numFreeCalendars === 0 ||
           (numFreeCalendars !== allCalendars.length &&
-            numFreeCalendars < allCalendars.length * partial_bookable_ratio)
+            numFreeCalendars < allCalendars.length * partial_bookable_ratio) ||
+          (required_participants.length &&
+            !required_participants.every((participant) =>
+              epoch[0].available_calendars.includes(participant),
+            ))
         ) {
           status = "busy";
         } else if (

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -255,8 +255,7 @@
 
         if (
           availability === AvailabilityStatus.PARTIAL &&
-          required_participants.length &&
-          availability === AvailabilityStatus.PARTIAL
+          required_participants.length
         ) {
           if (
             !required_participants.every((participant) =>

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -120,44 +120,44 @@ describe("availability component", () => {
   });
 
   describe("multiple availability sets", () => {
-    it("observes multiple availabilites", () => {
-      const calendars = [
-        {
-          email_address: "person@name.com",
-          availability: "busy",
-          timeslots: [
-            {
-              start_time: new Date(new Date().setHours(3, 0, 0, 0)),
-              end_time: new Date(new Date().setHours(6, 0, 0, 0)),
-            },
-            {
-              start_time: new Date(new Date().setHours(9, 0, 0, 0)),
-              end_time: new Date(new Date().setHours(15, 0, 0, 0)),
-            },
-          ],
-        },
-        {
-          email_address: "thelonious@nylas.com",
-          availability: "busy",
-          timeslots: [
-            {
-              start_time: new Date(new Date().setHours(4, 0, 0, 0)),
-              end_time: new Date(new Date().setHours(11, 0, 0, 0)),
-            },
-          ],
-        },
-        {
-          email_address: "booker@nylas.com",
-          availability: "busy",
-          timeslots: [
-            {
-              start_time: new Date(new Date().setHours(5, 30, 0, 0)),
-              end_time: new Date(new Date().setHours(16, 0, 0, 0)),
-            },
-          ],
-        },
-      ];
+    const calendars = [
+      {
+        email_address: "person@name.com",
+        availability: "busy",
+        timeslots: [
+          {
+            start_time: new Date(new Date().setHours(3, 0, 0, 0)),
+            end_time: new Date(new Date().setHours(6, 0, 0, 0)),
+          },
+          {
+            start_time: new Date(new Date().setHours(9, 0, 0, 0)),
+            end_time: new Date(new Date().setHours(15, 0, 0, 0)),
+          },
+        ],
+      },
+      {
+        email_address: "thelonious@nylas.com",
+        availability: "busy",
+        timeslots: [
+          {
+            start_time: new Date(new Date().setHours(4, 0, 0, 0)),
+            end_time: new Date(new Date().setHours(11, 0, 0, 0)),
+          },
+        ],
+      },
+      {
+        email_address: "booker@nylas.com",
+        availability: "busy",
+        timeslots: [
+          {
+            start_time: new Date(new Date().setHours(5, 30, 0, 0)),
+            end_time: new Date(new Date().setHours(16, 0, 0, 0)),
+          },
+        ],
+      },
+    ];
 
+    it("observes multiple availabilites", () => {
       cy.get("nylas-availability")
         .as("availability")
         .then((element) => {
@@ -167,6 +167,24 @@ describe("availability component", () => {
           cy.get(".slot.partial").should("have.length", 42);
           cy.get(".slot.busy").should("have.length", 10);
           cy.get(".slot.free").should("have.length", 44);
+        });
+    });
+
+    it("requires certain participants be present for booking", () => {
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.calendars = calendars;
+          cy.get(".slot[data-start-time='9/7/2021, 6:30:00 AM']")
+            .should("have.class", "partial")
+            .then(() => {
+              component.required_participants = [calendars[1].email_address];
+              cy.get(".slot[data-start-time='9/7/2021, 6:30:00 AM']").should(
+                "have.class",
+                "busy",
+              );
+            });
         });
     });
   });

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -122,7 +122,7 @@ describe("availability component", () => {
   describe("multiple availability sets", () => {
     const calendars = [
       {
-        email_address: "person@name.com",
+        emailAddress: "person@name.com",
         availability: "busy",
         timeslots: [
           {
@@ -136,7 +136,7 @@ describe("availability component", () => {
         ],
       },
       {
-        email_address: "thelonious@nylas.com",
+        emailAddress: "thelonious@nylas.com",
         availability: "busy",
         timeslots: [
           {
@@ -146,7 +146,7 @@ describe("availability component", () => {
         ],
       },
       {
-        email_address: "booker@nylas.com",
+        emailAddress: "booker@nylas.com",
         availability: "busy",
         timeslots: [
           {
@@ -176,14 +176,15 @@ describe("availability component", () => {
         .then((element) => {
           const component = element[0];
           component.calendars = calendars;
-          cy.get(".slot[data-start-time='9/7/2021, 6:30:00 AM']")
+          cy.get(
+            `.slot[data-start-time='${new Date().toLocaleDateString()}, 6:30:00 AM']`,
+          )
             .should("have.class", "partial")
             .then(() => {
-              component.required_participants = [calendars[1].email_address];
-              cy.get(".slot[data-start-time='9/7/2021, 6:30:00 AM']").should(
-                "have.class",
-                "busy",
-              );
+              component.required_participants = [calendars[1].emailAddress];
+              cy.get(
+                `.slot[data-start-time='${new Date().toLocaleDateString()}, 6:30:00 AM']`,
+              ).should("have.class", "busy");
             });
         });
     });


### PR DESCRIPTION
- Adds a `required_participants` prop; an array of email address strings
- If present, will mark any otherwise-partial timeslots / epochs as "busy" if all members of the array aren't present.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
