### PR TITLE
Prototype: scheduler reading from schedule editor manifest

### DIFF
--- a/commons/src/store/manifest.ts
+++ b/commons/src/store/manifest.ts
@@ -5,30 +5,71 @@ import type { Manifest } from "@commons/types/Nylas";
 type ManifestAccessor = { component_id: string; access_token?: string };
 type ManifestStore = Record<string, Promise<Manifest>>;
 
-function initialize(): Writable<ManifestStore> {
-  const get = (
-    target: ManifestStore,
-    key: string,
-  ): Promise<Manifest> | void => {
-    const accessor: ManifestAccessor = JSON.parse(key);
+function initialize() {
+  const { subscribe, update, set } = writable(new Proxy<ManifestStore>({}, {}));
+  let manifestMap: ManifestStore = {};
 
-    if (!accessor.component_id) return;
+  return {
+    subscribe,
+    get: (key: string): Promise<Manifest> | void => {
+      const accessor: ManifestAccessor = JSON.parse(key);
 
-    if (!target[key]) {
-      const fetchPromise = fetchManifest(
-        accessor.component_id,
-        accessor.access_token,
-      );
-      store.update((store) => ({
-        ...store,
-        [key]: fetchPromise,
-      }));
-      target[key] = fetchPromise;
-    }
-    return target[key];
+      if (!accessor.component_id) return;
+
+      if (!manifestMap[key]) {
+        const fetchPromise = fetchManifest(
+          accessor.component_id,
+          accessor.access_token,
+        );
+        update((store) => ({
+          ...store,
+          [key]: fetchPromise,
+        }));
+        manifestMap[key] = fetchPromise;
+      }
+      return manifestMap[key];
+    },
+    getAndMerge: async (key: string, ...otherManifestIds: string[]) => {
+      const accessor: ManifestAccessor = JSON.parse(key);
+
+      if (!accessor.component_id) return;
+
+      // TODO - handle case where manifest was already loaded using `get` so it isn't merged yet
+      if (!manifestMap[key]) {
+        const fetchPromise = fetchManifest(
+          accessor.component_id,
+          accessor.access_token,
+        ).then((manifest) => {
+          const filteredIds = otherManifestIds.filter((id) => !!id);
+          if (filteredIds.length === 0) {
+            return manifest;
+          }
+
+          const mergeManifestPromises = [];
+          for (const manifestId of filteredIds) {
+            mergeManifestPromises.push(
+              fetchManifest(manifestId, accessor.access_token),
+            );
+          }
+
+          return Promise.all(mergeManifestPromises).then((manifestsToMerge) => {
+            // TODO - not sure if this is exactly how we want to merge
+            return Object.assign({}, manifest, ...manifestsToMerge);
+          });
+        });
+        update((store) => ({
+          ...store,
+          [key]: fetchPromise,
+        }));
+        manifestMap[key] = fetchPromise;
+      }
+      return manifestMap[key];
+    },
+    reset: () => {
+      manifestMap = {};
+      set({});
+    },
   };
-  const store = writable(new Proxy<ManifestStore>({}, { get }));
-  return store;
 }
 
 export const ManifestStore = initialize();

--- a/commons/src/store/manifest.ts
+++ b/commons/src/store/manifest.ts
@@ -5,7 +5,7 @@ import type { Manifest } from "@commons/types/Nylas";
 type ManifestAccessor = {
   component_id: string;
   access_token?: string;
-  merge_ids?: [];
+  external_manifest_ids?: [];
 };
 type ManifestStore = Record<string, Promise<Manifest>>;
 
@@ -23,11 +23,11 @@ function initialize(): Writable<ManifestStore> {
         accessor.component_id,
         accessor.access_token,
       ).then((manifest) => {
-        if (!accessor.merge_ids) {
+        if (!accessor.external_manifest_ids) {
           return manifest;
         }
 
-        const filteredIds = accessor.merge_ids.filter((id) => !!id);
+        const filteredIds = accessor.external_manifest_ids.filter((id) => !!id);
         if (filteredIds.length === 0) {
           return manifest;
         }

--- a/commons/src/types/Scheduler.ts
+++ b/commons/src/types/Scheduler.ts
@@ -5,6 +5,7 @@ import type {
 
 export interface Manifest extends AvailabilityManifest {
   availability_id?: string;
+  editor_id?: string;
   booking_label?: string;
   event_title?: string;
   event_description?: string;

--- a/components/scheduler/src/Scheduler.svelte
+++ b/components/scheduler/src/Scheduler.svelte
@@ -41,8 +41,12 @@
 
   onMount(async () => {
     await tick();
-    const storeKey = JSON.stringify({ component_id: id, access_token });
-    manifest = (await ManifestStore.getAndMerge(storeKey, editor_id)) || {};
+    const storeKey = JSON.stringify({
+      component_id: id,
+      access_token,
+      merge_ids: [editor_id],
+    });
+    manifest = (await $ManifestStore[storeKey]) || {};
 
     // if (editor_id) {
     //   editorManifest = await fetchManifest(editor_id);

--- a/components/scheduler/src/Scheduler.svelte
+++ b/components/scheduler/src/Scheduler.svelte
@@ -1,6 +1,12 @@
 <svelte:options tag="nylas-scheduler" />
 
 <script lang="ts">
+  import {
+    ManifestStore,
+    EventStore,
+    AvailabilityStore,
+    fetchManifest,
+  } from "../../../commons/src";
   import { createEvent } from "@commons/connections/events";
   import { get_current_component } from "svelte/internal";
   import {
@@ -8,17 +14,19 @@
     getEventDispatcher,
     getPropertyValue,
   } from "@commons/methods/component";
+
+  import type { Manifest as EditorManifest } from "@commons/types/ScheduleEditor";
+  import type { Manifest } from "@commons/types/Scheduler";
   import type { TimeSlot } from "@commons/types/Availability";
   import type { EventQuery, TimespanEvent } from "@commons/types/Events";
-  import type { Manifest } from "@commons/types/Scheduler";
   import { onMount, tick } from "svelte";
-  import { AvailabilityStore, ManifestStore } from "../../../commons/src";
   import "../../availability/src/Availability.svelte";
 
   // #region props
   export let id: string = "";
   export let access_token: string = "";
   export let availability_id: string;
+  export let editor_id: string;
   export let email_ids: string[];
   export let booking_label: string;
   export let event_title: string;
@@ -29,13 +37,21 @@
   //#region mount and prop initialization
   let internalProps: Partial<Manifest> = {};
   let manifest: Partial<Manifest> = {};
+  let editorManifest: Partial<EditorManifest> = {};
+
   onMount(async () => {
     await tick();
     const storeKey = JSON.stringify({ component_id: id, access_token });
     manifest = (await $ManifestStore[storeKey]) || {};
 
+    if (editor_id) {
+      editorManifest = await fetchManifest(editor_id);
+    }
+
     internalProps = buildInternalProps($$props, manifest) as Partial<Manifest>;
   });
+
+  $: console.log({ editorManifest });
 
   $: {
     const rebuiltProps = buildInternalProps(
@@ -53,6 +69,7 @@
       availability_id,
       "",
     );
+    editor_id = getPropertyValue(internalProps.editor_id, editor_id, "");
     email_ids = getPropertyValue(internalProps.email_ids, email_ids, []);
     booking_label = getPropertyValue(
       internalProps.booking_label,
@@ -60,7 +77,7 @@
       "Schedule",
     );
     event_title = getPropertyValue(
-      internalProps.event_title,
+      internalProps.event_title || editorManifest.event_title,
       event_title,
       "Meeting",
     );
@@ -123,6 +140,7 @@
       <ul>
         {#each slots_to_book as timeSlot}
           <li>
+            <h3>{event_title}: {event_description}</h3>
             {timeSlot.start_time.toLocaleString()} to {timeSlot.end_time.toLocaleString()}
           </li>
         {/each}

--- a/components/scheduler/src/Scheduler.svelte
+++ b/components/scheduler/src/Scheduler.svelte
@@ -44,7 +44,7 @@
     const storeKey = JSON.stringify({
       component_id: id,
       access_token,
-      merge_ids: [editor_id],
+      external_manifest_ids: [editor_id],
     });
     manifest = (await $ManifestStore[storeKey]) || {};
 

--- a/components/scheduler/src/Scheduler.svelte
+++ b/components/scheduler/src/Scheduler.svelte
@@ -1,11 +1,7 @@
 <svelte:options tag="nylas-scheduler" />
 
 <script lang="ts">
-  import {
-    ManifestStore,
-    AvailabilityStore,
-    fetchManifest,
-  } from "../../../commons/src";
+  import { ManifestStore, AvailabilityStore } from "../../../commons/src";
   import { createEvent } from "@commons/connections/events";
   import { get_current_component } from "svelte/internal";
   import {
@@ -46,10 +42,6 @@
       external_manifest_ids: [editor_id],
     });
     manifest = (await $ManifestStore[storeKey]) || {};
-
-    // if (editor_id) {
-    //   editorManifest = await fetchManifest(editor_id);
-    // }
 
     internalProps = buildInternalProps($$props, manifest) as Partial<Manifest>;
   });

--- a/components/scheduler/src/Scheduler.svelte
+++ b/components/scheduler/src/Scheduler.svelte
@@ -3,7 +3,6 @@
 <script lang="ts">
   import {
     ManifestStore,
-    EventStore,
     AvailabilityStore,
     fetchManifest,
   } from "../../../commons/src";
@@ -126,7 +125,7 @@
     });
     await Promise.all(bookings);
 
-    dispatchEvent("bookedEvents");
+    dispatchEvent("bookedEvents", {});
 
     // Reset the Availability store and force a re-render
     // TODO: it's possible that this isn't good enough / will involve a race condition between provider sync and return. Need to test.

--- a/components/scheduler/src/Scheduler.svelte
+++ b/components/scheduler/src/Scheduler.svelte
@@ -42,11 +42,11 @@
   onMount(async () => {
     await tick();
     const storeKey = JSON.stringify({ component_id: id, access_token });
-    manifest = (await $ManifestStore[storeKey]) || {};
+    manifest = (await ManifestStore.getAndMerge(storeKey, editor_id)) || {};
 
-    if (editor_id) {
-      editorManifest = await fetchManifest(editor_id);
-    }
+    // if (editor_id) {
+    //   editorManifest = await fetchManifest(editor_id);
+    // }
 
     internalProps = buildInternalProps($$props, manifest) as Partial<Manifest>;
   });

--- a/components/scheduler/src/index.html
+++ b/components/scheduler/src/index.html
@@ -41,6 +41,7 @@
 
   <body>
     <main>
+<<<<<<< HEAD
       <nylas-availability
         show_as_week="true"
         allow_booking="true"
@@ -49,6 +50,13 @@
       >
       </nylas-availability>
       <nylas-scheduler id="demo-scheduler"></nylas-scheduler>
+=======
+      <nylas-scheduler
+        availability_id="demo-availability"
+        editor_id="demo-schedule-editor"
+        id="demo-scheduler"
+      ></nylas-scheduler>
+>>>>>>> e74c05b... Prototype: scheduler reading from schedule editor manifest
     </main>
   </body>
 </html>

--- a/components/scheduler/src/index.html
+++ b/components/scheduler/src/index.html
@@ -41,7 +41,6 @@
 
   <body>
     <main>
-<<<<<<< HEAD
       <nylas-availability
         show_as_week="true"
         allow_booking="true"
@@ -49,14 +48,7 @@
         id="demo-availability"
       >
       </nylas-availability>
-      <nylas-scheduler id="demo-scheduler"></nylas-scheduler>
-=======
-      <nylas-scheduler
-        availability_id="demo-availability"
-        editor_id="demo-schedule-editor"
-        id="demo-scheduler"
-      ></nylas-scheduler>
->>>>>>> e74c05b... Prototype: scheduler reading from schedule editor manifest
+      <nylas-scheduler id="demo-scheduler" editor_id="demo-schedule-editor"></nylas-scheduler>
     </main>
   </body>
 </html>

--- a/components/scheduler/src/init.spec.js
+++ b/components/scheduler/src/init.spec.js
@@ -3,4 +3,8 @@ describe("scheduler component", () => {
     cy.visit("/components/scheduler/src/index.html");
     cy.get("nylas-scheduler").should("exist");
   });
+
+  // TODO: when we have slots_to_book from https://github.com/nylas/components/pull/59, add tests for cascading event.title inheritance
+  // describe("Inherits and passes properties", () => {
+  // })
 });


### PR DESCRIPTION
(Draft, Looking for feedback)

This adds the `editor_id` property to `<nylas-scheduler>`, and if present, will read the manifest of a `<nylas-schedule-editor>`.

There is one created at `demo-schedule-editor`, and you can test the following cases with this PR:
- passing `event_title` directly in should overrule...
- reading from the editorManifest found at `demo-schedule-editor`, set to "My Wonderful Event", which should overrule...
- reading directly from the scheduler manifest found at `demo-scheduler`, set to "Scheduler Driven Event Title" which should overrule...
- the default in Scheduler.svelte of "Meeting"

Mostly I'd like to know if there's a way we could change `getPropertyValue` to allow more possible defaults to take place. The code you see here allows the above hierarchy of props to work, but it is a bit cumbersome.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
