### PR TITLE
[Mailbox Component]: Add query_string to Mailbox that accepts a string format

### DIFF
--- a/commons/src/types/Nylas.ts
+++ b/commons/src/types/Nylas.ts
@@ -170,16 +170,11 @@ export interface AgendaProperties extends Manifest {
 export interface EmailProperties extends Manifest {
   show_number_of_messages: boolean;
   show_received_timestamp: boolean;
-  is_clean_conversation_enabled: boolean;
   thread_id: string;
   theme: "theme-1" | "theme-2" | "theme-3" | "theme-4" | "theme-5";
   show_contact_avatar: boolean;
   clean_conversation: boolean;
-  query_parameters: ThreadsQuery;
-  keyword_to_search: string;
   show_star: boolean;
-  show_thread_checkbox: boolean;
-  unread_status: EmailUnreadStatus;
   show_expanded_email_view_onload: boolean;
 }
 
@@ -191,7 +186,7 @@ export interface MailboxProperties extends Manifest {
   actions_bar: MailboxActions[];
   header: string;
   keyword_to_search: string;
-  query_parameters: ThreadsQuery;
+  query_string: string;
   items_per_page: number;
 }
 

--- a/commons/src/types/Nylas.ts
+++ b/commons/src/types/Nylas.ts
@@ -176,6 +176,9 @@ export interface EmailProperties extends Manifest {
   clean_conversation: boolean;
   show_star: boolean;
   show_expanded_email_view_onload: boolean;
+  unread: boolean;
+  show_thread_actions: boolean;
+  click_action: "default" | "mailbox" | "custom";
 }
 
 export interface MailboxProperties extends Manifest {

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -61,7 +61,6 @@
   export let show_star: boolean;
   export let unread: boolean | null = null;
   export let you: Partial<Account> = {};
-  export let is_starred: boolean;
   export let show_contact_avatar: boolean;
   export let clean_conversation: boolean;
   export let show_expanded_email_view_onload: boolean;
@@ -177,7 +176,6 @@
       "default",
     );
     thread_id = getPropertyValue(internalProps.thread_id, thread_id, "");
-    is_starred = getPropertyValue(internalProps.is_starred, is_starred, false);
     show_contact_avatar = getPropertyValue(
       internalProps.show_contact_avatar,
       show_contact_avatar,

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -50,7 +50,8 @@
   export let header: string | null;
   export let actions_bar: MailboxActions[];
   export let keyword_to_search: string | null;
-  export let query_parameters: ThreadsQuery | null; // Allowed query parameter list https://developer.nylas.com/docs/api/#get/threads
+  // query_string format => "in=trash from=phil.r@nylas.com"
+  export let query_string: string | null; // Allowed query parameter list https://developer.nylas.com/docs/api/#get/threads
   export let items_per_page: number = 13;
   export let onSelectThread: (event: MouseEvent, t: Thread) => void =
     onSelectOne;
@@ -113,7 +114,12 @@
     hasComponentLoaded = true;
   });
 
-  $: queryParams = query_parameters || queryParams;
+  $: queryParams = {
+    ...queryParams,
+    ...Object.fromEntries(
+      new URLSearchParams(query_string?.replaceAll(" ", "&")),
+    ),
+  };
 
   let inboxThreads: Thread[]; // threads currently in the inbox
   $: if (threads) {
@@ -156,6 +162,11 @@
       13,
     );
     header = getPropertyValue(internalProps.header, header, null);
+    query_string = getPropertyValue(
+      internalProps.query_string,
+      query_string,
+      null,
+    );
     actions_bar = getPropertyValue(internalProps.actions_bar, actions_bar, []);
   }
 
@@ -610,7 +621,7 @@
     {#if openedEmailData}
       <div class="email-container">
         <nylas-email
-          is_clean_conversation_enabled={false}
+          clean_conversation={false}
           thread={openedEmailData}
           {you}
           {show_star}
@@ -730,7 +741,7 @@
                 </div>{/if}
               <div class="email-container">
                 <nylas-email
-                  is_clean_conversation_enabled={false}
+                  clean_conversation={false}
                   {thread}
                   {you}
                   {show_star}

--- a/components/mailbox/src/index.html
+++ b/components/mailbox/src/index.html
@@ -20,9 +20,7 @@
         mailbox.actions_bar = ["selectall", "star", "delete", "unread"];
         mailbox.show_star = true;
         // mailbox.keyword_to_search = "Hi";
-        // mailbox.query_parameters = {
-        //   from: "tips@nylas.com"
-        // }
+        // mailbox.query_string = "in=inbox from=tips@nylas.com";
       });
     </script>
   </head>


### PR DESCRIPTION
# What is done:
- Modified `query_parameters` prop to `query_string` that accepts query parameters string of the form: `in=trash from=phil.r@nylas.com`. This will allow us to support search for threads just like slack does.
- Cleaned up properties for Mailbox and Email component to represent the latest


[Story details](https://app.shortcut.com/nylas/story/68051)