### PR TITLE
[Email]: Fix responsiveness for received timestamp]

### DIFF
--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -918,7 +918,7 @@
         .from-participants {
           max-width: 220px;
           display: grid;
-          grid-template-columns: 1fr 60px;
+          grid-template-columns: 1fr fit-content(60px);
           .participants-name {
             .from-sub-section.second {
               display: none;
@@ -1092,7 +1092,7 @@
 
         .subject-snippet-date {
           display: grid;
-          grid-template-columns: auto 120px;
+          grid-template-columns: 1fr fit-content(120px);
           gap: 1rem;
           .desktop-subject-snippet {
             display: block;

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -665,14 +665,11 @@
         flex-wrap: wrap;
         display: grid;
         align-items: center;
-        grid-template-areas:
-          "from-star subject-snippet-date"
-          "mobile-subject-snippet mobile-subject-snippet";
+        grid-template-columns: fit-content(350px) 1fr;
         .from-star {
           display: grid;
           grid-template-columns: 25px auto;
           column-gap: $spacing-xs;
-          grid-area: from-star;
         }
 
         .mobile-subject-snippet {
@@ -680,7 +677,6 @@
           font-size: 14px;
           margin-top: $spacing-xs;
           flex-basis: 100%;
-          grid-area: mobile-subject-snippet;
           .subject {
             text-overflow: ellipsis;
             white-space: nowrap;
@@ -914,7 +910,7 @@
       .from-message-count {
         align-items: center;
         display: grid;
-        grid-template-columns: repeat(4, auto);
+        grid-template-columns: repeat(3, auto);
         grid-gap: $spacing-m;
         justify-content: flex-start;
         max-width: 350px;
@@ -939,7 +935,6 @@
         }
       }
       .subject-snippet-date {
-        grid-area: subject-snippet-date;
         .desktop-subject-snippet {
           display: none;
         }
@@ -993,6 +988,7 @@
     main {
       .email-row {
         .from-message-count {
+          max-width: 350px;
           .from-participants {
             .participants-name {
               overflow: hidden;
@@ -1030,10 +1026,8 @@
           display: grid;
           column-gap: $spacing-m;
           height: $collapsed-height;
-          grid-template-areas: "from-star subject-snippet-date";
-          grid-template-columns: 350px auto;
+          grid-template-columns: fit-content(350px) 1fr;
           justify-content: initial;
-
           div.starred {
             button {
               &:hover:before {

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -810,7 +810,7 @@
               display: block;
               max-width: 90vw;
               color: var(--grey);
-              margin-top: $spacing-m;
+              margin-top: $spacing-xs;
             }
             div.message-head {
               .avatar-from {
@@ -840,6 +840,7 @@
           div.message-head {
             display: flex;
             justify-content: space-between;
+            align-items: center;
           }
           div.message-date {
             display: flex;


### PR DESCRIPTION
Updated styles to make the received timestamp responsive.

# Screenshots:

## Before:
![image](https://user-images.githubusercontent.com/16315004/134993031-cc4805ac-bb3e-4cfe-96fb-44b3a7b97487.png)

## After:
![image](https://user-images.githubusercontent.com/16315004/134992456-9af509ae-1fe1-4668-a965-e03a2f2819bd.png)
![image](https://user-images.githubusercontent.com/16315004/134992482-b1d8ec5a-9a1f-4ecf-b03e-8f823fc091eb.png)
![image](https://user-images.githubusercontent.com/16315004/134992905-ce549ba8-630a-4593-884e-3529b0f54b4a.png)

# Readiness checklist

- [X] Cypress tests passing?

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
