### PR TITLE
Unwrapped availability component from scheduler

### DIFF
--- a/commons/src/types/Scheduler.ts
+++ b/commons/src/types/Scheduler.ts
@@ -1,8 +1,12 @@
-import type { Manifest as AvailabilityManifest } from "@commons/types/Availability";
+import type {
+  Manifest as AvailabilityManifest,
+  TimeSlot,
+} from "@commons/types/Availability";
 
 export interface Manifest extends AvailabilityManifest {
   availability_id?: string;
   booking_label?: string;
   event_title?: string;
   event_description?: string;
+  slots_to_book?: TimeSlot[];
 }

--- a/components/scheduler/src/index.html
+++ b/components/scheduler/src/index.html
@@ -7,8 +7,17 @@
     <script src="../index.js"></script>
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        const component = document.querySelector("nylas-scheduler");
-        component.email_ids = ["nylascypresstest@gmail.com"];
+        const availability = document.querySelector("nylas-availability");
+        const scheduler = document.querySelector("nylas-scheduler");
+
+        availability.email_ids = ["nylascypresstest@gmail.com"];
+        availability.addEventListener("timeSlotChosen", (event) => {
+          scheduler.slots_to_book = event.detail.timeSlots;
+        });
+
+        scheduler.addEventListener("bookedEvents", () => {
+          scheduler.slots_to_book = [];
+        });
       });
     </script>
     <style>
@@ -22,15 +31,24 @@
         margin-left: 10vw;
         height: 80vh;
         margin-top: 10vh;
+
+        display: grid;
+        grid-template-columns: 2fr 1fr;
+        gap: 1rem;
       }
     </style>
   </head>
+
   <body>
     <main>
-      <nylas-scheduler
-        availability_id="demo-availability"
-        id="demo-scheduler"
-      ></nylas-scheduler>
+      <nylas-availability
+        show_as_week="true"
+        allow_booking="true"
+        max_bookable_slots="4"
+        id="demo-availability"
+      >
+      </nylas-availability>
+      <nylas-scheduler id="demo-scheduler"></nylas-scheduler>
     </main>
   </body>
 </html>


### PR DESCRIPTION
Recommended implementation of Availability with Scheduler now is to use Availability's emitted `"timeSlotChosen"` event to update the Scheduler's `slots_to_book` property. The Scheduler now emits a `"bookedEvents"` event once the booking has been completed that can be used to reset the state if necessary.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
