### PR TITLE
[Email]: Show `me` in to, cc, bcc, from fields if the email matches you.email_address

### DIFF
--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -66,6 +66,7 @@
   export let show_expanded_email_view_onload: boolean;
   export let show_thread_actions: boolean;
 
+  let userEmail: string;
   onMount(async () => {
     await tick(); // https://github.com/sveltejs/svelte/issues/2227
     manifest = ((await $ManifestStore[
@@ -75,6 +76,10 @@
     // Fetch Account
     if (id && !you.id && !emailManuallyPassed) {
       you = await fetchAccount({ component_id: query.component_id });
+      userEmail =
+        !you.email_address || userEmail !== you.email_address
+          ? you.email_address
+          : userEmail;
       // Initialize labels / folders
       const accountOrganizationUnitQuery = {
         component_id: id,
@@ -87,7 +92,6 @@
       }
     }
   });
-
   let contacts: any = null;
   $: activeThreadContact =
     activeThread && contacts
@@ -1208,7 +1212,7 @@
                     handleEmailClick(e, msgIndex)}
                   on:keypress={(e) => handleEmailKeypress(e, msgIndex)}
                 >
-                  {#if message.expanded || msgIndex === activeThread.messages.length - 1}
+                  {#if message.expanded || (msgIndex === activeThread.messages.length - 1 && userEmail)}
                     <div class="message-head">
                       <div class="message-from-to">
                         <div class="avatar-from">
@@ -1222,8 +1226,10 @@
                           {/if}
                           <div class="message-from">
                             <span class="name"
-                              >{message.from[0].name ||
-                                message.from[0].email}</span
+                              >{message.from[0].email === userEmail
+                                ? "me"
+                                : message.from[0].name ||
+                                  message.from[0].email}</span
                             >
                             <!-- tooltip component -->
                             <nylas-tooltip
@@ -1238,8 +1244,8 @@
                         <div class="message-to">
                           {#each message.to as to, i}
                             <span>
-                              {#if to.name || to.email || you.email_address}
-                                to&colon;&nbsp;{to.email === you.email_address
+                              {#if to.name || (to.email && userEmail)}
+                                to&colon;&nbsp;{to.email === userEmail
                                   ? "me"
                                   : to.name || to.email}
                                 {#if i !== message.to.length - 1}
@@ -1275,7 +1281,7 @@
                         {message.snippet}
                       {/if}
                     </div>
-                  {:else}
+                  {:else if userEmail}
                     <div class="message-head">
                       <div class="avatar-from">
                         {#if show_contact_avatar}
@@ -1288,8 +1294,10 @@
                         {/if}
                         <div class="message-from">
                           <span class="name"
-                            >{message.from[0].name ||
-                              message.from[0].email}</span
+                            >{message.from[0].email === userEmail
+                              ? "me"
+                              : message.from[0].name ||
+                                message.from[0].email}</span
                           >
                           <!-- tooltip component -->
                           <nylas-tooltip
@@ -1486,7 +1494,9 @@
                 {/if}
                 <div class="message-from">
                   <span class="name"
-                    >{message.from[0].name || message.from[0].email}</span
+                    >{message.from[0].email === userEmail
+                      ? "me"
+                      : message.from[0].name || message.from[0].email}</span
                   >
                   <!-- tooltip component -->
                   <nylas-tooltip
@@ -1502,8 +1512,8 @@
               <div class="message-to">
                 {#each message.to as to, i}
                   <span>
-                    {#if to.name || to.email || you.email_address}
-                      to&colon;&nbsp;{to.email === you.email_address
+                    {#if to.name || (to.email && userEmail)}
+                      to&colon;&nbsp;{to.email === userEmail
                         ? "me"
                         : to.name || to.email}
                       {#if i !== message.to.length - 1}

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -76,10 +76,7 @@
     // Fetch Account
     if (id && !you.id && !emailManuallyPassed) {
       you = await fetchAccount({ component_id: query.component_id });
-      userEmail =
-        !you.email_address || userEmail !== you.email_address
-          ? you.email_address
-          : userEmail;
+      userEmail = you.email_address;
       // Initialize labels / folders
       const accountOrganizationUnitQuery = {
         component_id: id,
@@ -1212,7 +1209,7 @@
                     handleEmailClick(e, msgIndex)}
                   on:keypress={(e) => handleEmailKeypress(e, msgIndex)}
                 >
-                  {#if message.expanded || (msgIndex === activeThread.messages.length - 1 && userEmail)}
+                  {#if message.expanded || msgIndex === activeThread.messages.length - 1}
                     <div class="message-head">
                       <div class="message-from-to">
                         <div class="avatar-from">
@@ -1226,7 +1223,7 @@
                           {/if}
                           <div class="message-from">
                             <span class="name"
-                              >{message.from[0].email === userEmail
+                              >{userEmail && message.from[0].email === userEmail
                                 ? "me"
                                 : message.from[0].name ||
                                   message.from[0].email}</span
@@ -1244,8 +1241,9 @@
                         <div class="message-to">
                           {#each message.to as to, i}
                             <span>
-                              {#if to.name || (to.email && userEmail)}
-                                to&colon;&nbsp;{to.email === userEmail
+                              {#if to.name || to.email}
+                                to&colon;&nbsp;{userEmail &&
+                                to.email === userEmail
                                   ? "me"
                                   : to.name || to.email}
                                 {#if i !== message.to.length - 1}
@@ -1281,7 +1279,7 @@
                         {message.snippet}
                       {/if}
                     </div>
-                  {:else if userEmail}
+                  {:else}
                     <div class="message-head">
                       <div class="avatar-from">
                         {#if show_contact_avatar}
@@ -1294,7 +1292,7 @@
                         {/if}
                         <div class="message-from">
                           <span class="name"
-                            >{message.from[0].email === userEmail
+                            >{userEmail && message.from[0].email === userEmail
                               ? "me"
                               : message.from[0].name ||
                                 message.from[0].email}</span
@@ -1494,7 +1492,7 @@
                 {/if}
                 <div class="message-from">
                   <span class="name"
-                    >{message.from[0].email === userEmail
+                    >{userEmail && message.from[0].email === userEmail
                       ? "me"
                       : message.from[0].name || message.from[0].email}</span
                   >
@@ -1512,8 +1510,8 @@
               <div class="message-to">
                 {#each message.to as to, i}
                   <span>
-                    {#if to.name || (to.email && userEmail)}
-                      to&colon;&nbsp;{to.email === userEmail
+                    {#if to.name || to.email}
+                      to&colon;&nbsp;{userEmail && to.email === userEmail
                         ? "me"
                         : to.name || to.email}
                       {#if i !== message.to.length - 1}


### PR DESCRIPTION
- Added logic to display "me" if email in to, cc, bcc, and/or from matches `you.email_address`

- Save `you.email_address` in `userEmail` variable

- Added logic to check that `userEmail` exists before loading name

# Readiness checklist

- [ ] Cypress tests passing?
- [ ] New cypress tests added?
- [ ] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
