### PR TITLE
multi calendar overbooked threshold demo

### DIFF
--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -521,7 +521,7 @@
   function checkOverbooked(slots: SelectableSlot[]) {
     allCalendars.forEach((calendar) => {
       let availableSlotsForCalendar = slots.filter((slot) =>
-        slot.available_calendars.includes(calendar.account.emailAddress),
+        slot.available_calendars.includes(calendar.account?.emailAddress),
       );
       if (
         availableSlotsForCalendar.length >
@@ -529,7 +529,7 @@
       ) {
         availableSlotsForCalendar.forEach((slot) => {
           slot.available_calendars = slot.available_calendars.filter(
-            (cal) => cal !== calendar.account.emailAddress,
+            (cal) => cal !== calendar.account?.emailAddress,
           );
           if (!slot.available_calendars.length) {
             // if it has no calendars avialble, it's busy

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -303,8 +303,6 @@
       new Date(new Date(timestamp).setHours(start_hour)),
     );
     const dayEnd = timeHour(new Date(new Date(timestamp).setHours(end_hour)));
-    const totalSlots: number = 1440 / slot_size;
-    let busySlots: [{ startTime: Date; endTime: Date }] | [] = [];
     return scaleTime()
       .domain([dayStart, dayEnd])
       .ticks(timeMinute.every(slot_size) as TimeInterval)
@@ -321,18 +319,6 @@
             if (calendar.availability === AvailabilityStatus.BUSY) {
               if (!availabilityExistsInSlot) {
                 freeCalendars.push(calendar?.account?.emailAddress || "");
-                // } else {
-                //   if (
-                //     !busySlots.some(
-                //       (slot: { startTime: Date; endTime: Date }) => {
-                //         return (
-                //           slot.startTime === time && slot.endTime === endTime
-                //         );
-                //       },
-                //     )
-                //   ) {
-                //     busySlots.push({ startTime: time, endTime: endTime });
-                //   }
               }
             } else if (
               calendar.availability === AvailabilityStatus.FREE ||
@@ -912,7 +898,6 @@
           ) || null;
       } else if (
         slotSelection.length < max_bookable_slots &&
-        // (freeSlots/totalSlots * 100) < overbooked_threshold &&
         slot.availability !== AvailabilityStatus.BUSY
       ) {
         slot.selectionPending = true;


### PR DESCRIPTION
Introduces a second-pass iterator over day.slots[]; observes if the whole of them are greater than the overbooked threshold on a per-calendar basis, and if so, books all other slots as busy.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
