### PR TITLE
Creating CSS Variables for Availability Colours

### DIFF
--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -505,9 +505,8 @@
       access_token: access_token,
     };
     // Free-Busy endpoint returns busy timeslots for given email_ids between start_time & end_time
-    const consolidatedAvailabilityForGivenDay = await AvailabilityStore.getAvailability(
-      availabilityQuery,
-    );
+    const consolidatedAvailabilityForGivenDay =
+      await AvailabilityStore.getAvailability(availabilityQuery);
     if (consolidatedAvailabilityForGivenDay?.length) {
       consolidatedAvailabilityForGivenDay.forEach((user) => {
         freeBusyCalendars.push({
@@ -911,9 +910,6 @@
 <style lang="scss">
   @import "../../theming/variables.scss";
   $headerHeight: 40px;
-  $color-free: rgba(54, 210, 173, 0.4);
-  $color-busy: rgba(255, 100, 117, 0.4);
-  $color-partial: rgba(255, 255, 117, 0.4);
   main {
     height: 100%;
     overflow: hidden;
@@ -1026,14 +1022,14 @@
           }
 
           &.busy .inner {
-            background-color: $color-busy;
+            background-color: var(--busy-color, rgba(255, 100, 117, 0.4));
           }
           &.partial .inner {
-            background-color: $color-partial;
+            background-color: var(--partial-color, rgba(255, 255, 117, 0.4));
           }
 
           &.free .inner {
-            background-color: $color-free;
+            background-color: var(--free-color, rgba(54, 210, 173, 0.4));
           }
 
           .available-calendars {

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -150,13 +150,21 @@
       required_participants,
       [],
     );
-    busy_color = getPropertyValue(internalProps.busy_color, busy_color, "");
+    busy_color = getPropertyValue(
+      internalProps.busy_color,
+      busy_color,
+      "#ff647566",
+    );
     partial_color = getPropertyValue(
       internalProps.partial_color,
       partial_color,
-      "",
+      "#ffff7566",
     );
-    free_color = getPropertyValue(internalProps.free_color, free_color, "");
+    free_color = getPropertyValue(
+      internalProps.free_color,
+      free_color,
+      "#36d2ad66",
+    );
   }
 
   $: {

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -57,6 +57,9 @@
   export let attendees_to_show: number;
   export let allow_date_change: boolean;
   export let required_participants: string[];
+  export let busy_color: string;
+  export let partial_color: string;
+  export let free_color: string;
   //#endregion props
 
   //#region mount and prop initialization
@@ -147,6 +150,13 @@
       required_participants,
       [],
     );
+    busy_color = getPropertyValue(internalProps.busy_color, busy_color, "");
+    partial_color = getPropertyValue(
+      internalProps.partial_color,
+      partial_color,
+      "",
+    );
+    free_color = getPropertyValue(internalProps.free_color, free_color, "");
   }
 
   $: {
@@ -1022,14 +1032,14 @@
           }
 
           &.busy .inner {
-            background-color: var(--busy-color, rgba(255, 100, 117, 0.4));
+            background-color: var(--busy-color, #ff647566);
           }
           &.partial .inner {
-            background-color: var(--partial-color, rgba(255, 255, 117, 0.4));
+            background-color: var(--partial-color, #ffff7566);
           }
 
           &.free .inner {
-            background-color: var(--free-color, rgba(54, 210, 173, 0.4));
+            background-color: var(--free-color, #36d2ad66);
           }
 
           .available-calendars {
@@ -1217,6 +1227,7 @@
   class:dated={allow_date_change}
   class:allow_booking
   on:mouseleave={() => endDrag(null, null)}
+  style="--free-color: {free_color}; --busy-color: {busy_color}; --partial-color: {partial_color};"
 >
   {#if allow_date_change}
     <header class="change-dates">

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -141,6 +141,13 @@
               component.allow_date_change = JSON.parse(event.target.value);
             });
           });
+
+        document.querySelectorAll('input[name^="color-"]').forEach((elem) => {
+          elem.addEventListener("input", function (event) {
+            const type = elem.getAttribute("data-type");
+            component.style.setProperty(type, event.target.value);
+          });
+        });
       });
     </script>
     <style>
@@ -310,6 +317,26 @@
         <label>
           <input type="radio" name="allow-date-change" value="false" />
           Not allowed
+        </label>
+      </fieldset>
+
+      <fieldset>
+        <legend>Colours</legend>
+        <label>
+          <input type="color" name="color-free" data-type="--free-color" />
+          Free color
+        </label>
+        <label>
+          <input type="color" name="color-busy" data-type="--busy-color" />
+          Busy color
+        </label>
+        <label>
+          <input
+            type="color"
+            name="color-partial"
+            data-type="--partial-color"
+          />
+          Partial color
         </label>
       </fieldset>
     </aside>

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -323,16 +323,31 @@
       <fieldset>
         <legend>Colours</legend>
         <label>
-          <input type="color" name="color-free" data-type="free_color" />
-          Free color
-        </label>
-        <label>
-          <input type="color" name="color-busy" data-type="busy_color" />
+          <input
+            type="color"
+            name="color-busy"
+            data-type="busy_color"
+            value="#ffc1c8"
+          />
           Busy color
         </label>
         <label>
-          <input type="color" name="color-partial" data-type="partial_color" />
+          <input
+            type="color"
+            name="color-partial"
+            data-type="partial_color"
+            value="#ffffc8"
+          />
           Partial color
+        </label>
+        <label>
+          <input
+            type="color"
+            name="color-free"
+            data-type="free_color"
+            value="#aeedde"
+          />
+          Free color
         </label>
       </fieldset>
     </aside>

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -145,7 +145,7 @@
         document.querySelectorAll('input[name^="color-"]').forEach((elem) => {
           elem.addEventListener("input", function (event) {
             const type = elem.getAttribute("data-type");
-            component.style.setProperty(type, event.target.value);
+            component[type] = event.target.value;
           });
         });
       });
