### PR TITLE
[Fix NPM Publish]: Updated build file to publish to npm correctly

### DIFF
--- a/.github/workflows/build-test-publish.yaml
+++ b/.github/workflows/build-test-publish.yaml
@@ -148,6 +148,8 @@ jobs:
     needs: [build, lint, test-unit, type-check, test-cypress]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - name: Check out source code
         uses: actions/checkout@v2
@@ -171,17 +173,16 @@ jobs:
           npm config set access public
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@users.noreply.github.com"
+          
+      - name: Configure NPM Token
+        run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
 
       - name: Publish (canary)
         if: contains(github.ref, 'canary') == true
         run: |
           npm run lerna -- changed && npm run lerna -- publish from-git --no-verify-access --dist-tag canary --canary --preid canary --yes
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish (stable)
         if: contains(github.ref, 'canary') == false
         run: |
           npm run lerna -- changed && npm run lerna -- publish from-git --no-verify-access --yes
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Fixed publish to npm & updated build file.

This change adds the following command to `.npmrc` file in the root folder. 
`//registry.npmjs.org/:_authToken=${NPM_TOKEN}`

Reference: 
https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
