### PR TITLE
[Contact-List]: Initialize show_filter & default_photo props from the manifest and/or set defaults

### DIFF
--- a/commons/src/types/Nylas.ts
+++ b/commons/src/types/Nylas.ts
@@ -221,6 +221,8 @@ export interface ContactListProperties extends Manifest {
   threads_to_load: number;
   contacts_to_load: number;
   show_names: boolean;
+  show_filter: boolean;
+  default_photo: string | null;
 }
 
 export interface ConversationProperties extends Manifest {

--- a/components/contact-list/src/ContactList.svelte
+++ b/components/contact-list/src/ContactList.svelte
@@ -495,7 +495,11 @@
 
     {#if show_filter}
       <label class="entry filter">
-        Filter by email: <input type="text" bind:value={filterValue} />
+        Filter by email: <input
+          id="show-filter-input"
+          type="text"
+          bind:value={filterValue}
+        />
       </label>
     {/if}
 

--- a/components/contact-list/src/ContactList.svelte
+++ b/components/contact-list/src/ContactList.svelte
@@ -102,6 +102,16 @@
       "email",
     );
     sort_by = getPropertyValue(internalProps.sort_by, sort_by, "name");
+    show_filter = getPropertyValue(
+      internalProps.show_filter,
+      show_filter,
+      true,
+    );
+    default_photo = getPropertyValue(
+      internalProps.default_photo,
+      default_photo,
+      null,
+    );
     show_names = getPropertyValue(internalProps.show_names, show_names, true);
     contacts_to_load = getPropertyValue(
       internalProps.contacts_to_load,

--- a/components/contact-list/src/init.spec.js
+++ b/components/contact-list/src/init.spec.js
@@ -177,6 +177,21 @@ describe("Optional Prop Handling", () => {
       .should("exist");
   });
 
+  it("Component shows filter by email option when 'show_filter' is set to true", () => {
+    cy.loadContacts();
+    cy.visit("/components/contact-list/src/index.html");
+    cy.get("nylas-contact-list").should("exist");
+    cy.get("nylas-contact-list").then((element) => {
+      const component = element[0];
+      component.show_filter = true;
+    });
+    cy.wait("@contacts");
+    cy.get("label.entry.filter").contains("Filter by email: ");
+    cy.get("input#show-filter-input").should("exist");
+    cy.get("input#show-filter-input").type("nylascypresstest");
+    cy.get("nylas-contact-list").find(".contact").should("have.length", 2);
+  });
+
   it("Component loads and works for sort_by=last_emailed when account has email & contact scopes", () => {
     cy.loadContacts();
     cy.visit("/components/contact-list/src/index.html");


### PR DESCRIPTION
# Background:
`https://share.nyl.as/contact-list/[component-id]` does not display filter by email option, even though it is set in the manifest.

# Implementation:
- Setting the initial prop values for `show_filter` & `default_photo` from the manifest and/or default values


# Screenshot
![image](https://user-images.githubusercontent.com/16315004/133323997-ff336716-de16-4771-9ec2-0d40f246e63b.png)
![image](https://user-images.githubusercontent.com/16315004/133329680-8bdb1b2d-741c-4e82-bc97-26b965d35e8c.png)


# Readiness checklist

- [X] Cypress tests passing?
- [X] New cypress tests added?
- [X] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
