### PR TITLE
Tests for cascading properties in <nylas-scheduler>

### DIFF
--- a/components/scheduler/src/init.spec.js
+++ b/components/scheduler/src/init.spec.js
@@ -4,7 +4,60 @@ describe("scheduler component", () => {
     cy.get("nylas-scheduler").should("exist");
   });
 
-  // TODO: when we have slots_to_book from https://github.com/nylas/components/pull/59, add tests for cascading event.title inheritance
-  // describe("Inherits and passes properties", () => {
-  // })
+  const slots_to_book = [
+    {
+      selectionStatus: "selected",
+      calendar_id: "abc123",
+      availability: "free",
+      available_calendars: ["thelonious@nylas.com"],
+      start_time: new Date(new Date().setHours(1, 0, 0, 0)),
+      end_time: new Date(new Date().setHours(3, 0, 0, 0)),
+    },
+  ];
+
+  describe("Inherits and passes properties", () => {
+    it("has a default event title", () => {
+      cy.get("nylas-availability").as("availability");
+      cy.get("nylas-scheduler")
+        .as("scheduler")
+        .then((element) => {
+          const component = element[0];
+          component.slots_to_book = slots_to_book;
+          cy.get("h3").contains("Meeting:");
+        });
+    });
+    it("inherits event title from manifest", () => {
+      cy.document().then(($document) => {
+        $document.getElementsByTagName("nylas-scheduler")[0].remove();
+        let newScheduler = $document.createElement("nylas-scheduler");
+        newScheduler.id = "demo-scheduler";
+        newScheduler.slots_to_book = slots_to_book;
+        $document.body.getElementsByTagName("main")[0].append(newScheduler);
+      });
+      cy.get("h3").contains("Scheduler Manifest Driven Event Title:");
+    });
+    it("inherits event title from editor-manifest", () => {
+      cy.document().then(($document) => {
+        $document.getElementsByTagName("nylas-scheduler")[0].remove();
+        let newScheduler = $document.createElement("nylas-scheduler");
+        newScheduler.id = "demo-scheduler";
+        newScheduler.editor_id = "demo-schedule-editor";
+        newScheduler.slots_to_book = slots_to_book;
+        $document.body.getElementsByTagName("main")[0].append(newScheduler);
+      });
+      cy.get("h3").contains("My Wonderful Event:");
+    });
+    it("inherits event title from passed-property", () => {
+      cy.document().then(($document) => {
+        $document.getElementsByTagName("nylas-scheduler")[0].remove();
+        let newScheduler = $document.createElement("nylas-scheduler");
+        newScheduler.id = "demo-scheduler";
+        newScheduler.editor_id = "demo-schedule-editor";
+        newScheduler.event_title = "Test-Passed Title";
+        newScheduler.slots_to_book = slots_to_book;
+        $document.body.getElementsByTagName("main")[0].append(newScheduler);
+      });
+      cy.get("h3").contains("Test-Passed Title:");
+    });
+  });
 });


### PR DESCRIPTION
Tests to ensure that our scheduler will inherit properties that cascade in the following way:
- If property (event_title) is passed directly as a prop, use that. If not...
- If editor_id is present, check editor manifest for the prop. If not...
- if id is present, check its manifest for the prop. If not...
- default back to the default (in this case, "Meeting")

Logic for this test was completed in #61 

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
