### PR TITLE
Nylas Availability: List view

### DIFF
--- a/commons/src/types/Availability.ts
+++ b/commons/src/types/Availability.ts
@@ -24,6 +24,7 @@ export interface Manifest extends NylasManifest {
   partial_color: string;
   free_color: string;
   busy_color: string;
+  view_as: "schedule" | "list";
 }
 
 export interface Calendar {

--- a/commons/src/types/ScheduleEditor.ts
+++ b/commons/src/types/ScheduleEditor.ts
@@ -23,4 +23,5 @@ export interface Manifest extends NylasManifest {
   notification_mode?: NotificationMode;
   notification_message?: string;
   notification_subject?: string;
+  view_as?: "schedule" | "list";
 }

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -944,6 +944,19 @@
     days = [...days]; // re-render
     resetDragState();
   }
+
+  // Click action for un-draggable slot-list buttons (list view)
+  function toggleSlot(slot: SelectableSlot) {
+    if (slot.selectionStatus === SelectionStatus.SELECTED) {
+      slot.selectionStatus = SelectionStatus.UNSELECTED;
+    } else {
+      if (slotSelection.length < max_bookable_slots) {
+        slot.selectionStatus = SelectionStatus.SELECTED;
+      }
+    }
+    days = [...days];
+  }
+
   //#endregion dragging
 </script>
 
