### PR TITLE
Schedule editor: Adds show_hosts prop

### DIFF
--- a/commons/src/types/Availability.ts
+++ b/commons/src/types/Availability.ts
@@ -20,6 +20,10 @@ export interface Manifest extends NylasManifest {
   attendees_to_show: number;
   allow_date_change: boolean;
   required_participants: string[];
+  show_hosts: "show" | "hide";
+  partial_color: string;
+  free_color: string;
+  busy_color: string;
 }
 
 export interface Calendar {

--- a/commons/src/types/ScheduleEditor.ts
+++ b/commons/src/types/ScheduleEditor.ts
@@ -3,4 +3,5 @@ import type { Manifest as NylasManifest } from "@commons/types/Nylas";
 export interface Manifest extends NylasManifest {
   event_title?: string;
   event_description?: string;
+  show_hosts?: "show" | "hide";
 }

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -92,8 +92,6 @@
     calendarID = calendarsList?.find((cal) => cal.is_primary)?.id || "";
   });
 
-  $: console.log({ editorManifest });
-
   $: {
     const rebuiltProps = buildInternalProps(
       $$props,
@@ -539,8 +537,9 @@
       access_token: access_token,
     };
     // Free-Busy endpoint returns busy timeslots for given email_ids between start_time & end_time
-    const consolidatedAvailabilityForGivenDay =
-      await AvailabilityStore.getAvailability(availabilityQuery);
+    const consolidatedAvailabilityForGivenDay = await AvailabilityStore.getAvailability(
+      availabilityQuery,
+    );
     if (consolidatedAvailabilityForGivenDay?.length) {
       consolidatedAvailabilityForGivenDay.forEach((user) => {
         freeBusyCalendars.push({

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -32,6 +32,7 @@
     EventQuery,
     CalendarAccount,
   } from "@commons/types/Availability";
+  import type { Manifest as EditorManifest } from "@commons/types/ScheduleEditor";
   import "@commons/components/ContactImage/ContactImage.svelte";
   import AvailableIcon from "./assets/available.svg";
   import UnavailableIcon from "./assets/unavailable.svg";
@@ -41,6 +42,7 @@
   //#region props
   export let id: string = "";
   export let access_token: string = "";
+  export let editor_id: string;
   export let start_hour: number;
   export let end_hour: number;
   export let slot_size: number; // in minutes
@@ -60,16 +62,23 @@
   export let busy_color: string;
   export let partial_color: string;
   export let free_color: string;
+  export let show_hosts: "show" | "hide";
   //#endregion props
 
   //#region mount and prop initialization
   let internalProps: Partial<Manifest> = {};
   let manifest: Partial<Manifest> = {};
+  let editorManifest: Partial<EditorManifest> = {};
+
   $: calendarID = "";
   onMount(async () => {
     await tick();
     clientHeight = main?.getBoundingClientRect().height;
-    const storeKey = JSON.stringify({ component_id: id, access_token });
+    const storeKey = JSON.stringify({
+      component_id: id,
+      access_token,
+      external_manifest_ids: [editor_id],
+    });
     manifest = (await $ManifestStore[storeKey]) || {};
 
     internalProps = buildInternalProps($$props, manifest) as Partial<Manifest>;
@@ -82,6 +91,8 @@
     const calendarsList = await CalendarStore.getCalendars(calendarQuery); // TODO: we probably dont want to expose a list of all a users calendars to the end-user here.
     calendarID = calendarsList?.find((cal) => cal.is_primary)?.id || "";
   });
+
+  $: console.log({ editorManifest });
 
   $: {
     const rebuiltProps = buildInternalProps(
@@ -164,6 +175,11 @@
       internalProps.free_color,
       free_color,
       "#36d2ad66",
+    );
+    show_hosts = getPropertyValue(
+      internalProps.show_hosts || editorManifest.show_hosts,
+      show_hosts,
+      "show",
     );
   }
 
@@ -708,6 +724,7 @@
     }
     return classes.join(" ");
   }
+
   //#endregion Attendee Overlay
 
   // #region Date Change
@@ -1051,21 +1068,27 @@
           }
 
           .available-calendars {
-            display: inline-block;
+            display: none;
             position: relative;
             z-index: 2;
-            display: none; // TODO: temporary, until we rework this to not collide w/ time ranges
+            float: right;
 
             span {
               background: rgba(0, 0, 0, 0.5);
               display: inline-block;
-              margin: 0.25rem;
+              margin: 0;
               padding: 0.25rem;
-              font-size: 0.7rem;
               color: white;
+              border-radius: 4px;
+              font-size: 0.6rem;
+              // font-weight: 700;
             }
           }
         }
+      }
+
+      &:hover .epoch.partial .available-calendars {
+        display: block;
       }
 
       .slots {
@@ -1093,11 +1116,18 @@
             background-color: purple;
             box-shadow: none;
             border-bottom: 1px solid transparent;
+            z-index: 3;
           }
 
           &.pending {
             background-color: rgba(128, 0, 128, 0.3);
             box-shadow: 0 0 10px rgba(0, 0, 0, 0.25);
+            z-index: 3;
+          }
+
+          &.selected + .selected,
+          &.pending + .pending {
+            z-index: 2;
           }
 
           &.busy {
@@ -1286,14 +1316,16 @@
               data-end-time={new Date(epoch.end_time).toLocaleString()}
             >
               <div class="inner">
-                <div class="available-calendars">
-                  <span
-                    on:mouseenter={(event) => showOverlay(event, epoch)}
-                    on:mouseleave={hideOverlay}
-                  >
-                    {epoch.available_calendars.length} of {allCalendars.length}
-                  </span>
-                </div>
+                {#if show_hosts === "show"}
+                  <div class="available-calendars">
+                    <span
+                      on:mouseenter={(event) => showOverlay(event, epoch)}
+                      on:mouseleave={hideOverlay}
+                    >
+                      {epoch.available_calendars.length} of {allCalendars.length}
+                    </span>
+                  </div>
+                {/if}
               </div>
             </div>
           {/each}

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -66,7 +66,8 @@
           },
         ];
 
