### PR TITLE
Manifest store fix: doesn't reset its entire instance on every get()

### DIFF
--- a/commons/src/store/manifest.ts
+++ b/commons/src/store/manifest.ts
@@ -44,10 +44,10 @@ function initialize(): Writable<ManifestStore> {
           return Object.assign({}, manifest, ...manifestsToMerge);
         });
       });
-      store.update((store) => ({
-        ...store,
-        [key]: fetchPromise,
-      }));
+      store.update((store) => {
+        store[key] = fetchPromise;
+        return store;
+      });
       target[key] = fetchPromise;
     }
     return target[key];


### PR DESCRIPTION
credit to @ozsivanov for the fix!

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
