### PR TITLE
Prototype: Nylas availability drag-selection

### DIFF
--- a/commons/src/types/Availability.ts
+++ b/commons/src/types/Availability.ts
@@ -45,6 +45,7 @@ export interface TimeSlot {
 export interface SelectableSlot extends TimeSlot {
   selectionStatus: SelectionStatus;
   availability: AvailabilityStatus;
+  selectionPending?: boolean;
 }
 
 export interface AvailabilityQuery {

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -1255,7 +1255,7 @@
                     })}
                   <!-- TODO: work event.title into here -->
                 </span>
-              {:else if slot.selectionPending && slot.availability !== AvailabilityStatus.BUSY && (!day.slots[iter - 1].selectionPending || day.slots[iter - 1].availability === AvailabilityStatus.BUSY)}
+              {:else if slot.selectionPending && slot.availability !== AvailabilityStatus.BUSY && (!day.slots[iter - 1]?.selectionPending || day.slots[iter - 1]?.availability === AvailabilityStatus.BUSY)}
                 <span class="selected-heading">
                   {slot.start_time.toLocaleTimeString([], {
                     hour: "numeric",

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -694,19 +694,19 @@
   function addToDrag(slot: SelectableSlot, day: Day) {
     if (dragging) {
       if (dragExisting) {
-        if (day === dragStartDay) {
-          let delta =
-            day.slots.indexOf(slot) - day.slots.indexOf(dragStartSlot);
+        let delta =
+          day.slots.indexOf(slot) - dragStartDay.slots.indexOf(dragStartSlot);
+        days.forEach((day) =>
           day.slots
             .filter((slot) => slot.selectionPending)
-            .forEach((slot) => (slot.selectionPending = false));
-          draggedBlockSlots?.forEach((slot) => {
-            day.slots[day.slots.indexOf(slot) + delta].selectionPending = true;
-          });
-          days = [...days];
-        } else {
-          console.log("moved to another day, do more math", day, dragStartDay);
-        }
+            .forEach((slot) => (slot.selectionPending = false)),
+        );
+        draggedBlockSlots?.forEach((slot) => {
+          day.slots[
+            dragStartDay.slots.indexOf(slot) + delta
+          ].selectionPending = true;
+        });
+        days = [...days];
       } else {
         let direction: "forward" | "backward" = "forward";
         if (allow_booking && day === dragStartDay) {
@@ -772,20 +772,31 @@
   }
 
   function endDrag(slot: SelectableSlot | null, day: Day | null) {
+    console.log("END DRAG");
     if (dragExisting) {
-      draggedBlockSlots?.forEach(
-        (slot) => (slot.selectionStatus = SelectionStatus.UNSELECTED),
-      );
-      days.forEach((day) =>
-        day.slots
-          .filter((x) => x.selectionPending)
-          .forEach((x) => {
-            if (x.availability !== AvailabilityStatus.BUSY) {
-              x.selectionStatus = SelectionStatus.SELECTED;
-            }
-            x.selectionPending = false;
-          }),
-      );
+      if (day) {
+        draggedBlockSlots?.forEach(
+          (slot) => (slot.selectionStatus = SelectionStatus.UNSELECTED),
+        );
+        days.forEach((day) =>
+          day.slots
+            .filter((x) => x.selectionPending)
+            .forEach((x) => {
+              if (x.availability !== AvailabilityStatus.BUSY) {
+                x.selectionStatus = SelectionStatus.SELECTED;
+              }
+              x.selectionPending = false;
+            }),
+        );
+      } else {
+        days.forEach((day) =>
+          day.slots
+            .filter((x) => x.selectionPending)
+            .forEach((x) => {
+              x.selectionPending = false;
+            }),
+        );
+      }
     } else {
       if (!day || day !== dragStartDay) {
         days.forEach((day) =>

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -120,7 +120,7 @@
     partial_bookable_ratio = getPropertyValue(
       internalProps.partial_bookable_ratio,
       partial_bookable_ratio,
-      0,
+      0.01,
     );
     show_as_week = getPropertyValue(
       internalProps.show_as_week,
@@ -257,6 +257,14 @@
           freeCalendars.length < allCalendars.length * partial_bookable_ratio
         ) {
           availability = AvailabilityStatus.BUSY;
+        }
+
+        // Allows users to book over busy slots if partial_bookable_ratio is 0
+        if (
+          availability === AvailabilityStatus.BUSY &&
+          partial_bookable_ratio === 0
+        ) {
+          availability = AvailabilityStatus.PARTIAL;
         }
 
         if (
@@ -772,7 +780,6 @@
   }
 
   function endDrag(slot: SelectableSlot | null, day: Day | null) {
-    console.log("END DRAG");
     if (dragExisting) {
       if (day) {
         draggedBlockSlots?.forEach(

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -646,6 +646,22 @@
     }
   }
   // #endregion Date Change
+
+  //#region dragging
+  let dragging = false;
+  function startDrag(slot: TimeSlot) {
+    console.log("started dragging on ", slot);
+    dragging = true;
+  }
+
+  function addToDrag(slot: TimeSlot) {
+    console.log("added to drag");
+  }
+
+  function endDrag(slot: TimeSlot) {
+    console.log("drag ended");
+  }
+  //#endregion dragging
 </script>
 
 <style lang="scss">
@@ -1017,6 +1033,13 @@
               data-start-time={new Date(slot.start_time).toLocaleString()}
               data-end-time={new Date(slot.end_time).toLocaleString()}
               disabled={slot.availability === AvailabilityStatus.BUSY}
+              on:mousedown={() => startDrag(slot)}
+              on:mouseenter={() => {
+                if (dragging) addToDrag(slot);
+              }}
+              on:mouseup={() => {
+                if (dragging) endDrag(slot);
+              }}
               on:click={() => {
                 if (allow_booking) {
                   slot.selectionStatus =

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -710,9 +710,11 @@
             .forEach((slot) => (slot.selectionPending = false)),
         );
         draggedBlockSlots?.forEach((slot) => {
-          day.slots[
-            dragStartDay!.slots.indexOf(slot) + delta
-          ].selectionPending = true;
+          if (day.slots[dragStartDay!.slots.indexOf(slot) + delta]) {
+            day.slots[
+              dragStartDay!.slots.indexOf(slot) + delta
+            ].selectionPending = true;
+          }
         });
         days = [...days];
       } else {

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -985,7 +985,7 @@
             display: inline-block;
             position: relative;
             z-index: 2;
-            display: none; // TODO: TEMP
+            display: none; // TODO: temporary, until we rework this to not collide w/ time ranges
 
             span {
               background: rgba(0, 0, 0, 0.5);
@@ -1256,12 +1256,13 @@
               }}
               on:click={(e) => {
                 if (e.pointerType !== "mouse") {
-                  // account for keyboard button press; TODO: fix type error
+                  // account for keyboard button press; TODO: fix type error, fix keyboard-deselect
                   startDrag(slot, day);
                   endDrag(slot, day);
                 }
               }}
             >
+              <!-- TODO: generally clean up block time handling -->
               {#if sortedSlots.find((block) => block.start_time === slot.start_time)}
                 <span class="selected-heading">
                   {sortedSlots

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -836,16 +836,13 @@
       }
     } else {
       // Mode: Drag-mreating a new event
-      if (!day || day !== dragStartDay) {
-      } else {
-        days.forEach((day) =>
-          day.slots
-            .filter((x) => x.selectionPending)
-            .forEach((x) => {
-              x.selectionStatus = SelectionStatus.SELECTED;
-            }),
-        );
-      }
+      days.forEach((day) =>
+        day.slots
+          .filter((x) => x.selectionPending)
+          .forEach((x) => {
+            x.selectionStatus = SelectionStatus.SELECTED;
+          }),
+      );
     }
     days = [...days]; // re-render
     resetDragState();

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -1284,7 +1284,7 @@
           {/each}
         </div>
         <div class="slots">
-          {#each day.slots as slot, iter}
+          {#each day.slots as slot}
             <button
               data-available-calendars={slot.available_calendars.toString()}
               aria-label="{new Date(
@@ -1306,7 +1306,6 @@
                 startDrag(slot, day);
               }}
               on:mouseenter={() => {
-                // TODO: make sure touchstart / touchmove is good w this
                 addToDrag(slot, day);
               }}
               on:mouseup={() => {

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -959,6 +959,7 @@
             display: inline-block;
             position: relative;
             z-index: 2;
+            display: none; // TODO: TEMP
 
             span {
               background: rgba(0, 0, 0, 0.5);
@@ -995,7 +996,8 @@
 
           &.selected {
             background-color: purple;
-            box-shadow: 0 0 10px rgba(0, 0, 0, 0.25);
+            box-shadow: none;
+            border-bottom: 1px solid transparent;
           }
 
           &.pending {
@@ -1005,6 +1007,17 @@
 
           &.busy {
             cursor: not-allowed;
+          }
+
+          .selected-heading {
+            position: absolute;
+            top: 3px;
+            left: 3px;
+            color: white;
+            background: rgba(0, 0, 0, 0.5);
+            padding: 0 3px;
+            font-size: 0.75rem;
+            z-index: 2;
           }
         }
       }
@@ -1190,7 +1203,7 @@
           {/each}
         </div>
         <div class="slots">
-          {#each day.slots as slot}
+          {#each day.slots as slot, iter}
             <button
               data-available-calendars={slot.available_calendars.toString()}
               aria-label="{new Date(
@@ -1206,7 +1219,7 @@
                 dragging = true;
                 startDrag(slot, day);
               }}
-              on:mousemove={() => {
+              on:mouseenter={() => {
                 // TODO: make sure touchstart / touchmove is good w this
                 addToDrag(slot, day);
               }}
@@ -1222,7 +1235,49 @@
                   endDrag(slot, day);
                 }
               }}
-            />
+            >
+              {#if sortedSlots.find((block) => block.start_time === slot.start_time)}
+                <span class="selected-heading">
+                  {sortedSlots
+                    .find((block) => block.start_time === slot.start_time)
+                    ?.start_time.toLocaleTimeString([], {
+                      hour: "numeric",
+                      minute: "2-digit",
+                      hour12: true,
+                    })}
+                  -
+                  {sortedSlots
+                    .find((block) => block.start_time === slot.start_time)
+                    ?.end_time.toLocaleTimeString([], {
+                      hour: "numeric",
+                      minute: "2-digit",
+                      hour12: true,
+                    })}
+                  <!-- TODO: work event.title into here -->
+                </span>
+              {:else if slot.selectionPending && slot.availability !== AvailabilityStatus.BUSY && (!day.slots[iter - 1].selectionPending || day.slots[iter - 1].availability === AvailabilityStatus.BUSY)}
+                <span class="selected-heading">
+                  {slot.start_time.toLocaleTimeString([], {
+                    hour: "numeric",
+                    minute: "2-digit",
+                    hour12: true,
+                  })}
+                  -
+                  {day.slots
+                    .find(
+                      (s) =>
+                        s.start_time > slot.start_time &&
+                        (!s.selectionPending ||
+                          s.availability === AvailabilityStatus.BUSY),
+                    )
+                    ?.start_time.toLocaleTimeString([], {
+                      hour: "numeric",
+                      minute: "2-digit",
+                      hour12: true,
+                    })}
+                </span>
+              {/if}
+            </button>
           {/each}
         </div>
       </div>

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -664,8 +664,8 @@
   $: draggedBlockSlots = draggedBlock
     ? dragStartDay?.slots.filter(
         (slot) =>
-          slot.start_time >= draggedBlock.start_time &&
-          slot.end_time <= draggedBlock.end_time,
+          slot.start_time >= draggedBlock!.start_time &&
+          slot.end_time <= draggedBlock!.end_time,
       )
     : [];
 
@@ -693,7 +693,7 @@
 
   function addToDrag(slot: SelectableSlot, day: Day) {
     if (dragging) {
-      if (dragExisting) {
+      if (dragExisting && dragStartSlot && dragStartDay) {
         let delta =
           day.slots.indexOf(slot) - dragStartDay.slots.indexOf(dragStartSlot);
         days.forEach((day) =>
@@ -703,22 +703,22 @@
         );
         draggedBlockSlots?.forEach((slot) => {
           day.slots[
-            dragStartDay.slots.indexOf(slot) + delta
+            dragStartDay!.slots.indexOf(slot) + delta
           ].selectionPending = true;
         });
         days = [...days];
       } else {
         let direction: "forward" | "backward" = "forward";
-        if (allow_booking && day === dragStartDay) {
+        if (allow_booking && day === dragStartDay && dragStartSlot) {
           if (slot.start_time < dragStartSlot.start_time) {
             direction = "backward";
           }
           day.slots.forEach((daySlot) => {
             if (
               direction === "forward"
-                ? daySlot.start_time >= dragStartSlot.start_time &&
+                ? daySlot.start_time >= dragStartSlot!.start_time &&
                   daySlot.start_time <= slot.start_time
-                : daySlot.start_time <= dragStartSlot.start_time &&
+                : daySlot.start_time <= dragStartSlot!.start_time &&
                   daySlot.start_time >= slot.start_time
             ) {
               daySlot.selectionPending =

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -66,12 +66,7 @@
           },
         ];
 
-        //component.calendars = calendars;
-        component.email_ids = [
-          "phil.r@nylas.com",
-          "hazik.a@nylas.com",
-          "chantal.l@nylas.com",
-        ];
+        component.calendars = calendars;
 
         component.addEventListener("timeSlotChosen", (event) => {
           console.log(event.detail.timeSlots);
@@ -324,7 +319,7 @@
         <nylas-availability
           allow_booking="true"
           max_bookable_slots="8"
-          id="phils-availability"
+          id="demo-availability"
         ></nylas-availability>
       </div>
     </main>

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -66,7 +66,12 @@
           },
         ];
 
-        component.calendars = calendars;
+        //component.calendars = calendars;
+        component.email_ids = [
+          "phil.r@nylas.com",
+          "hazik.a@nylas.com",
+          "chantal.l@nylas.com",
+        ];
 
         component.addEventListener("timeSlotChosen", (event) => {
           console.log(event.detail.timeSlots);
@@ -316,7 +321,11 @@
 
     <main>
       <div class="demo-box">
-        <nylas-availability id="demo-availability"></nylas-availability>
+        <nylas-availability
+          allow_booking="true"
+          max_bookable_slots="9999"
+          id="phils-availability"
+        ></nylas-availability>
       </div>
     </main>
   </body>

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -323,7 +323,7 @@
       <div class="demo-box">
         <nylas-availability
           allow_booking="true"
-          max_bookable_slots="9999"
+          max_bookable_slots="8"
           id="phils-availability"
         ></nylas-availability>
       </div>

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -113,10 +113,6 @@ describe("availability component", () => {
           cy.get(".slot.free").should("have.length", 28);
         });
     });
-
-    it("busy time slot is disabled", () => {
-      cy.get(".slot.busy").should("be.disabled");
-    });
   });
 
   describe("multiple availability sets", () => {

--- a/components/scheduler/src/Scheduler.svelte
+++ b/components/scheduler/src/Scheduler.svelte
@@ -126,6 +126,22 @@
   }
 </script>
 
+<style lang="scss">
+  main {
+    height: 100%;
+    overflow: hidden;
+    display: grid;
+    font-family: Arial, Helvetica, sans-serif;
+    position: relative;
+    z-index: 1;
+
+    .booker {
+      height: 100%;
+      overflow: auto;
+    }
+  }
+</style>
+
 <nylas-error {id} />
 <main>
   <section class="booker">

--- a/components/scheduler/src/index.html
+++ b/components/scheduler/src/index.html
@@ -44,7 +44,7 @@
       <nylas-availability
         show_as_week="true"
         allow_booking="true"
-        max_bookable_slots="999"
+        max_bookable_slots="4"
         id="demo-availability"
       >
       </nylas-availability>

--- a/components/scheduler/src/index.html
+++ b/components/scheduler/src/index.html
@@ -44,11 +44,14 @@
       <nylas-availability
         show_as_week="true"
         allow_booking="true"
-        max_bookable_slots="4"
+        max_bookable_slots="999"
         id="demo-availability"
       >
       </nylas-availability>
-      <nylas-scheduler id="demo-scheduler" editor_id="demo-schedule-editor"></nylas-scheduler>
+      <nylas-scheduler
+        id="demo-scheduler"
+        editor_id="demo-schedule-editor"
+      ></nylas-scheduler>
     </main>
   </body>
 </html>

--- a/components/scheduler/src/index.html
+++ b/components/scheduler/src/index.html
@@ -44,8 +44,9 @@
       <nylas-availability
         show_as_week="true"
         allow_booking="true"
-        max_bookable_slots="4"
+        max_bookable_slots="8"
         id="demo-availability"
+        slot_size="60"
       >
       </nylas-availability>
       <nylas-scheduler


### PR DESCRIPTION
- Allows click+drag creation and click+drag movement of events
- Contextual awareness of busy slots: will split a long event into multiple events if you drag over busy timeslots
- Multi-day chaining: if an event ends at midnight and the next event starts the following day at midnight, consider that a single event
- Timespans shown in events: now show "HH:MM - HH-MM" in all selected event spans (don't make the user glance to the ticks axis)
- Side-effect: allow `partial_bookable_ratio = 0` to let you book overtop of busy timeslots

https://user-images.githubusercontent.com/713991/133119312-5d80e252-d74f-4640-a3a6-046d4d2c8c34.mov

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
