### PR TITLE
Nylas availability: mobile view

### DIFF
--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -255,38 +255,16 @@
   const dispatchEvent = getEventDispatcher(get_current_component());
 
   //#region layout
+
   let main: HTMLElement;
   let tickContainer: HTMLElement;
   let dayContainerWidth: number = 0;
-  // $: dayWidth = dayWidths[0];
   let clientHeight: number;
 
   const MINIMUM_DAY_WIDTH = 100;
 
   // Internally-settable reactive-to-external-props variable
   let datesToShow: number;
-  // $: {
-  //   if (
-  //     $$props.hasOwnProperty("dates_to_show") &&
-  //     $$props.dates_to_show !== datesToShow
-  //   ) {
-  //     datesToShow = getPropertyValue(
-  //       internalProps.dates_to_show,
-  //       1,
-  //       1,
-  //     );
-  //   } else if (!datesToShow) {
-  //     datesToShow = +dates_to_show;
-  //   }
-  // }
-
-  // function establishDatesToShow(width, intervalCounter = 0) {
-  //   console.log('esty', intervalCounter);
-  //   if (intervalCounter < dates_to_show && width < MINIMUM_DAY_WIDTH) {
-  //     return establishDatesToShow(width, intervalCounter+1)
-  //   }
-  //   return dates_to_show - intervalCounter;
-  // }
 
   $: optimalDatesToShow =
     Math.floor(dayContainerWidth / MINIMUM_DAY_WIDTH) || 1;
@@ -296,51 +274,6 @@
       : dates_to_show;
 
   $: tooSmallForWeek = show_as_week && optimalDatesToShow < 7;
-  $: console.log(
-    { dayContainerWidth },
-    { optimalDatesToShow },
-    { datesToShow },
-    { tooSmallForWeek },
-  );
-  // $: datesToShow = establishDatesToShow(dayWidth);
-
-  $: console.log({ datesToShow });
-
-  // $: console.log({dayWidth});
-
-  // $: needsToDropOne =
-  //   dates_to_show > 1
-  //   // && datesToShow < dates_to_show
-  //   && dayWidth - (dayWidth / (datesToShow + 1)) < MINIMUM_DAY_WIDTH;
-
-  // $: console.log('what would doing one more do?', {dayWidth}, dayWidth - (dayWidth / (datesToShow + 1)), needsToDropOne);
-
-  // $: if (dayWidth - (dayWidth / (datesToShow + 1)) < MINIMUM_DAY_WIDTH) {
-  //   console.log('ya');
-  //   datesToShow = datesToShow - 1;
-  // } else {
-  //   datesToShow = datesToShow - 1;
-  // }
-  ////////////////////////////////////////
-  // $: {
-  //   if (dates_to_show > 1) {
-  //     if (dayWidth < MINIMUM_DAY_WIDTH) {
-  //       console.log('111');
-  //       datesToShow = datesToShow - 1;
-  //     // } else if (dayWidth + (dayWidth * dayWidth / (datesToShow + 1)) < MINIMUM_DAY_WIDTH) {
-  //     //   console.log('222');
-  //     //   datesToShow = datesToShow + 1;
-  //     } else {
-  //       console.log('222');
-  //       datesToShow = datesToShow;
-  //     }
-  //   }
-  // }
-  //   // && datesToShow < dates_to_show
-  //   && (dayWidth * dayWidth / (datesToShow + 1)) < MINIMUM_DAY_WIDTH) {
-  //   console.log('OH NO')
-  //   datesToShow = datesToShow - 1;
-  // }
 
   //#endregion layout
 
@@ -572,7 +505,6 @@
     startDay: Date,
     endDay: Date,
     reverse?: boolean,
-    intervalCounter: number = 0,
   ): Date[] {
     let range = scaleTime()
       .domain([startDay, endDay])
@@ -592,14 +524,6 @@
         return generateDayRange(startDay, timeDay.offset(endDay, 1));
       }
     }