@@ -321,21 +321,17 @@
       </fieldset>
 
       <fieldset>
-        <legend>Colours (via CSS var)</legend>
+        <legend>Colours</legend>
         <label>
-          <input type="color" name="color-free" data-type="--free-color" />
+          <input type="color" name="color-free" data-type="free_color" />
           Free color
         </label>
         <label>
-          <input type="color" name="color-busy" data-type="--busy-color" />
+          <input type="color" name="color-busy" data-type="busy_color" />
           Busy color
         </label>
         <label>
-          <input
-            type="color"
-            name="color-partial"
-            data-type="--partial-color"
-          />
+          <input type="color" name="color-partial" data-type="partial_color" />
           Partial color
         </label>
       </fieldset>

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -321,7 +321,7 @@
       </fieldset>
 
       <fieldset>
-        <legend>Colours</legend>
+        <legend>Colours (via CSS var)</legend>
         <label>
           <input type="color" name="color-free" data-type="--free-color" />
           Free color

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -629,4 +629,43 @@ describe("availability component", () => {
         });
     });
   });
+
+  describe("change colours", () => {
+    it("changes colour by prop", () => {
+      cy.get(".epoch.partial .inner").should(
+        "not.have.css",
+        "background-color",
+        "rgb(0, 0, 0)",
+      );
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.partial_color = "#000";
+          cy.get(".epoch.partial .inner").should(
+            "have.css",
+            "background-color",
+            "rgb(0, 0, 0)",
+          );
+        });
+    });
+    it("changes colour by css var", () => {
+      cy.get(".epoch.partial .inner").should(
+        "not.have.css",
+        "background-color",
+        "rgb(0, 0, 0)",
+      );
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.style.setProperty("--partial-color", "#000");
+          cy.get(".epoch.partial .inner").should(
+            "have.css",
+            "background-color",
+            "rgb(0, 0, 0)",
+          );
+        });
+    });
+  });
 });

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -428,34 +428,35 @@ describe("availability component", () => {
       });
 
       cy.wait(1000); // TODO: have this as a wait for render to be complete instead of a timer
+      cy.get(".slot.free").should("exist");
       expect(selectedTimeslots).to.have.lengthOf(0);
       cy.get(".slot.free")
         .eq(0)
         .click()
         .then(() => {
           expect(selectedTimeslots).to.have.lengthOf(1);
-        });
-      cy.get(".slot.free")
-        .eq(3)
-        .click()
-        .then(() => {
-          expect(selectedTimeslots).to.have.lengthOf(2);
-        });
-      cy.get(".slot.free")
-        .eq(1)
-        .click()
-        .then(() => {
-          expect(selectedTimeslots).to.have.lengthOf(2);
-          expect(selectedTimeslots[0].end_time.toISOString()).eq(
-            consecutiveSlotEndTime,
-          );
-          expect(selectedTimeslots[1].start_time.toISOString()).eq(
-            singularSlotStartTime,
-          );
-          expect(selectedTimeslots[1].end_time.toISOString()).eq(
-            singularSlotEndTime,
-          );
-          done();
+          cy.get(".slot.free")
+            .eq(3)
+            .click()
+            .then(() => {
+              expect(selectedTimeslots).to.have.lengthOf(2);
+              cy.get(".slot.free")
+                .eq(1)
+                .click()
+                .then(() => {
+                  expect(selectedTimeslots).to.have.lengthOf(2);
+                  expect(selectedTimeslots[0].end_time.toISOString()).eq(
+                    consecutiveSlotEndTime,
+                  );
+                  expect(selectedTimeslots[1].start_time.toISOString()).eq(
+                    singularSlotStartTime,
+                  );
+                  expect(selectedTimeslots[1].end_time.toISOString()).eq(
+                    singularSlotEndTime,
+                  );
+                  done();
+                });
+            });
         });
     });
   });

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -649,23 +649,5 @@ describe("availability component", () => {
           );
         });
     });
-    it("changes colour by css var", () => {
-      cy.get(".epoch.partial .inner").should(
-        "not.have.css",
-        "background-color",
-        "rgb(0, 0, 0)",
-      );
-      cy.get("nylas-availability")
-        .as("availability")
-        .then((element) => {
-          const component = element[0];
-          component.style.setProperty("--partial-color", "#000");
-          cy.get(".epoch.partial .inner").should(
-            "have.css",
-            "background-color",
-            "rgb(0, 0, 0)",
-          );
-        });
-    });
   });
 });

--- a/components/contact-list/src/init.spec.js
+++ b/components/contact-list/src/init.spec.js
@@ -200,6 +200,7 @@ describe("Optional Prop Handling", () => {
       const component = element[0];
       component.sort_by = "last_emailed";
     });
+    cy.get(".loader").should("not.exist");
     cy.get("nylas-contact-list")
       .find(".contact")
       .should("have.length.greaterThan", 1);


### PR DESCRIPTION
This PR is about adding colour customization to Availability component using CSS vars. The Scheduler Editor should also be able to customize the colours. 

- [x] CSS vars control colours
- [x] Make it so Scheduler Editor can modify colours (make it a property)

<img width="1776" alt="image" src="https://user-images.githubusercontent.com/8989414/133478469-1820a121-1417-4fdd-9921-6db1f07158bf.png">


# Readiness checklist

- [x] Cypress tests passing?
- [x] New cypress tests added?
- [x] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
