### PR TITLE
Nylas Availability: event buffers

### DIFF
--- a/commons/src/types/Availability.ts
+++ b/commons/src/types/Availability.ts
@@ -25,6 +25,7 @@ export interface Manifest extends NylasManifest {
   free_color: string;
   busy_color: string;
   view_as: "schedule" | "list";
+  event_buffer: number;
 }
 
 export interface Calendar {

--- a/commons/src/types/Availability.ts
+++ b/commons/src/types/Availability.ts
@@ -25,7 +25,8 @@ export interface Manifest extends NylasManifest {
   free_color: string;
   busy_color: string;
   view_as: "schedule" | "list";
-  event_buffer: number;
+  pre_event_buffer: number;
+  post_event_buffer: number;
 }
 
 export interface Calendar {

--- a/commons/src/types/Availability.ts
+++ b/commons/src/types/Availability.ts
@@ -25,8 +25,7 @@ export interface Manifest extends NylasManifest {
   free_color: string;
   busy_color: string;
   view_as: "schedule" | "list";
-  pre_event_buffer: number;
-  post_event_buffer: number;
+  event_buffer: number;
 }
 
 export interface Calendar {

--- a/commons/src/types/ScheduleEditor.ts
+++ b/commons/src/types/ScheduleEditor.ts
@@ -24,5 +24,6 @@ export interface Manifest extends NylasManifest {
   notification_message?: string;
   notification_subject?: string;
   view_as?: "schedule" | "list";
-  event_buffer: number;
+  pre_event_buffer: number;
+  post_event_buffer: number;
 }

--- a/commons/src/types/ScheduleEditor.ts
+++ b/commons/src/types/ScheduleEditor.ts
@@ -24,4 +24,5 @@ export interface Manifest extends NylasManifest {
   notification_message?: string;
   notification_subject?: string;
   view_as?: "schedule" | "list";
+  event_buffer: number;
 }

--- a/commons/src/types/ScheduleEditor.ts
+++ b/commons/src/types/ScheduleEditor.ts
@@ -24,6 +24,5 @@ export interface Manifest extends NylasManifest {
   notification_message?: string;
   notification_subject?: string;
   view_as?: "schedule" | "list";
-  pre_event_buffer: number;
-  post_event_buffer: number;
+  event_buffer: number;
 }

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -63,6 +63,7 @@
   export let free_color: string;
   export let show_hosts: "show" | "hide";
   export let view_as: "schedule" | "list";
+  export let event_buffer: number;
 
   /**
    * Re-loads availability data from the Nylas API.
@@ -233,6 +234,11 @@
       internalProps.view_as || editorManifest.view_as,
       view_as,
       "schedule",
+    );
+    event_buffer = getPropertyValue(
+      internalProps.event_buffer || editorManifest.event_buffer,
+      event_buffer,
+      15,
     );
   }
 

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -63,7 +63,8 @@
   export let free_color: string;
   export let show_hosts: "show" | "hide";
   export let view_as: "schedule" | "list";
-  export let event_buffer: number;
+  export let pre_event_buffer: number;
+  export let post_event_buffer: number;
 
   /**
    * Re-loads availability data from the Nylas API.
@@ -235,10 +236,15 @@
       view_as,
       "schedule",
     );
-    event_buffer = getPropertyValue(
-      internalProps.event_buffer || editorManifest.event_buffer,
-      event_buffer,
-      15,
+    pre_event_buffer = getPropertyValue(
+      internalProps.pre_event_buffer || editorManifest.pre_event_buffer,
+      pre_event_buffer,
+      0,
+    );
+    post_event_buffer = getPropertyValue(
+      internalProps.post_event_buffer || editorManifest.post_event_buffer,
+      post_event_buffer,
+      0,
     );
   }
 
@@ -327,14 +333,14 @@
       new Date(new Date(timestamp).setHours(start_hour)),
     );
     const dayEnd = timeHour(new Date(new Date(timestamp).setHours(end_hour)));
-    // console.log(parseInt(slot_size) + (2*event_buffer));
+    // console.log(parseInt(slot_size) + pre_event_buffer+post_event_buffer);
     return scaleTime()
       .domain([dayStart, dayEnd])
-      .ticks(timeMinute.every(slot_size) as TimeInterval) //every( parseInt(slot_size) + (2*event_buffer)) )
+      .ticks(timeMinute.every(slot_size) as TimeInterval) //every(parseInt(slot_size) + pre_event_buffer+post_event_buffer)
       .slice(0, -1) // dont show the 25th hour
       .map((time: Date) => {
         // startTime needs to be updated as well, because currently it is using 'time' which causes random overlap
-        const endTime = timeMinute.offset(time, slot_size); //(time, parseInt(slot_size) + (2*event_buffer))
+        const endTime = timeMinute.offset(time, slot_size); //(time, (parseInt(slot_size) + pre_event_buffer+post_event_buffer))
         const freeCalendars: string[] = [];
         let availability = AvailabilityStatus.FREE; // default
         if (allCalendars.length) {

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -337,11 +337,17 @@
         let availability = AvailabilityStatus.FREE; // default
         if (allCalendars.length) {
           for (const calendar of allCalendars) {
-            let availabilityExistsInSlot = calendar.timeslots.some(
-              (block) =>
-                time < timeMinute.offset(block.end_time, event_buffer) &&
-                timeMinute.offset(block.start_time, -event_buffer) < endTime,
-            );
+            let availabilityExistsInSlot = calendar.timeslots.some((block) => {
+              if (calendar.availability === AvailabilityStatus.FREE) {
+                // typical use case
+                return time < block.end_time && block.start_time < endTime;
+              } else if (calendar.availability === AvailabilityStatus.BUSY) {
+                return (
+                  time < timeMinute.offset(block.end_time, event_buffer) &&
+                  timeMinute.offset(block.start_time, -event_buffer) < endTime
+                );
+              }
+            });
             if (calendar.availability === AvailabilityStatus.BUSY) {
               if (!availabilityExistsInSlot) {
                 freeCalendars.push(calendar?.account?.emailAddress || "");

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -669,10 +669,14 @@
     if (parseInt(event_buffer) === 0) return slots;
 
     allCalendars.forEach((calendar) => {
+      console.log("slots:", slots); //slots in the day (all slots, 24 if 60 min, 48 if 30 min, 96 if 15 min)
       let availableSlotsForCalendar = slots.filter((slot) =>
         slot.available_calendars.includes(calendar.account.emailAddress),
       );
+      console.log("calendar:", availableSlotsForCalendar); // slots with current user calendar (12 in the first test case with just Jim person)
       let filteredSlotsForCalendar = deepCopy(availableSlotsForCalendar);
+      console.log("calendar2:", filteredSlotsForCalendar); // copy of slots with current user calendar (12 in the first test case with just Jim person)
+
       availableSlotsForCalendar.forEach((slot, i) => {
         if (slot.availability !== AvailabilityStatus.BUSY) {
           //maybe FREE
@@ -689,16 +693,15 @@
                 slot.available_calendars.filter(
                   (cal) => cal !== calendar.account.emailAddress,
                 );
-              if (
-                !availableSlotsForCalendar[i - j].available_calendars.length
-              ) {
+              if (!filteredSlotsForCalendar[i - j].available_calendars.length) {
                 // if it has no calendars avialble, it's busy
+                // console.log(availableSlotsForCalendar, i);
                 availableSlotsForCalendar[i - j].availability =
                   AvailabilityStatus.BUSY;
               } else if (
-                availableSlotsForCalendar[i - j].availability ===
+                filteredSlotsForCalendar[i - j].availability ===
                   AvailabilityStatus.FREE &&
-                availableSlotsForCalendar[i - j].available_calendars.length !==
+                filteredSlotsForCalendar[i - j].available_calendars.length !==
                   allCalendars.length
               ) {
                 // if it was previously free, but now lacks a calendar, it should be considered Partial.
@@ -710,7 +713,8 @@
         }
       });
 
-      console.log(availableSlotsForCalendar);
+      // console.log(filteredSlotsForCalendar);
+      // console.log(availableSlotsForCalendar);
     });
     return slots; //filteredSlots
   }

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -327,12 +327,14 @@
       new Date(new Date(timestamp).setHours(start_hour)),
     );
     const dayEnd = timeHour(new Date(new Date(timestamp).setHours(end_hour)));
+    // console.log(parseInt(slot_size) + (2*event_buffer));
     return scaleTime()
       .domain([dayStart, dayEnd])
-      .ticks(timeMinute.every(slot_size) as TimeInterval)
+      .ticks(timeMinute.every(slot_size) as TimeInterval) //every( parseInt(slot_size) + (2*event_buffer)) )
       .slice(0, -1) // dont show the 25th hour
       .map((time: Date) => {
-        const endTime = timeMinute.offset(time, slot_size);
+        // startTime needs to be updated as well, because currently it is using 'time' which causes random overlap
+        const endTime = timeMinute.offset(time, slot_size); //(time, parseInt(slot_size) + (2*event_buffer))
         const freeCalendars: string[] = [];
         let availability = AvailabilityStatus.FREE; // default
         if (allCalendars.length) {

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -12,9 +12,6 @@
         const startTimeInput = document.querySelector("input#start-time");
         const endTimeInput = document.querySelector("input#end-time");
         const daysInput = document.querySelector("input#days-to-show");
-        const overbookedThresholdInput = document.querySelector(
-          "input#overbooked-threshold",
-        );
 
         const calendars = [
           {
@@ -85,10 +82,6 @@
 
         daysInput.addEventListener("input", (event) => {
           component.dates_to_show = parseInt(event.target.value);
-        });
-
-        overbookedThresholdInput.addEventListener("input", (event) => {
-          component.overbooked_threshold = parseInt(event.target.value);
         });
 
         document.querySelectorAll('input[name="slot-size"]').forEach((elem) => {
@@ -273,20 +266,6 @@
         <label>
           <input type="radio" name="event-buffer" value="30" />
           30 minutes
-        </label>
-      </fieldset>
-
-      <fieldset>
-        <legend>Overbooked Threshold</legend>
-        <label>
-          <input
-            id="overbooked-threshold"
-            type="range"
-            min="0"
-            max="100"
-            step="1"
-            value="100"
-          />
         </label>
       </fieldset>
 

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -91,10 +91,17 @@
         });
 
         document
-          .querySelectorAll('input[name="event-buffer"]')
+          .querySelectorAll('input[name="pre-event-buffer"]')
           .forEach((elem) => {
             elem.addEventListener("input", function (event) {
-              component.event_buffer = event.target.value;
+              component.pre_event_buffer = event.target.value;
+            });
+          });
+        document
+          .querySelectorAll('input[name="post-event-buffer"]')
+          .forEach((elem) => {
+            elem.addEventListener("input", function (event) {
+              component.post_event_buffer = event.target.value;
             });
           });
 
@@ -254,17 +261,44 @@
       </fieldset>
 
       <fieldset>
-        <legend>Event Buffer</legend>
+        <legend>Pre Event Buffer</legend>
         <label>
-          <input checked type="radio" name="event-buffer" value="10" />
+          <input
+            checked
+            type="radio"
+            name="pre-event-buffer"
+            value="10"
+            checked
+          />
           10 minutes
         </label>
         <label>
-          <input type="radio" name="event-buffer" value="15" checked />
+          <input type="radio" name="pre-event-buffer" value="15" />
           15 minutes
         </label>
         <label>
-          <input type="radio" name="event-buffer" value="30" />
+          <input type="radio" name="pre-event-buffer" value="30" />
+          30 minutes
+        </label>
+      </fieldset>
+      <fieldset>
+        <legend>Post Event Buffer</legend>
+        <label>
+          <input
+            checked
+            type="radio"
+            name="post-event-buffer"
+            value="10"
+            checked
+          />
+          10 minutes
+        </label>
+        <label>
+          <input type="radio" name="post-event-buffer" value="15" />
+          15 minutes
+        </label>
+        <label>
+          <input type="radio" name="post-event-buffer" value="30" />
           30 minutes
         </label>
       </fieldset>

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -12,18 +12,21 @@
         const startTimeInput = document.querySelector("input#start-time");
         const endTimeInput = document.querySelector("input#end-time");
         const daysInput = document.querySelector("input#days-to-show");
+        const overbookedThresholdInput = document.querySelector(
+          "input#overbooked-threshold",
+        );
 
         const calendars = [
           {
             availability: "busy",
             timeslots: [
               {
-                start_time: new Date(new Date().setHours(3, 0, 0, 0)),
+                start_time: new Date(new Date().setHours(0, 0, 0, 0)),
                 end_time: new Date(new Date().setHours(6, 0, 0, 0)),
               },
               {
-                start_time: new Date(new Date().setHours(9, 0, 0, 0)),
-                end_time: new Date(new Date().setHours(15, 0, 0, 0)),
+                start_time: new Date(new Date().setHours(6, 0, 0, 0)),
+                end_time: new Date(new Date().setHours(12, 0, 0, 0)),
               },
             ],
             account: {
@@ -84,11 +87,23 @@
           component.dates_to_show = parseInt(event.target.value);
         });
 
+        overbookedThresholdInput.addEventListener("input", (event) => {
+          component.overbooked_threshold = parseInt(event.target.value);
+        });
+
         document.querySelectorAll('input[name="slot-size"]').forEach((elem) => {
           elem.addEventListener("input", function (event) {
             component.slot_size = event.target.value;
           });
         });
+
+        document
+          .querySelectorAll('input[name="event-buffer"]')
+          .forEach((elem) => {
+            elem.addEventListener("input", function (event) {
+              component.event_buffer = event.target.value;
+            });
+          });
 
         document
           .querySelectorAll('input[name="show-ticks"]')
@@ -242,6 +257,36 @@
         <label>
           <input type="radio" name="slot-size" value="60" />
           60 minutes
+        </label>
+      </fieldset>
+
+      <fieldset>
+        <legend>Event Buffer</legend>
+        <label>
+          <input checked type="radio" name="event-buffer" value="10" />
+          10 minutes
+        </label>
+        <label>
+          <input type="radio" name="event-buffer" value="15" />
+          15 minutes
+        </label>
+        <label>
+          <input type="radio" name="event-buffer" value="30" />
+          30 minutes
+        </label>
+      </fieldset>
+
+      <fieldset>
+        <legend>Overbooked Threshold</legend>
+        <label>
+          <input
+            id="overbooked-threshold"
+            type="range"
+            min="0"
+            max="100"
+            step="1"
+            value="100"
+          />
         </label>
       </fieldset>
 

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -267,9 +267,13 @@
             checked
             type="radio"
             name="pre-event-buffer"
-            value="10"
+            value="0"
             checked
           />
+          0 minutes
+        </label>
+        <label>
+          <input type="radio" name="pre-event-buffer" value="10" />
           10 minutes
         </label>
         <label>
@@ -288,9 +292,13 @@
             checked
             type="radio"
             name="post-event-buffer"
-            value="10"
+            value="0"
             checked
           />
+          0 minutes
+        </label>
+        <label>
+          <input type="radio" name="post-event-buffer" value="10" />
           10 minutes
         </label>
         <label>

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -33,37 +33,38 @@
               avatarUrl: "",
             },
           },
-          {
-            availability: "busy",
-            timeslots: [
-              {
-                start_time: new Date(new Date().setHours(4, 0, 0, 0)),
-                end_time: new Date(new Date().setHours(11, 0, 0, 0)),
-              },
-            ],
-            account: {
-              emailAddress: "thelonious@nylas.com",
-              firstName: "Thelonious",
-              lastName: "",
-              avatarUrl: "",
-            },
-          },
-          {
-            emailAddress: "booker@nylas.com",
-            availability: "free",
-            timeslots: [
-              {
-                start_time: new Date(new Date().setHours(5, 15, 0, 0)),
-                end_time: new Date(new Date().setHours(16, 0, 0, 0)),
-              },
-            ],
-            account: {
-              emailAddress: "booker@nylas.com",
-              firstName: "Bill",
-              lastName: "Ooker",
-              avatarUrl: "",
-            },
-          },
+          // ,
+          // {
+          //   availability: "busy",
+          //   timeslots: [
+          //     {
+          //       start_time: new Date(new Date().setHours(0, 0, 0, 0)),
+          //       end_time: new Date(new Date().setHours(12, 0, 0, 0)),
+          //     },
+          //   ],
+          //   account: {
+          //     emailAddress: "thelonious@nylas.com",
+          //     firstName: "Thelonious",
+          //     lastName: "",
+          //     avatarUrl: "",
+          //   },
+          // },
+          // {
+          //   emailAddress: "booker@nylas.com",
+          //   availability: "busy",
+          //   timeslots: [
+          //     {
+          //       start_time: new Date(new Date().setHours(16, 0, 0, 0)),
+          //       end_time: new Date(new Date().setHours(18, 0, 0, 0)),
+          //     },
+          //   ],
+          //   account: {
+          //     emailAddress: "booker@nylas.com",
+          //     firstName: "Bill",
+          //     lastName: "Ooker",
+          //     avatarUrl: "",
+          //   },
+          // },
         ];
 
         component.calendars = calendars;

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -91,17 +91,10 @@
         });
 
         document
-          .querySelectorAll('input[name="pre-event-buffer"]')
+          .querySelectorAll('input[name="event-buffer"]')
           .forEach((elem) => {
             elem.addEventListener("input", function (event) {
-              component.pre_event_buffer = event.target.value;
-            });
-          });
-        document
-          .querySelectorAll('input[name="post-event-buffer"]')
-          .forEach((elem) => {
-            elem.addEventListener("input", function (event) {
-              component.post_event_buffer = event.target.value;
+              component.event_buffer = event.target.value;
             });
           });
 
@@ -261,52 +254,21 @@
       </fieldset>
 
       <fieldset>
-        <legend>Pre Event Buffer</legend>
+        <legend>Event Buffer</legend>
         <label>
-          <input
-            checked
-            type="radio"
-            name="pre-event-buffer"
-            value="0"
-            checked
-          />
+          <input checked type="radio" name="event-buffer" value="0" checked />
           0 minutes
         </label>
         <label>
-          <input type="radio" name="pre-event-buffer" value="10" />
+          <input type="radio" name="event-buffer" value="10" />
           10 minutes
         </label>
         <label>
-          <input type="radio" name="pre-event-buffer" value="15" />
+          <input type="radio" name="event-buffer" value="15" />
           15 minutes
         </label>
         <label>
-          <input type="radio" name="pre-event-buffer" value="30" />
-          30 minutes
-        </label>
-      </fieldset>
-      <fieldset>
-        <legend>Post Event Buffer</legend>
-        <label>
-          <input
-            checked
-            type="radio"
-            name="post-event-buffer"
-            value="0"
-            checked
-          />
-          0 minutes
-        </label>
-        <label>
-          <input type="radio" name="post-event-buffer" value="10" />
-          10 minutes
-        </label>
-        <label>
-          <input type="radio" name="post-event-buffer" value="15" />
-          15 minutes
-        </label>
-        <label>
-          <input type="radio" name="post-event-buffer" value="30" />
+          <input type="radio" name="event-buffer" value="30" />
           30 minutes
         </label>
       </fieldset>

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -267,7 +267,7 @@
           10 minutes
         </label>
         <label>
-          <input type="radio" name="event-buffer" value="15" />
+          <input type="radio" name="event-buffer" value="15" checked />
           15 minutes
         </label>
         <label>

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -18,7 +18,7 @@
             availability: "busy",
             timeslots: [
               {
-                start_time: new Date(new Date().setHours(0, 0, 0, 0)),
+                start_time: new Date(new Date().setHours(2, 0, 0, 0)),
                 end_time: new Date(new Date().setHours(6, 0, 0, 0)),
               },
               {
@@ -51,7 +51,7 @@
           // },
           // {
           //   emailAddress: "booker@nylas.com",
-          //   availability: "busy",
+          //   availability: "free",
           //   timeslots: [
           //     {
           //       start_time: new Date(new Date().setHours(16, 0, 0, 0)),

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -18,12 +18,12 @@
             availability: "busy",
             timeslots: [
               {
-                start_time: new Date(new Date().setHours(2, 0, 0, 0)),
+                start_time: new Date(new Date().setHours(3, 0, 0, 0)),
                 end_time: new Date(new Date().setHours(6, 0, 0, 0)),
               },
               {
-                start_time: new Date(new Date().setHours(6, 0, 0, 0)),
-                end_time: new Date(new Date().setHours(12, 0, 0, 0)),
+                start_time: new Date(new Date().setHours(9, 0, 0, 0)),
+                end_time: new Date(new Date().setHours(15, 0, 0, 0)),
               },
             ],
             account: {
@@ -33,38 +33,37 @@
               avatarUrl: "",
             },
           },
-          // ,
-          // {
-          //   availability: "busy",
-          //   timeslots: [
-          //     {
-          //       start_time: new Date(new Date().setHours(0, 0, 0, 0)),
-          //       end_time: new Date(new Date().setHours(12, 0, 0, 0)),
-          //     },
-          //   ],
-          //   account: {
-          //     emailAddress: "thelonious@nylas.com",
-          //     firstName: "Thelonious",
-          //     lastName: "",
-          //     avatarUrl: "",
-          //   },
-          // },
-          // {
-          //   emailAddress: "booker@nylas.com",
-          //   availability: "free",
-          //   timeslots: [
-          //     {
-          //       start_time: new Date(new Date().setHours(16, 0, 0, 0)),
-          //       end_time: new Date(new Date().setHours(18, 0, 0, 0)),
-          //     },
-          //   ],
-          //   account: {
-          //     emailAddress: "booker@nylas.com",
-          //     firstName: "Bill",
-          //     lastName: "Ooker",
-          //     avatarUrl: "",
-          //   },
-          // },
+          {
+            availability: "busy",
+            timeslots: [
+              {
+                start_time: new Date(new Date().setHours(4, 0, 0, 0)),
+                end_time: new Date(new Date().setHours(11, 0, 0, 0)),
+              },
+            ],
+            account: {
+              emailAddress: "thelonious@nylas.com",
+              firstName: "Thelonious",
+              lastName: "",
+              avatarUrl: "",
+            },
+          },
+          {
+            emailAddress: "booker@nylas.com",
+            availability: "free",
+            timeslots: [
+              {
+                start_time: new Date(new Date().setHours(5, 15, 0, 0)),
+                end_time: new Date(new Date().setHours(16, 0, 0, 0)),
+              },
+            ],
+            account: {
+              emailAddress: "booker@nylas.com",
+              firstName: "Bill",
+              lastName: "Ooker",
+              avatarUrl: "",
+            },
+          },
         ];
 
         component.calendars = calendars;

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -747,4 +747,36 @@ describe("availability component", () => {
         });
     });
   });
+  describe("Event Buffer", () => {
+    it("With 0 min buffer time", () => {
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.event_buffer = 0;
+          cy.get(".slot.busy").should("have.length", 5);
+          cy.get(".slot.free").should("have.length", 4);
+        });
+    });
+    it("Adds 15 min buffer time", () => {
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.event_buffer = 15;
+          cy.get(".slot.busy").should("have.length", 6);
+          cy.get(".slot.free").should("have.length", 3);
+        });
+    });
+    it("Adds 30 min buffer time", () => {
+      cy.get("nylas-availability")
+        .as("availability")
+        .then((element) => {
+          const component = element[0];
+          component.event_buffer = 30;
+          cy.get(".slot.busy").should("have.length", 7);
+          cy.get(".slot.free").should("have.length", 2);
+        });
+    });
+  });
 });


### PR DESCRIPTION
Indicates an amount of time before or after a booked event where others may not be booked.

For example, if `event_buffer` is 30 minutes, and you have `slot_size` set to 30, then the slot immediately after a busy event will also show up as busy.

If your slot_size is set to 20 minutes, then the TWO slots immediately after your event would be set as busy.

This would commonly be used for "downtime between meetings" or "travel time to get back to the office", etc.

TODO: new tests


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
