### PR TITLE
[Mailbox][Conversation]: Fixed 'id' requirement for manually passed data

### DIFF
--- a/commons/src/store/contacts.ts
+++ b/commons/src/store/contacts.ts
@@ -37,11 +37,11 @@ function initializeContacts() {
             }
           })
           .catch(() => []);
+        update((contacts) => {
+          contacts[queryKey] = contactsMap[queryKey];
+          return { ...contacts };
+        });
       }
-      update((contacts) => {
-        contacts[queryKey] = contactsMap[queryKey];
-        return { ...contacts };
-      });
       return contactsMap[queryKey];
     },
     reset: () => set({}),

--- a/components/conversation/src/Conversation.svelte
+++ b/components/conversation/src/Conversation.svelte
@@ -240,11 +240,11 @@
 
   function _sendMessage(e) {
     e.preventDefault();
+    dispatchEvent("sendMessageClicked", {
+      event: e,
+      message: { ...reply, body: replyBody },
+    });
     if (!conversation && conversationManuallyPassed) {
-      dispatchEvent("sendMessageClicked", {
-        event: e,
-        message: { ...reply, body: replyBody },
-      });
       replyBody = "";
       return;
     }

--- a/components/conversation/src/Conversation.svelte
+++ b/components/conversation/src/Conversation.svelte
@@ -43,13 +43,18 @@
   const dispatchEvent = getEventDispatcher(get_current_component());
   $: dispatchEvent("manifestLoaded", manifest);
 
+  let conversationManuallyPassed: boolean;
+  $: conversationManuallyPassed = !!messages && messages.length > 0;
+
   onMount(async () => {
     manifest = ((await $ManifestStore[
       JSON.stringify({ component_id: id, access_token })
     ]) || {}) as ConversationProperties;
   });
 
-  $: messages = conversation?.messages || [];
+  $: conversationMessages = conversationManuallyPassed
+    ? messages
+    : conversation?.messages || [];
 
   let participants: Participant[] = [];
   $: participants = conversation?.participants || [];
@@ -99,11 +104,17 @@
   $: {
     if (id && thread_id) {
       setConversation();
+    } else if (conversationManuallyPassed) {
+      status = "loaded";
     }
   }
 
   $: {
-    if (messages.length && !messages.filter((m) => m.conversation).length) {
+    if (
+      !conversationManuallyPassed &&
+      conversationMessages.length &&
+      !conversationMessages.filter((m) => m.conversation).length
+    ) {
       cleanConversation();
     }
   }
@@ -159,16 +170,15 @@
 
   let replyBody = "";
 
-  const handleContactsChange = (field: "to" | "from" | "cc") => (
-    data: Participant[],
-  ) => {
-    reply[field] = data;
-  };
+  const handleContactsChange =
+    (field: "to" | "from" | "cc") => (data: Participant[]) => {
+      reply[field] = data;
+    };
 
   let lastMessage: Message;
   let lastMessageInitialised = false;
-  $: if (messages) {
-    lastMessage = messages[messages.length - 1];
+  $: if (conversationMessages) {
+    lastMessage = conversationMessages[conversationMessages.length - 1];
     lastMessageInitialised = true;
   }
 
@@ -210,20 +220,54 @@
   function cleanConversation() {
     fetchCleanConversations({
       component_id: id,
-      message_id: messages
+      message_id: conversationMessages
         .slice(-CONVERSATION_ENDPOINT_MAX_MESSAGES)
         .map((message) => message.id),
     }).then((results) => {
       results.forEach((msg: Message) => {
-        let existingMessage = messages.find((message) => message.id === msg.id);
+        let existingMessage = conversationMessages.find(
+          (message) => message.id === msg.id,
+        );
         if (existingMessage) {
           existingMessage.conversation = msg.conversation;
           existingMessage.body = msg.body;
         }
       });
-      messages = messages;
+      conversationMessages = conversationMessages;
     });
     return true;
+  }
+
+  function _sendMessage(e) {
+    e.preventDefault();
+    if (!conversation && conversationManuallyPassed) {
+      dispatchEvent("sendMessageClicked", {
+        event: e,
+        message: { ...reply, body: replyBody },
+      });
+      replyBody = "";
+      return;
+    }
+    if (replyStatus !== "sending") {
+      replyStatus = "sending";
+      if (!conversation) {
+        return;
+      }
+      sendMessage(id, {
+        from: reply.from,
+        to: reply.to,
+        body: `${replyBody} <br /><br /> --Sent with Nylas`,
+        subject: conversation.subject,
+        cc: reply.cc,
+        reply_to_message_id: lastMessage.id,
+        bcc: [],
+      }).then((res) => {
+        const conversationQuery = { queryKey: queryKey, data: res };
+        ConversationStore.addMessageToThread(conversationQuery);
+        replyStatus = "";
+        replyBody = "";
+      });
+    }
   }
 
   //#endregion Clean Conversation
@@ -506,9 +550,9 @@
     </header>
     {#if status === "loading"}Loading Messages...{/if}
     <div class="messages {theme}" class:dont-show-avatars={hideAvatars}>
-      {#each messages as message, i}
+      {#each conversationMessages as message, i}
         {#await message.from[0] then from}
-          {#await messages[i - 1] ? messages[i - 1].from[0] : { name: "", email: "" } then previousFrom}
+          {#await conversationMessages[i - 1] ? conversationMessages[i - 1].from[0] : { name: "", email: "" } then previousFrom}
             {#await participants.findIndex((p) => p.email === from.email && p.name === from.name) then participantIndex}
               {#await from.email === you.email_address then isYou}
                 <article
@@ -571,31 +615,7 @@
     </div>
     {#if show_reply}
       <div class="reply-box">
-        <form
-          on:submit={(e) => {
-            if (replyStatus !== "sending") {
-              e.preventDefault();
-              replyStatus = "sending";
-              if (!conversation) {
-                return;
-              }
-              sendMessage(id, {
-                from: reply.from,
-                to: reply.to,
-                body: `${replyBody} <br /><br /> --Sent with Nylas`,
-                subject: conversation.subject,
-                cc: reply.cc,
-                reply_to_message_id: lastMessage.id,
-                bcc: [],
-              }).then((res) => {
-                const conversationQuery = { queryKey: queryKey, data: res };
-                ConversationStore.addMessageToThread(conversationQuery);
-                replyStatus = "";
-                replyBody = "";
-              });
-            }
-          }}
-        >
+        <form on:submit={_sendMessage}>
           <label for="send-response" class="sr-only">
             Type and send a response
           </label>

--- a/components/conversation/src/index.html
+++ b/components/conversation/src/index.html
@@ -19,6 +19,18 @@
       margin: 0;
     }
   </style>
+  <!-- // If a list of messages is passed in manually
+<script type="module">
+  import { mockedMessages } from "./test-data.js";
+
+  document.addEventListener("DOMContentLoaded", function () {
+    const conversation = document.getElementsByTagName("nylas-conversation")[0];
+    conversation.addEventListener("sendMessageClicked", function (e) {
+      console.log("sendMessageClicked: ", e.detail.message)
+    })
+    conversation.messages = mockedMessages
+  });
+</script> -->
 
   <body>
     <nylas-conversation
@@ -28,5 +40,8 @@
       show_avatars="true"
       show_reply="true"
     />
+
+    <!-- If a list of messages is passed in manually -->
+    <!-- <nylas-conversation theme="ellsworth-kelly" show_avatars="true" show_reply="true" /> -->
   </body>
 </html>

--- a/components/conversation/src/test-data.js
+++ b/components/conversation/src/test-data.js
@@ -1,0 +1,127 @@
+export const mockedMessages = [
+  {
+    account_id: "ehiyqnpjag93ylo6etchcdhr9",
+    bcc: [],
+    cc: [],
+    date: 1629163362,
+    files: [],
+    from: [{ email: "aaron.d@nylas.com", name: "Aaron D'Mello" }],
+    id: "bp1y6jnepx3t9uyr548b4nsdp",
+    labels: [
+      {
+        display_name: "Sent Mail",
+        id: "6n0whoxa8tdpvreq01mrgvr3d",
+        name: "sent",
+      },
+    ],
+    object: "message",
+    reply_to: [],
+    snippet:
+      "Hey there, Welcome to Nylas! Glad to have you onboard Aaron D'Mello Sr. Software Engineer, Nylas aaron.d@nylas.com +1(647)220-5567",
+    starred: false,
+    subject: "Welcome to Nylas",
+    thread_id: "dclpsfd1i46mukv77b8y0qe4s",
+    to: [
+      {
+        email: "jack.smith@gmail.com",
+        name: "Jack Smith",
+      },
+    ],
+    unread: false,
+  },
+  {
+    account_id: "ehiyqnpjag93ylo6etchcdhr9",
+    bcc: [],
+    cc: [],
+    date: 1629163387,
+    files: [],
+    from: [
+      {
+        email: "jack.smith@gmail.com",
+        name: "Jack Smith",
+      },
+    ],
+    id: "60mqc30m5cfffi7mii61oajxt",
+    labels: [
+      {
+        display_name: "Inbox",
+        id: "5izbd0saul1qtmdp1jakkkdhx",
+        name: "inbox",
+      },
+      {
+        display_name: "Important",
+        id: "2wx96u918ncyeuv9yzjroo43g",
+        name: "important",
+      },
+    ],
+    object: "message",
+    reply_to: [],
+    snippet:
+      "Thank you! Excited to be here. On Aug 16, 2021, at 9:22 PM, Aaron D'Mello <aaron.d@nylas.com> wrote: Hey there, Welcome to Nylas! Glad to have you onboard Aaron D'Mello Sr. Software Engineer,",
+    starred: false,
+    subject: "Re: Welcome to Nylas",
+    thread_id: "dclpsfd1i46mukv77b8y0qe4s",
+    to: [{ email: "aaron.d@nylas.com", name: "Aaron D'Mello" }],
+    unread: false,
+  },
+  {
+    account_id: "ehiyqnpjag93ylo6etchcdhr9",
+    bcc: [],
+    cc: [],
+    date: 1629163426,
+    files: [],
+    from: [{ email: "aaron.d@nylas.com", name: "Aaron D'Mello" }],
+    id: "c3blsr1mbvh0lx4x9jibs61dn",
+    labels: [
+      {
+        display_name: "Sent Mail",
+        id: "6n0whoxa8tdpvreq01mrgvr3d",
+        name: "sent",
+      },
+    ],
+    object: "message",
+    reply_to: [],
+    snippet:
+      "That is awesome! Let’s chat soon regarding your first project. Aaron D'Mello Sr. Software Engineer, Nylas aaron.d@nylas.com +1(647)220-5567 On Aug 16, 2021, at 9:23 PM, Jack Smith",
+    starred: false,
+    subject: "Re: Welcome to Nylas",
+    thread_id: "dclpsfd1i46mukv77b8y0qe4s",
+    to: [
+      {
+        email: "jack.smith@gmail.com",
+        name: "Jack Smith",
+      },
+    ],
+    unread: false,
+  },
+  {
+    account_id: "ehiyqnpjag93ylo6etchcdhr9",
+    bcc: [],
+    cc: [],
+    date: 1629163454,
+    files: [],
+    from: [{ email: "aaron.d@nylas.com", name: "Aaron D'Mello" }],
+    id: "95moas06tbxv2gbashcqgaucr",
+    labels: [
+      {
+        display_name: "Sent Mail",
+        id: "6n0whoxa8tdpvreq01mrgvr3d",
+        name: "sent",
+      },
+    ],
+    object: "message",
+    reply_to: [],
+    snippet:
+      "Sounds great! Looking forward to it. Aaron D'Mello Sr. Software Engineer, Nylas aaron.d@nylas.com +1(647)220-5567 On Aug 16, 2021, at 9:23 PM, Aaron D'Mello <aaron.d@nylas.com> wrote: That is",
+    starred: false,
+    subject: "Re: Welcome to Nylas",
+    thread_id: "dclpsfd1i46mukv77b8y0qe4s",
+    to: [
+      {
+        email: "jack.smith@gmail.com",
+        name: "Jack Smith",
+      },
+    ],
+    unread: false,
+  },
+];

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -224,7 +224,7 @@
     // Thread is being passed in directly. We won't need to do an initial fetch.
     // Is it in the store already? (via <nylas-mailbox>, for example)
     let foundThread = $Threads.find(
-      (storedThread) => storedThread.id === thread?.id,
+      (storedThread) => storedThread && storedThread.id === thread?.id,
     ) as Conversation;
     if (!foundThread) {
       // Thread does not exist in the store, assume it was passed in

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -72,15 +72,19 @@
       JSON.stringify({ component_id: id, access_token })
     ]) || {}) as EmailProperties;
 
-    // Initialize labels / folders
-    const accountOrganizationUnitQuery = {
-      component_id: id,
-      access_token,
-    };
-    if (you.organization_unit === AccountOrganizationUnit.Label) {
-      labels = await LabelStore.getLabels(accountOrganizationUnitQuery);
-    } else if (you.organization_unit === AccountOrganizationUnit.Folder) {
-      folders = await FolderStore.getFolders(accountOrganizationUnitQuery);
+    // Fetch Account
+    if (id && !you.id && !emailManuallyPassed) {
+      you = await fetchAccount({ component_id: query.component_id });
+      // Initialize labels / folders
+      const accountOrganizationUnitQuery = {
+        component_id: id,
+        access_token,
+      };
+      if (you?.organization_unit === AccountOrganizationUnit.Label) {
+        labels = await LabelStore.getLabels(accountOrganizationUnitQuery);
+      } else if (you?.organization_unit === AccountOrganizationUnit.Folder) {
+        folders = await FolderStore.getFolders(accountOrganizationUnitQuery);
+      }
     }
   });
 
@@ -175,7 +179,10 @@
       click_action,
       "default",
     );
-    thread_id = getPropertyValue(internalProps.thread_id, thread_id, "");
+    // Assign thread_id to threadID stored in the manifest only when passing a thread_id
+    const internalPropThreadID =
+      !thread && !message_id && !message ? internalProps.thread_id : "";
+    thread_id = getPropertyValue(internalPropThreadID, thread_id, "");
     show_contact_avatar = getPropertyValue(
       internalProps.show_contact_avatar,
       show_contact_avatar,
@@ -255,14 +262,6 @@
   // #endregion thread intake and set
   let emailManuallyPassed: boolean;
   $: emailManuallyPassed = !!thread;
-
-  $: if (id && !you.id) {
-    fetchAccount({ component_id: query.component_id }).then(
-      (account: Account) => {
-        you = account;
-      },
-    );
-  }
 
   //#region Clean Conversation
   // If a user sets message_body_type to "clean", expand their message to clean conversation.
@@ -391,16 +390,16 @@
 
   async function toggleUnreadStatus(e: MouseEvent | KeyboardEvent) {
     if (activeThread) {
+      dispatchEvent("toggleThreadUnreadStatus", {
+        event: e,
+        thread: activeThread,
+      });
       if (click_action !== "mailbox") {
         activeThread.unread = !activeThread.unread;
         unread = activeThread.unread;
         await saveActiveThread();
         return;
       }
-      dispatchEvent("toggleThreadUnreadStatus", {
-        event: e,
-        thread: activeThread,
-      });
       return;
     }
     unread = !unread;

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -78,14 +78,19 @@
       manifest,
     ) as Partial<SvelteAllProps>;
 
+    // Fetch Account
+    if (id && !you.id && !all_threads) {
+      you = await fetchAccount({ component_id: query.component_id });
+    }
+
     const accountOrganizationUnitQuery = {
       component_id: id,
       access_token,
     };
     // Initialize labels / folders
-    if (you.organization_unit === AccountOrganizationUnit.Label) {
+    if (you?.organization_unit === AccountOrganizationUnit.Label) {
       labels = await LabelStore.getLabels(accountOrganizationUnitQuery);
-    } else if (you.organization_unit === AccountOrganizationUnit.Folder) {
+    } else if (you?.organization_unit === AccountOrganizationUnit.Folder) {
       folders = await FolderStore.getFolders(accountOrganizationUnitQuery);
     }
 
@@ -177,14 +182,6 @@
   $: if (all_threads) {
     threads = all_threads as Thread[];
     inboxThreads = threads; // TODO: filter out those in trash folder
-  }
-
-  $: if (id && !you.id && !all_threads) {
-    fetchAccount({ component_id: query.component_id }).then(
-      (account: Account) => {
-        you = account;
-      },
-    );
   }
 
   let main: Element;

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -179,7 +179,7 @@
     inboxThreads = threads; // TODO: filter out those in trash folder
   }
 
-  $: if (id && !you.id) {
+  $: if (id && !you.id && !all_threads) {
     fetchAccount({ component_id: query.component_id }).then(
       (account: Account) => {
         you = account;


### PR DESCRIPTION
# Background:
The component id requirement is only applicable if the user is using Nylas APIs. For users who just want to pass in static data, the components should work out of the box without an id.

# Implementation:
- Conversation: 
    - Added `test-data.js` with `mockedMessages` 
    - Added commented code in `index.html` for passing messages manually
    - Updated `Conversation.svelte` to respect the passed messages and dispatch an event on sending a message
- Mailbox:
    - Calling `fetchAccount` only when the id is passed in and the threads are not passed manually
    - Added a dispatchEvent on `threadClicked`

# Schreenshots:
### Conversation (`messages` passed manually):
![image](https://user-images.githubusercontent.com/16315004/135317273-8468681b-fc04-41b6-b2a1-128d49556009.png)
### Mailbox (`all_threads` passed manually)::
![image](https://user-images.githubusercontent.com/16315004/135317520-d616c0c3-4740-4c51-9649-368c20957ad8.png)
![image](https://user-images.githubusercontent.com/16315004/135317555-7c753bfe-60f3-43ed-81d1-871323f8648a.png)


# Readiness checklist

- [X] Cypress tests passing?
- [X] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
