### PR TITLE
Ali/ch67647/schedule editor field overbooked threshold

### DIFF
--- a/commons/src/types/Availability.ts
+++ b/commons/src/types/Availability.ts
@@ -25,6 +25,7 @@ export interface Manifest extends NylasManifest {
   free_color: string;
   busy_color: string;
   view_as: "schedule" | "list";
+  overbooked_threshold: number;
 }
 
 export interface Calendar {

--- a/commons/src/types/ScheduleEditor.ts
+++ b/commons/src/types/ScheduleEditor.ts
@@ -24,4 +24,5 @@ export interface Manifest extends NylasManifest {
   notification_message?: string;
   notification_subject?: string;
   view_as?: "schedule" | "list";
+  overbooked_threshold: number;
 }

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -63,6 +63,7 @@
   export let free_color: string;
   export let show_hosts: "show" | "hide";
   export let view_as: "schedule" | "list";
+  export let overbooked_threshold: number;
 
   /**
    * Re-loads availability data from the Nylas API.
@@ -231,6 +232,11 @@
       internalProps.view_as || editorManifest.view_as,
       view_as,
       "schedule",
+    );
+    overbooked_threshold = getPropertyValue(
+      internalProps.overbooked_threshold || editorManifest.overbooked_threshold,
+      overbooked_threshold,
+      100,
     );
   }
 

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -12,6 +12,9 @@
         const startTimeInput = document.querySelector("input#start-time");
         const endTimeInput = document.querySelector("input#end-time");
         const daysInput = document.querySelector("input#days-to-show");
+        const overbookedThresholdInput = document.querySelector(
+          "input#overbooked-threshold",
+        );
 
         const calendars = [
           {
@@ -82,6 +85,11 @@
 
         daysInput.addEventListener("input", (event) => {
           component.dates_to_show = parseInt(event.target.value);
+        });
+
+        overbookedThresholdInput.addEventListener("input", (event) => {
+          component.overbooked_threshold = parseInt(event.target.value);
+          console.log("threshold", component.overbooked_threshold);
         });
 
         document.querySelectorAll('input[name="slot-size"]').forEach((elem) => {
@@ -242,6 +250,20 @@
         <label>
           <input type="radio" name="slot-size" value="60" />
           60 minutes
+        </label>
+      </fieldset>
+
+      <fieldset>
+        <legend>Overbooked Threshold</legend>
+        <label>
+          <input
+            id="overbooked-threshold"
+            type="range"
+            min="0"
+            max="100"
+            step="1"
+            value="100"
+          />
         </label>
       </fieldset>
 

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -89,7 +89,6 @@
 
         overbookedThresholdInput.addEventListener("input", (event) => {
           component.overbooked_threshold = parseInt(event.target.value);
-          console.log("threshold", component.overbooked_threshold);
         });
 
         document.querySelectorAll('input[name="slot-size"]').forEach((elem) => {


### PR DESCRIPTION
- Added overbooked_threshold input field to the Availability component
- Added overbooked_threshold to the Availability and ScheduleEditor manifest interfaces
- Added overbooked_threshold logic to check if the booked slots are over the threshold, and if so, update the slots as busy

Identified issue:
In some cases, the first few slots remain `partial` or `free` despite the overbooked_threshold value being 0, which shouldn't be the case. Exploring this right now, and any suggestions are appreciated. 

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