-    // if (dayWidth - (dayWidth / (datesToShow + 1)) < MINIMUM_DAY_WIDTH)
-    // if (dayWidth > 0 && dayWidth < MINIMUM_DAY_WIDTH && intervalCounter === 0) {
-    //   console.log('oh no!');
-    //   console.log('hmm',  generateDayRange(startDay, endDay, reverse, intervalCounter + 1), dayWidth);
-    //   return generateDayRange(startDay, endDay, reverse, intervalCounter + 1);
-    // } else {
-    //   console.log('u good bb');
-    // }
     return range;
   }
 

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -123,6 +123,7 @@
   onMount(async () => {
     await tick();
     clientHeight = main?.getBoundingClientRect().height;
+    dayContainerWidth = main?.getBoundingClientRect().height;
     const storeKey = JSON.stringify({
       component_id: id,
       access_token,
@@ -258,6 +259,7 @@
 
   let main: HTMLElement;
   let tickContainer: HTMLElement;
+  let dayContainer: HTMLElement;
   let dayContainerWidth: number = 0;
   let clientHeight: number;
 
@@ -1431,6 +1433,7 @@
     class="days"
     class:schedule={view_as === "schedule"}
     class:list={view_as === "list"}
+    bind:this={dayContainer}
     bind:clientWidth={dayContainerWidth}
   >
     {#each days as day}

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -1433,7 +1433,7 @@
     class:list={view_as === "list"}
     bind:clientWidth={dayContainerWidth}
   >
-    {#each days as day, iter}
+    {#each days as day}
       <div class="day">
         <header>
           <h2>

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -291,8 +291,17 @@
   $: optimalDatesToShow =
     Math.floor(dayContainerWidth / MINIMUM_DAY_WIDTH) || 1;
   $: datesToShow =
-    optimalDatesToShow < dates_to_show ? optimalDatesToShow : dates_to_show;
-  $: console.log({ dayContainerWidth }, { optimalDatesToShow });
+    optimalDatesToShow < dates_to_show || show_as_week
+      ? optimalDatesToShow
+      : dates_to_show;
+
+  $: tooSmallForWeek = show_as_week && optimalDatesToShow < 7;
+  $: console.log(
+    { dayContainerWidth },
+    { optimalDatesToShow },
+    { datesToShow },
+    { tooSmallForWeek },
+  );
   // $: datesToShow = establishDatesToShow(dayWidth);
 
   $: console.log({ datesToShow });
@@ -348,13 +357,14 @@
     generateDayRange(
       startDay, // TODO: weird just to get show_weekends passed in
       show_as_week
-        ? timeDay.offset(startDay, 6)
+        ? timeDay.offset(startDay, tooSmallForWeek ? datesToShow - 1 : 6)
         : timeDay.offset(startDay, datesToShow - 1),
     );
 
-  $: startDay = show_as_week
-    ? timeWeek.floor(startDate)
-    : timeDay.floor(startDate);
+  $: startDay =
+    show_as_week && !tooSmallForWeek
+      ? timeWeek.floor(startDate)
+      : timeDay.floor(startDate);
 
   $: endDay = dayRange[dayRange.length - 1];
 
@@ -862,7 +872,7 @@
     if ($$props.start_date) {
       delete $$props.start_date;
     }
-    if (show_as_week) {
+    if (show_as_week && !tooSmallForWeek) {
       startDate = timeWeek.offset(endDay, 1);
     } else {
       startDate = timeDay.offset(endDay, 1);
@@ -872,7 +882,7 @@
     if ($$props.start_date) {
       delete $$props.start_date;
     }
-    if (show_as_week) {
+    if (show_as_week && !tooSmallForWeek) {
       startDate = timeWeek.offset(startDay, -1);
     } else {
       // Can't do something as simple as `start_date = timeDay.offset(startDay, -datesToShow)` here;

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -290,6 +290,7 @@ describe("availability component", () => {
     });
 
     it("Updates dates_to_show via component prop", () => {
+      cy.viewport(1500, 550);
       cy.get("nylas-availability")
         .as("availability")
         .then((element) => {
@@ -607,6 +608,7 @@ describe("availability component", () => {
         });
     });
     it("Moves a full week on prev/next push", () => {
+      cy.viewport(1500, 550);
       cy.get("nylas-availability")
         .as("availability")
         .then((element) => {

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -462,6 +462,10 @@ describe("availability component", () => {
   });
 
   describe("weeks and weekends", () => {
+    beforeEach(() => {
+      cy.viewport(1500, 550);
+    });
+
     it("Handles week_view false", () => {
       cy.get("nylas-availability")
         .as("availability")

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -675,4 +675,70 @@ describe("availability component", () => {
         });
     });
   });
+
+  describe("Limiting screen size", () => {
+    it("Cuts off the number of days if they drop below 100px in width", () => {
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.dates_to_show = 7;
+          cy.viewport(1500, 550);
+          cy.get(".days .day").should("have.length", 7);
+          cy.viewport(1200, 550);
+          cy.get(".days .day").should("have.length", 6);
+          cy.viewport(600, 550);
+          cy.get(".days .day").should("have.length", 1);
+          cy.viewport(3000, 550);
+          cy.get(".days .day").should("have.length", 7);
+        });
+    });
+    it("Allows you to navigate a squashed schedule", () => {
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.dates_to_show = 7;
+          component.start_date = new Date("2021-04-06 00:00");
+          component.show_as_week = false;
+          cy.viewport(800, 550);
+          cy.get("div.day:eq(0) header h2").contains("Tuesday");
+          cy.get("div.day:eq(2) header h2").contains("Thursday");
+          cy.get("div.day:eq(3)").should("not.exist");
+          cy.get(".change-dates button:eq(1)").click();
+          cy.get(".day:eq(0) header h2").contains("Friday");
+          cy.get(".day:eq(1) header h2").contains("Saturday");
+        });
+    });
+    it("Handles show_as_week gracefully when squashed", () => {
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.dates_to_show = 7;
+          component.start_date = new Date("2021-04-06 00:00");
+          component.show_as_week = true;
+          cy.viewport(1800, 550);
+          cy.get("div.day:eq(0) header h2").contains("Sunday");
+          cy.get("div.day:eq(0) header h2").contains("4");
+          cy.get("div.day:eq(2) header h2").contains("Tuesday");
+          cy.get(".days .day").should("have.length", 7);
+          cy.viewport(800, 550);
+          cy.get("div.day:eq(0) header h2").contains("Tuesday");
+          cy.get(".days .day").should("have.length", 3);
+          cy.get(".change-dates button:eq(1)").click();
+          cy.get(".day:eq(0) header h2").contains("Friday");
+          cy.get(".day:eq(1) header h2").contains("Saturday");
+          cy.get(".change-dates button:eq(0)").click();
+          cy.get(".change-dates button:eq(0)").click();
+          cy.get(".day:eq(0) header h2").contains("Saturday");
+          cy.get(".day:eq(1) header h2").contains("Sunday");
+          cy.get(".days .day").should("have.length", 3);
+          cy.viewport(1800, 550);
+          cy.get("div.day:eq(0) header h2").contains("Sunday");
+          cy.get("div.day:eq(0) header h2").contains("28");
+          cy.get("div.day:eq(2) header h2").contains("Tuesday");
+        });
+    });
+  });
 });


### PR DESCRIPTION
Lets the availability component (and therefore scheduler component) gracefully reduce the number of dates shown when browser width is reduced, such as on mobile.

![squishy-avail](https://user-images.githubusercontent.com/713991/134534629-acc524cb-cdf5-49ab-b9df-0f449fb7c866.gif)

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
