### PR TITLE
Load nylas-availability in the nylas-scheduler demo

### DIFF
--- a/components/scheduler/src/index.html
+++ b/components/scheduler/src/index.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8" />
     <title>Scheduler Demo</title>
     <script src="../index.js"></script>
+    <script src="../../availability/index.js"></script>
     <script>
       document.addEventListener("DOMContentLoaded", function () {
         const availability = document.querySelector("nylas-availability");


### PR DESCRIPTION
Noticed that [the current live demo of scheduler](https://components.nylas.io/components/scheduler/src/index.html) does not have a link to `<nylas-availability>`'s source; this adds it.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