@@ -1456,8 +1469,7 @@
                 data-start-time={new Date(slot.start_time).toLocaleString()}
                 data-end-time={new Date(slot.end_time).toLocaleString()}
                 on:click={() => {
-                  startDrag(slot, day);
-                  tick().then(() => endDrag(slot, day));
+                  toggleSlot(slot);
                 }}
               >
                 {new Date(slot.start_time).toLocaleTimeString([], {

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -63,6 +63,7 @@
   export let partial_color: string;
   export let free_color: string;
   export let show_hosts: "show" | "hide";
+  export let view_as: "schedule" | "list";
   //#endregion props
 
   //#region mount and prop initialization
@@ -178,6 +179,11 @@
       internalProps.show_hosts || editorManifest.show_hosts,
       show_hosts,
       "show",
+    );
+    view_as = getPropertyValue(
+      internalProps.view_as || editorManifest.view_as,
+      view_as,
+      "schedule",
     );
   }
 
@@ -1305,73 +1311,79 @@
             </span>
           </h2>
         </header>
-        <div class="epochs">
-          {#each day.epochs as epoch}
-            <div
-              class="epoch {epoch.status}"
-              style="height: {epoch.height}%; top: {epoch.offset}%;"
-              data-available-calendars={epoch.available_calendars.toString()}
-              data-start-time={new Date(epoch.start_time).toLocaleString()}
-              data-end-time={new Date(epoch.end_time).toLocaleString()}
-            >
-              <div class="inner">
-                {#if show_hosts === "show"}
-                  <div class="available-calendars">
-                    <span
-                      on:mouseenter={(event) => showOverlay(event, epoch)}
-                      on:mouseleave={hideOverlay}
-                    >
-                      {epoch.available_calendars.length} of {allCalendars.length}
-                    </span>
-                  </div>
-                {/if}
+        {#if view_as === "schedule"}
+          <div class="epochs">
+            {#each day.epochs as epoch}
+              <div
+                class="epoch {epoch.status}"
+                style="height: {epoch.height}%; top: {epoch.offset}%;"
+                data-available-calendars={epoch.available_calendars.toString()}
+                data-start-time={new Date(epoch.start_time).toLocaleString()}
+                data-end-time={new Date(epoch.end_time).toLocaleString()}
+              >
+                <div class="inner">
+                  {#if show_hosts === "show"}
+                    <div class="available-calendars">
+                      <span
+                        on:mouseenter={(event) => showOverlay(event, epoch)}
+                        on:mouseleave={hideOverlay}
+                      >
+                        {epoch.available_calendars.length} of {allCalendars.length}
+                      </span>
+                    </div>
+                  {/if}
+                </div>
               </div>
-            </div>
-          {/each}
-        </div>
-        <div class="slots">
-          {#each day.slots as slot}
-            <button
-              data-available-calendars={slot.available_calendars.toString()}
-              aria-label="{new Date(
-                slot.start_time,
-              ).toLocaleString()} to {new Date(
-                slot.end_time,
-              ).toLocaleString()}}; Free calendars: {slot.available_calendars.toString()}"
-              class="slot {slot.selectionStatus} {slot.availability}"
-              class:pending={slot.selectionPending}
-              data-start-time={new Date(slot.start_time).toLocaleString()}
-              data-end-time={new Date(slot.end_time).toLocaleString()}
-              on:mousedown={() => {
-                if (
-                  slotSelection.length < max_bookable_slots ||
-                  slot.selectionStatus === SelectionStatus.SELECTED
-                ) {
-                  mouseIsDown = true;
-                }
-                startDrag(slot, day);
-              }}
-              on:mouseenter={() => {
-                addToDrag(slot, day);
-              }}
-              on:mouseup={() => {
-                if (mouseIsDown) {
-                  endDrag(slot, day);
-                }
-              }}
-              on:keypress={(e) => {
-                if (e.code === "Space" || e.code === "Enter") {
+            {/each}
+          </div>
+          <div class="slots">
+            {#each day.slots as slot}
+              <button
+                data-available-calendars={slot.available_calendars.toString()}
+                aria-label="{new Date(
+                  slot.start_time,
+                ).toLocaleString()} to {new Date(
+                  slot.end_time,
+                ).toLocaleString()}}; Free calendars: {slot.available_calendars.toString()}"
+                class="slot {slot.selectionStatus} {slot.availability}"
+                class:pending={slot.selectionPending}
+                data-start-time={new Date(slot.start_time).toLocaleString()}
+                data-end-time={new Date(slot.end_time).toLocaleString()}
+                on:mousedown={() => {
+                  if (
+                    slotSelection.length < max_bookable_slots ||
+                    slot.selectionStatus === SelectionStatus.SELECTED
+                  ) {
+                    mouseIsDown = true;
+                  }
                   startDrag(slot, day);
-                  tick().then(() => endDrag(slot, day));
-                }
-              }}
-            >
-              {#if getBlockTimes(slot, day)}
-                <span class="selected-heading">{getBlockTimes(slot, day)}</span>
-              {/if}
-            </button>
-          {/each}
-        </div>
+                }}
+                on:mouseenter={() => {
+                  addToDrag(slot, day);
+                }}
+                on:mouseup={() => {
+                  if (mouseIsDown) {
+                    endDrag(slot, day);
+                  }
+                }}
+                on:keypress={(e) => {
+                  if (e.code === "Space" || e.code === "Enter") {
+                    startDrag(slot, day);
+                    tick().then(() => endDrag(slot, day));
+                  }
+                }}
+              >
+                {#if getBlockTimes(slot, day)}
+                  <span class="selected-heading"
+                    >{getBlockTimes(slot, day)}</span
+                  >
+                {/if}
+              </button>
+            {/each}
+          </div>
+        {:else if view_as === "list"}
+          <div class="slot-list" />
+        {/if}
       </div>
     {/each}
   </div>

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -1021,7 +1021,6 @@
       padding-top: $headerHeight;
       font-size: 0.8rem;
       font-family: sans-serif;
-      // text-align: right;
 
       li {
         display: block;
@@ -1030,7 +1029,6 @@
         overflow: hidden;
         padding: 0 0.25rem;
         display: grid;
-        // align-content: center;
         justify-content: right;
       }
     }
@@ -1039,7 +1037,6 @@
       display: grid;
       grid-template-rows: $headerHeight 1fr;
       position: relative;
-      // overflow: hidden;
 
       h2 {
         margin: 0;

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -949,10 +949,8 @@
   function toggleSlot(slot: SelectableSlot) {
     if (slot.selectionStatus === SelectionStatus.SELECTED) {
       slot.selectionStatus = SelectionStatus.UNSELECTED;
-    } else {
-      if (slotSelection.length < max_bookable_slots) {
-        slot.selectionStatus = SelectionStatus.SELECTED;
-      }
+    } else if (slotSelection.length < max_bookable_slots) {
+      slot.selectionStatus = SelectionStatus.SELECTED;
     }
     days = [...days];
   }

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -988,7 +988,25 @@
       grid-auto-flow: column;
       grid-auto-columns: 1fr;
       height: 100%;
-      overflow: hidden;
+      overflow: auto;
+
+      &.schedule {
+        overflow: hidden;
+      }
+      &.list {
+        .day {
+          display: block;
+
+          header {
+            position: sticky;
+            top: 0;
+            margin-top: 0;
+            background-color: white;
+            height: $headerHeight;
+            z-index: 2;
+          }
+        }
+      }
     }
 
     .ticks {
@@ -1021,8 +1039,7 @@
       display: grid;
       grid-template-rows: $headerHeight 1fr;
       position: relative;
-      height: 100%;
-      overflow: hidden;
+      // overflow: hidden;
 
       h2 {
         margin: 0;
@@ -1167,7 +1184,7 @@
         padding: 0;
 
         .slot {
-          border-radius: 8px;
+          border-radius: 4px;
           background: transparent;
           position: relative;
           align-items: center;
@@ -1175,10 +1192,16 @@
           align-content: center;
           font-family: sans-serif;
           border: 1px solid rgba(0, 0, 0, 0.1);
+          box-shadow: none !important;
+
+          &:hover {
+            box-shadow: none;
+            background-color: rgba(0, 0, 0, 0.1);
+          }
 
           &.selected {
-            border-color: purple;
-            // box-shadow: none;
+            background: purple;
+            color: white;
           }
 
           .partial {
@@ -1330,7 +1353,11 @@
       {/each}
     </ul>
   {/if}
-  <div class="days">
+  <div
+    class="days"
+    class:schedule={view_as === "schedule"}
+    class:list={view_as === "list"}
+  >
     {#each days as day}
       <div class="day">
         <header>

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -1202,9 +1202,12 @@
           border: 1px solid rgba(0, 0, 0, 0.1);
           box-shadow: none !important;
 
-          &:hover {
-            box-shadow: none;
-            background-color: rgba(0, 0, 0, 0.1);
+          @media (hover: hover) and (pointer: fine) {
+            // prevents touch-deselect hover state color
+            &:hover {
+              box-shadow: none;
+              background-color: rgba(0, 0, 0, 0.1);
+            }
           }
 
           &.selected {

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -66,7 +66,8 @@
           },
         ];
 
-        component.calendars = calendars;
+        //component.calendars = calendars;
+        component.email_ids = ["phil.r@nylas.com", "hazik.a@nylas.com"];
 
         component.addEventListener("timeSlotChosen", (event) => {
           console.log(event.detail.timeSlots);
@@ -374,7 +375,8 @@
         <nylas-availability
           allow_booking="true"
           max_bookable_slots="8"
-          id="demo-availability"
+          id="phils-availability"
+          view_as="list"
         ></nylas-availability>
       </div>
     </main>

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -148,6 +148,12 @@
             component[type] = event.target.value;
           });
         });
+
+        document.querySelectorAll('input[name="view-as"]').forEach((elem) => {
+          elem.addEventListener("input", function (event) {
+            component.view_as = event.target.value;
+          });
+        });
       });
     </script>
     <style>
@@ -348,6 +354,17 @@
             value="#aeedde"
           />
           Free color
+        </label>
+      </fieldset>
+      <fieldset>
+        <legend>View As</legend>
+        <label>
+          <input checked type="radio" name="view-as" value="schedule" />
+          Schedule
+        </label>
+        <label>
+          <input type="radio" name="view-as" value="list" />
+          List
         </label>
       </fieldset>
     </aside>

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -66,8 +66,7 @@
           },
         ];
 
-        //component.calendars = calendars;
-        component.email_ids = ["phil.r@nylas.com", "hazik.a@nylas.com"];
+        component.calendars = calendars;
 
         component.addEventListener("timeSlotChosen", (event) => {
           console.log(event.detail.timeSlots);
@@ -375,8 +374,7 @@
         <nylas-availability
           allow_booking="true"
           max_bookable_slots="8"
-          id="phils-availability"
-          view_as="list"
+          id="demo-availability"
         ></nylas-availability>
       </div>
     </main>

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -652,8 +652,7 @@ describe("availability component", () => {
     });
   });
 
-  describe.only("list view", () => {
-    // TODO
+  describe("list view", () => {
     it("Shows scheduler view by default", () => {
       cy.get("nylas-availability")
         .as("availability")

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -651,4 +651,29 @@ describe("availability component", () => {
         });
     });
   });
+
+  describe.only("list view", () => {
+    // TODO
+    it("Shows scheduler view by default", () => {
+      cy.get("nylas-availability")
+        .as("availability")
+        .then(() => {
+          cy.get(".epochs").should("exist");
+          cy.get(".slots").should("exist");
+          cy.get(".slot-list").should("not.exist");
+        });
+    });
+    it("Shows list view by passed property", () => {
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.view_as = "list";
+
+          cy.get(".epochs").should("not.exist");
+          cy.get(".slots").should("not.exist");
+          cy.get(".slot-list").should("exist");
+        });
+    });
+  });
 });

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -34,6 +34,7 @@
   export let notification_mode: NotificationMode;
   export let notification_message: string;
   export let notification_subject: string;
