### PR TITLE
[composer] Made the `value` prop reactive.

### DIFF
--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -128,9 +128,6 @@
         JSON.stringify({ component_id: id, access_token })
       ]) || {};
 
-    if (value) {
-      mergeMessage(value);
-    }
     if (manifest && id) {
       const account: Account = await fetchAccount({
         component_id: id,
@@ -163,6 +160,10 @@
     if (JSON.stringify(rebuiltProps) !== JSON.stringify(internalProps)) {
       internalProps = rebuiltProps;
     }
+  }
+
+  $: if (value) {
+    mergeMessage(value);
   }
 
   $: {

--- a/components/composer/src/init.spec.js
+++ b/components/composer/src/init.spec.js
@@ -189,7 +189,7 @@ describe("Composer html", () => {
     });
 
     it("shows template", () => {
-      element.value.body = "";
+      element.value = { body: "" };
       element.template = `Hey what up!<br />
       <br />
       <br />
@@ -433,11 +433,13 @@ describe("Composer html", () => {
     });
 
     it("Replaces merge fields as defined in replace_fields when passed as a strinigfied version", () => {
-      element.value.body = `[hi] what up!<br />
+      element.value = {
+        body: `[hi] what up!<br />
       <br />
       <br />
       Thanks,
-      -Phil`;
+      -Phil`,
+      };
       cy.get("nylas-composer")
         .as("composer")
         .then((el) => {
@@ -459,11 +461,13 @@ describe("Composer html", () => {
     });
 
     it("Replaces merge fields as defined in replace_fields when passed a prop", () => {
-      element.value.body = `[hi] what up!<br />
+      element.value = {
+        body: `[hi] what up!<br />
       <br />
       <br />
       Thanks,
-      -Phil`;
+      -Phil`,
+      };
       cy.get("nylas-composer")
         .as("composer")
         .then((el) => {

--- a/components/composer/src/init.spec.js
+++ b/components/composer/src/init.spec.js
@@ -275,6 +275,19 @@ describe("Composer html", () => {
       cy.wait(75);
       cy.contains("async@test.com");
     });
+
+    it("Has a reactive value prop", () => {
+      cy.get("nylas-composer").should("exist").as("composer");
+      cy.get("header"); // wait for component to render
+
+      cy.get("@composer").then((el) => {
+        const component = el[0];
+        component.value = { body: "Test reactive prop" };
+        cy.get(".html-editor[contenteditable=true]")
+          .invoke("prop", "innerHTML")
+          .should("include", "Test reactive prop");
+      });
+    });
   });
 
   describe("Composer actions", () => {


### PR DESCRIPTION
- [x] Previously the `value` prop could only be set at instantiation of the composer component. This prevented users from being able to change its value dynamically via JS like `element.value = { ...newValues }`.
- [x] Un-supported BC break: you can no longer set `element.value.property = change`  and expect any reactive changes. You must set a new object e.g `element.value = { property: change }` to trigger Svelte's reactive re-render. Tests have been updated to reflect this. 

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
