### PR TITLE
[Conversation]: Add ability to add or remove participants when you send a message to the thread conversation

### DIFF
--- a/commons/src/store/threads.ts
+++ b/commons/src/store/threads.ts
@@ -81,13 +81,6 @@ function initializeThreads() {
       set({});
     },
 
-    // addThreads: (incomingThreads: StoredThreads) => {
-    //   update((threads) => {
-    //     threads[incomingThreads.queryKey] = incomingThreads.data;
-    //     return { ...threads };
-    //   });
-    // },
-
     hydrateMessageInThread: (incomingMessage: Message, query: MailboxQuery) => {
       const queryKey = JSON.stringify(query);
       const foundThread = threadsMap[queryKey].find(

--- a/components/contacts-search/src/ContactsSearch.svelte
+++ b/components/contacts-search/src/ContactsSearch.svelte
@@ -16,6 +16,7 @@
   export let placeholder: string = "To";
   export let single: boolean = false;
   export let change: ChangeCallback | void;
+  export let show_dropdown: boolean = true;
 
   let selectedContacts: Participant[] = [];
   let term: string = ""; // TODO: rename to "term"
@@ -355,7 +356,7 @@
       </form>
     {/if}
   </div>
-  {#if isOpen}
+  {#if isOpen && show_dropdown}
     <div class="dropdown-content">
       <!-- <p class="active">{email}</p> -->
       {#if loading && !filteredContacts.length}

--- a/components/conversation/src/Conversation.svelte
+++ b/components/conversation/src/Conversation.svelte
@@ -535,7 +535,6 @@
               />
             </span>
             <span class="cc">
-              <!-- {#each reply.cc as cc}<span>{cc.email}</span>{/each} -->
               <nylas-contacts-search
                 placeholder="cc:"
                 change={handleContactsChange("cc")}


### PR DESCRIPTION
# Implementation:
- Added `nylas-contact-search` to show participants in `to` & `cc` fields in the reply section, this allows for adding and removing participants
- Updated Conversation to reflect same internalProps structure as the other components
- Added a new prop `show_dropdown` to `ContactsSearch` component that defaults to `true`. Using this prop to hide the dropdown in Conversation component for now 

# TODO:
- Add a prop to `Conversation` component that will fetch contacts and populate the dropdown suggestions for `nylas-contact-search` in `to` & `cc` fields

[Story details](https://app.shortcut.com/nylas/story/68692)