-        component.calendars = calendars;
+        //component.calendars = calendars;
+        component.email_ids = ["phil.r@nylas.com", "hazik.a@nylas.com"];
 
         component.addEventListener("timeSlotChosen", (event) => {
           console.log(event.detail.timeSlots);
@@ -357,7 +358,10 @@
         <nylas-availability
           allow_booking="true"
           max_bookable_slots="8"
-          id="demo-availability"
+          editor_id="demo-schedule-editor"
+          show_hosts="show"
+          show_as_week="true"
+          id="phils-availability"
         ></nylas-availability>
       </div>
     </main>

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -66,8 +66,7 @@
           },
         ];
 
-        //component.calendars = calendars;
-        component.email_ids = ["phil.r@nylas.com", "hazik.a@nylas.com"];
+        component.calendars = calendars;
 
         component.addEventListener("timeSlotChosen", (event) => {
           console.log(event.detail.timeSlots);
@@ -358,10 +357,7 @@
         <nylas-availability
           allow_booking="true"
           max_bookable_slots="8"
-          editor_id="demo-schedule-editor"
-          show_hosts="show"
-          show_as_week="true"
-          id="phils-availability"
+          id="demo-availability"
         ></nylas-availability>
       </div>
     </main>

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -67,6 +67,13 @@
 </script>
 
 <style lang="scss">
+  div {
+    border: 3px solid #f00;
+    strong {
+      display: block;
+      font-style: italic;
+    }
+  }
 </style>
 
 {#if manifest && manifest.error}
@@ -84,8 +91,8 @@
       <input type="text" bind:value={manifestProperties.event_description} />
     </label>
   </div>
-  <div>
-    <strong>Show meeting hosts to the end-user?</strong>
+  <div role="radiogroup" aria-labelledby="show_hosts">
+    <strong id="show_hosts">Show meeting hosts to the end-user?</strong>
     <label>
       <input
         type="radio"

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -14,6 +14,7 @@
   export let access_token: string = "";
   export let event_title: string;
   export let event_description: string;
+  export let show_hosts: "show" | "hide";
 
   //#region mount and prop initialization
   let internalProps: Partial<Manifest> = {};
@@ -47,37 +48,66 @@
       event_description,
       "",
     );
+    show_hosts = getPropertyValue(internalProps.show_hosts, show_hosts, "show");
   }
 
-  $: editableProperties = [
-    {
-      label: "Event Title",
-      value: event_title,
-    },
-    {
-      label: "Event Description",
-      value: event_description,
-    },
-  ];
+  $: manifestProperties = {
+    event_title,
+    event_description,
+    show_hosts,
+  };
   // #endregion mount and prop initialization
 
   function saveProperties() {
     console.log("Saving the following properties:");
-    console.log(editableProperties);
+    Object.entries(manifestProperties).forEach(([k, v]) => {
+      console.log(k, v);
+    });
   }
 </script>
 
 <style lang="scss">
+  fieldset {
+    margin: 0;
+    padding: 0;
+    border: 0;
+  }
 </style>
 
 {#if manifest && manifest.error}
   <nylas-domain-error {id} />
 {:else}
-  {#each editableProperties as prop}
+  <fieldset>
     <label>
-      <strong>{prop.label}</strong>
-      <input value={prop.value} />
+      <strong>Event Title</strong>
+      <input type="text" bind:value={manifestProperties.event_title} />
     </label>
-  {/each}
+  </fieldset>
+  <fieldset>
+    <label>
+      <strong>Event Description</strong>
+      <input type="text" bind:value={manifestProperties.event_description} />
+    </label>
+  </fieldset>
+  <fieldset>
+    <strong>Show meeting hosts to the end-user?</strong>
+    <label>
+      <input
+        type="radio"
+        bind:group={manifestProperties.show_hosts}
+        value="show"
+      />
+      <span>Show Hosts</span>
+    </label>
+    <label>
+      <input
+        type="radio"
+        bind:group={manifestProperties.show_hosts}
+        value="hide"
+      />
+      <span>Hide Hosts</span>
+    </label>
+  </fieldset>
+
   <button on:click={saveProperties}>Save Editor Options</button>
 {/if}

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -67,33 +67,29 @@
 </script>
 
 <style lang="scss">
-  fieldset {
-    margin: 0;
-    padding: 0;
-    border: 0;
-  }
 </style>
 
 {#if manifest && manifest.error}
   <nylas-domain-error {id} />
 {:else}
-  <fieldset>
+  <div>
     <label>
       <strong>Event Title</strong>
       <input type="text" bind:value={manifestProperties.event_title} />
     </label>
-  </fieldset>
-  <fieldset>
+  </div>
+  <div>
     <label>
       <strong>Event Description</strong>
       <input type="text" bind:value={manifestProperties.event_description} />
     </label>
-  </fieldset>
-  <fieldset>
+  </div>
+  <div>
     <strong>Show meeting hosts to the end-user?</strong>
     <label>
       <input
         type="radio"
+        name="show_hosts"
         bind:group={manifestProperties.show_hosts}
         value="show"
       />
@@ -102,12 +98,13 @@
     <label>
       <input
         type="radio"
+        name="show_hosts"
         bind:group={manifestProperties.show_hosts}
         value="hide"
       />
       <span>Hide Hosts</span>
     </label>
-  </fieldset>
+  </div>
 
   <button on:click={saveProperties}>Save Editor Options</button>
 {/if}


### PR DESCRIPTION
- adds show_hosts as a passable manifest property
- Fixes the issue where you couldn't overwrite a manifest-passed property on save by binding to an object property
- did away with an iterated array as questions to ask, to allow for better eventual template conditionals and customization.
- adds the ability for `availability` to receive an `editor_id`, like `scheduler`.
- `<nylas-availability>` now responds to `show_hosts`; will show available_calendars again if true (defaults to true)


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
