### PR TITLE
[Mailbox][Bug-fix]: 'unread_status' set to read should show all messages as read (the text should not be bold)

### DIFF
--- a/components/conversation/src/Conversation.svelte
+++ b/components/conversation/src/Conversation.svelte
@@ -37,6 +37,7 @@
   export let theme: string;
   export let show_avatars: boolean | string;
   export let show_reply: boolean | string;
+  export let you: Partial<Account> = {};
 
   let manifest: Partial<ConversationProperties> = {};
 
@@ -50,6 +51,11 @@
     manifest = ((await $ManifestStore[
       JSON.stringify({ component_id: id, access_token })
     ]) || {}) as ConversationProperties;
+
+    // Fetch Account
+    if (id && !you.id && !conversationManuallyPassed) {
+      you = await fetchAccount({ component_id: query.component_id });
+    }
   });
 
   $: conversationMessages = conversationManuallyPassed
@@ -205,14 +211,6 @@
   let replyStatus: string = "";
 
   //#endregion Reply
-
-  let you: Partial<Account> = { name: "" };
-  $: if (id && !you.id)
-    fetchAccount({ component_id: query.component_id }).then(
-      (account: Account) => {
-        you = account;
-      },
-    );
 
   const CONVERSATION_ENDPOINT_MAX_MESSAGES = 20;
 

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -1170,14 +1170,20 @@
                 <div class="read-status">
                   <button
                     title={`Mark thread as ${
-                      unread || activeThread.unread ? "" : "un"
+                      unread ||
+                      (activeThread.unread && click_action !== "mailbox")
+                        ? ""
+                        : "un"
                     }read`}
                     aria-label={`Mark thread as ${
-                      unread || activeThread.unread ? "" : "un"
+                      unread ||
+                      (activeThread.unread && click_action !== "mailbox")
+                        ? ""
+                        : "un"
                     }read`}
                     on:click|stopPropagation={toggleUnreadStatus}
                   >
-                    {#if unread || activeThread.unread}
+                    {#if unread || (activeThread.unread && click_action !== "mailbox")}
                       <MarkReadIcon aria-hidden="true" />
                     {:else}
                       <MarkUnreadIcon aria-hidden="true" />
@@ -1317,7 +1323,8 @@
           <div
             class="email-row condensed"
             class:show_star
-            class:unread={unread || activeThread.unread}
+            class:unread={unread ||
+              (activeThread.unread && click_action !== "mailbox")}
           >
             <div class="from{show_star ? '-star' : ''}">
               {#if show_star}
@@ -1420,14 +1427,20 @@
                   <div class="read-status">
                     <button
                       title={`Mark thread as ${
-                        unread || activeThread.unread ? "" : "un"
+                        unread ||
+                        (activeThread.unread && click_action !== "mailbox")
+                          ? ""
+                          : "un"
                       }read`}
                       aria-label={`Mark thread as ${
-                        unread || activeThread.unread ? "" : "un"
+                        unread ||
+                        (activeThread.unread && click_action !== "mailbox")
+                          ? ""
+                          : "un"
                       }read`}
                       on:click|stopPropagation={toggleUnreadStatus}
                     >
-                      {#if unread || activeThread.unread}
+                      {#if unread || (activeThread.unread && click_action !== "mailbox")}
                         <MarkReadIcon aria-hidden="true" />
                       {:else}
                         <MarkUnreadIcon aria-hidden="true" />

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -639,7 +639,8 @@
           {you}
           {show_star}
           click_action="mailbox"
-          unread={unreadThreads.has(openedEmailData)}
+          unread={unreadThreads.has(openedEmailData) ||
+            (openedEmailData.unread && unread_status === "default")}
           on:threadClicked={threadClicked}
           on:messageClicked={messageClicked}
           on:threadStarred={threadStarred}
@@ -759,7 +760,8 @@
                   {you}
                   {show_star}
                   click_action="mailbox"
-                  unread={unreadThreads.has(thread)}
+                  unread={unreadThreads.has(thread) ||
+                    (thread.unread && unread_status === "default")}
                   on:threadClicked={threadClicked}
                   on:messageClicked={messageClicked}
                   on:threadStarred={threadStarred}


### PR DESCRIPTION
- Mailbox: Fixed the condition to show messages as read/unread. Mailbox should pass the thread's actual unread value to the email **only** if `unread_status = "default"`
- Email: We should defer to activeThread's unread status **only** when the `click_action != "mailbox"`

# Screenshots:
#### unread_status = "default"
![image](https://user-images.githubusercontent.com/16315004/135336826-e93aa61a-21ee-4182-93eb-e6afed73fec3.png)

#### unread_status = "unread"
![image](https://user-images.githubusercontent.com/16315004/135336868-2ecaea59-8b6e-4e16-b464-eddd8c4c1cd5.png)

#### unread_status = "read"
![image](https://user-images.githubusercontent.com/16315004/135336912-a7adb4b3-00a4-4127-9ae3-b9956a704bfa.png)


# Readiness checklist

- [X] Cypress tests passing?
- [X] Included before/after screenshots, if the change is visual


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
