### PR TITLE
[ContactList]: Changed default value of sort_by prop to name

### DIFF
--- a/components/agenda/README.md
+++ b/components/agenda/README.md
@@ -40,7 +40,7 @@ For both installation options, in the body of your page, you can instantiate the
 
 ## Using It in Your App
 
-All Nylas components have two ways of dislaying data to your end-user:
+All Nylas components have two ways of displaying data to your end-user:
 
 1. [Fetching data directly from Nylas](#fetching-data-directly-from-nylas)
 2. [Passing in your own data](#passing-in-your-own-data)

--- a/components/contact-list/src/ContactList.svelte
+++ b/components/contact-list/src/ContactList.svelte
@@ -101,7 +101,7 @@
       click_action,
       "email",
     );
-    sort_by = getPropertyValue(internalProps.sort_by, sort_by, "last_emailed");
+    sort_by = getPropertyValue(internalProps.sort_by, sort_by, "name");
     show_names = getPropertyValue(internalProps.show_names, show_names, true);
     contacts_to_load = getPropertyValue(
       internalProps.contacts_to_load,

--- a/components/contact-list/src/init.spec.js
+++ b/components/contact-list/src/init.spec.js
@@ -176,4 +176,36 @@ describe("Optional Prop Handling", () => {
       .find("[data-cy=default_set_by_user]")
       .should("exist");
   });
+
+  it("Component loads and works for sort_by=last_emailed when account has email & contact scopes", () => {
+    cy.loadContacts();
+    cy.visit("/components/contact-list/src/index.html");
+    cy.get("nylas-contact-list").should("exist");
+    cy.get("nylas-contact-list").then((element) => {
+      const component = element[0];
+      component.sort_by = "last_emailed";
+    });
+    cy.get("nylas-contact-list")
+      .find(".contact")
+      .should("have.length.greaterThan", 1);
+  });
+});
+
+describe("ContactList component with contact scope (only) should work by default", () => {
+  beforeEach(() => {
+    cy.loadContacts();
+    cy.visit("/components/contact-list/src/index.html");
+    cy.get("nylas-contact-list").should("exist");
+    cy.get("nylas-contact-list").then((element) => {
+      const component = element[0];
+      component.id = "75f0cbc5-6b15-4bf1-894e-11eeb198cc34";
+      component.sort_by = "name";
+    });
+  });
+
+  it("Component loads and works for sort_by=name when account has only contact scope", () => {
+    cy.get("nylas-contact-list")
+      .find(".contact")
+      .should("have.length.greaterThan", 1);
+  });
 });


### PR DESCRIPTION
ContactList prop `sort_by` takes 2 possible value `name` & `last_emailed`.`last_emailed` requires that the account associated with the component have both contact & email scopes whereas `name` requires only contact scope. 

Since, there could be users who essentially don't want to sort by last emailed, requiring additional email scope does not make sense. So, changing the default value to `name`

NOTE: 
This change is also associated with a change in the middleware.
- Middleware update: https://github.com/nylas/web-components-middleware/pull/121

# Readiness checklist
- [X] Cypress tests passing?

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