+  export let view_as: "schedule" | "list";
 
   //#region mount and prop initialization
   let internalProps: Partial<Manifest> = {};
@@ -77,6 +78,7 @@
       event_location,
       "",
     );
+    view_as = getPropertyValue(internalProps.view_as, view_as, "schedule");
     show_hosts = getPropertyValue(internalProps.show_hosts, show_hosts, "show");
     start_hour = getPropertyValue(internalProps.start_hour, start_hour, 0);
     end_hour = getPropertyValue(internalProps.end_hour, end_hour, 24);
@@ -166,6 +168,7 @@
     notification_mode,
     notification_message,
     notification_subject,
+    view_as,
   };
 
   $: console.table(manifestProperties);
@@ -417,6 +420,27 @@
     <label>
       <strong>Notification Subject</strong>
       <input type="text" bind:value={manifestProperties.notification_subject} />
+    </label>
+  </div>
+  <div role="radiogroup" aria-labelledby="view_as">
+    <strong id="view_as">View as a Schedule, or as a List?</strong>
+    <label>
+      <input
+        type="radio"
+        name="view_as"
+        bind:group={manifestProperties.view_as}
+        value="schedule"
+      />
+      <span>Schedule</span>
+    </label>
+    <label>
+      <input
+        type="radio"
+        name="view_as"
+        bind:group={manifestProperties.view_as}
+        value="list"
+      />
+      <span>List</span>
     </label>
   </div>
   <button on:click={saveProperties}>Save Editor Options</button>

