### PR TITLE
[Email][ContactImage]: Added logic to cache contact pictures in ContactImage component

### DIFF
--- a/commons/src/components/ContactImage/ContactImage.svelte
+++ b/commons/src/components/ContactImage/ContactImage.svelte
@@ -2,8 +2,7 @@
 
 <script>
   import { beforeUpdate } from "svelte/internal";
-  import { fetchContactImage } from "@commons";
-
+  import { ContactAvatarStore } from "@commons";
   export let contact;
   export let contact_query;
   export let height = "32px";
@@ -13,7 +12,10 @@
 
   beforeUpdate(async () => {
     if (contact && contact.picture_url) {
-      image = await fetchContactImage(contact_query, contact.id);
+      image = await ContactAvatarStore.getContactAvatar(
+        contact_query,
+        contact.id,
+      );
     }
   });
 </script>

--- a/commons/src/index.ts
+++ b/commons/src/index.ts
@@ -23,6 +23,7 @@ export {
 export { AvailabilityStore } from "./store/availability";
 export { CalendarStore } from "./store/calendars";
 export { ContactStore } from "./store/contacts";
+export { ContactAvatarStore } from "./store/contact-avatar";
 export { ConversationStore } from "./store/conversations";
 export { EventStore } from "./store/events";
 export { MailboxStore, Threads } from "./store/threads";

--- a/commons/src/store/contact-avatar.ts
+++ b/commons/src/store/contact-avatar.ts
@@ -1,0 +1,30 @@
+import { writable } from "svelte/store";
+import { fetchContactImage } from "@commons";
+import type { ContactsQuery } from "@commons/types/Contacts";
+
+const contactAvatarMap: Record<string, string> = {};
+
+function initializeContactAvatars() {
+  const { subscribe, set } = writable<Record<string, string>>({});
+  return {
+    subscribe,
+    getContactAvatar: async (
+      query: ContactsQuery,
+      contact_id: string,
+      refresh = false,
+    ) => {
+      if (!contactAvatarMap[contact_id] || refresh) {
+        const avatar = await fetchContactImage(query, contact_id)
+          .then((res) => res)
+          .catch(() => "");
+        if (avatar) {
+          contactAvatarMap[contact_id] = avatar;
+        }
+      }
+      return contactAvatarMap[contact_id];
+    },
+    reset: () => set({}),
+  };
+}
+
+export const ContactAvatarStore = initializeContactAvatars();


### PR DESCRIPTION
# Implementation:
- Added `ContactAvatarStore` which handles storing and fetching contact pictures
- Using this store to get the contact image in ContactImage component (`nylas-contact-image`)


# Readiness checklist
- [X] Cypress tests passing?

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
