### PR TITLE
Reload function for Availability component

### DIFF
--- a/commons/src/types/Availability.ts
+++ b/commons/src/types/Availability.ts
@@ -59,8 +59,9 @@ export interface AvailabilityQuery {
     start_time: number;
     end_time: number;
   };
-  access_token?: string;
   component_id: string;
+  access_token?: string;
+  forceReload?: boolean;
 }
 
 export interface AvailabilityResponse {

--- a/components/scheduler/src/Scheduler.svelte
+++ b/components/scheduler/src/Scheduler.svelte
@@ -10,7 +10,6 @@
     getPropertyValue,
   } from "@commons/methods/component";
 
-  import type { Manifest as EditorManifest } from "@commons/types/ScheduleEditor";
   import type { Manifest } from "@commons/types/Scheduler";
   import type { TimeSlot } from "@commons/types/Availability";
   import type { EventQuery, TimespanEvent } from "@commons/types/Events";
@@ -37,7 +36,6 @@
   //#region mount and prop initialization
   let internalProps: Partial<Manifest> = {};
   let manifest: Partial<Manifest> = {};
-  let editorManifest: Partial<EditorManifest> = {};
 
   onMount(async () => {
     await tick();
@@ -50,8 +48,6 @@
 
     internalProps = buildInternalProps($$props, manifest) as Partial<Manifest>;
   });
-
-  $: console.log({ editorManifest });
 
   $: {
     const rebuiltProps = buildInternalProps(
@@ -77,7 +73,7 @@
       "Schedule",
     );
     event_title = getPropertyValue(
-      internalProps.event_title || editorManifest.event_title,
+      internalProps.event_title,
       event_title,
       "Meeting",
     );
@@ -181,9 +177,6 @@
     } else if (notification_mode === NotificationMode.SHOW_MESSAGE) {
       show_success_notification = true;
     }
-    // Reset the Availability store and force a re-render
-    // TODO: it's possible that this isn't good enough / will involve a race condition between provider sync and return. Need to test.
-    AvailabilityStore.reset();
     availability_id = availability_id;
   }
 </script>

--- a/components/scheduler/src/index.html
+++ b/components/scheduler/src/index.html
@@ -17,7 +17,7 @@
         });
 
         scheduler.addEventListener("bookedEvents", () => {
-          scheduler.slots_to_book = [];
+          availability.reload(true, true);
         });
       });
     </script>


### PR DESCRIPTION
Added `reload()` function for Availability component that can be used to re-fetch the Availability data. The function accepts parameters that can clear the previously selected slots, and update the local availability store to assume that the events were booked successfully.

Note that in this gif, the slots are displayed as "busy" because the local store is updated, but become "free" again when the fetch availability request returns (seems like there is some delay in booking events right now).

![booking](https://user-images.githubusercontent.com/8049234/134141010-d3a7d3f0-b95a-4309-9cc6-b71d24141624.gif)




# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