--- a/components/scheduler/src/index.html
+++ b/components/scheduler/src/index.html
@@ -11,7 +11,12 @@
         const availability = document.querySelector("nylas-availability");
         const scheduler = document.querySelector("nylas-scheduler");
 
-        availability.email_ids = ["nylascypresstest@gmail.com"];
+        availability.email_ids = [
+          "phil.r@nylas.com",
+          "chantal.l@nylas.com",
+          "david.t@nylas.com",
+          "hazik.a@nylas.com",
+        ];
         availability.addEventListener("timeSlotChosen", (event) => {
           scheduler.slots_to_book = event.detail.timeSlots;
         });
@@ -32,9 +37,9 @@
         margin-left: 10vw;
         height: 80vh;
         margin-top: 10vh;
-
         display: grid;
         grid-template-columns: 2fr 1fr;
+        grid-template-rows: 100%;
         gap: 1rem;
       }
     </style>
@@ -46,9 +51,12 @@
         show_as_week="true"
         allow_booking="true"
         max_bookable_slots="8"
-        id="demo-availability"
+        id="phils-availability"
         editor_id="demo-schedule-editor"
-        slot_size="60"
+        slot_size="15"
+        view_as="list"
+        start_hour="9"
+        end_hour="17"
       >
       </nylas-availability>
       <nylas-scheduler

--- a/components/scheduler/src/index.html
+++ b/components/scheduler/src/index.html
@@ -49,7 +49,6 @@
         id="demo-availability"
         editor_id="demo-schedule-editor"
         slot_size="10"
-        view_as="list"
         start_hour="9"
         end_hour="17"
       >

--- a/components/scheduler/src/index.html
+++ b/components/scheduler/src/index.html
@@ -11,12 +11,7 @@
         const availability = document.querySelector("nylas-availability");
         const scheduler = document.querySelector("nylas-scheduler");
 
-        availability.email_ids = [
-          "phil.r@nylas.com",
-          "chantal.l@nylas.com",
-          "david.t@nylas.com",
-          "hazik.a@nylas.com",
-        ];
+        availability.email_ids = ["nylascypresstest@gmail.com"];
         availability.addEventListener("timeSlotChosen", (event) => {
           scheduler.slots_to_book = event.detail.timeSlots;
         });
@@ -51,9 +46,9 @@
         show_as_week="true"
         allow_booking="true"
         max_bookable_slots="8"
-        id="phils-availability"
+        id="demo-availability"
         editor_id="demo-schedule-editor"
-        slot_size="15"
+        slot_size="10"
         view_as="list"
         start_hour="9"
         end_hour="17"


### PR DESCRIPTION
- Introduces a new `view_as` property with options of `schedule` (default) or `list`
- List view shows buttons consecutively without any height-based availability or styling. Hides all busy times.
- Also adds the properties to `<nylas-schedule-editor>` for manifest manipulation later

![CleanShot 2021-09-20 at 16 52 00](https://user-images.githubusercontent.com/713991/134073994-3df02699-70e3-4755-b57b-a1cbef08b1ee.png)

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
