### PR TITLE
Recurrence/cadence in booking scheduler events

### DIFF
--- a/commons/src/types/Events.ts
+++ b/commons/src/types/Events.ts
@@ -20,6 +20,12 @@ interface _Event {
   attendeeStatus?: "yes" | "no" | "noreply" | "maybe";
   isNewEvent?: boolean;
   conferencing?: EventConferencing;
+  recurrence: EventRecurrence;
+}
+
+export interface EventRecurrence {
+  rrule: string[];
+  timezone: string;
 }
 
 export interface EventConferencing {

--- a/commons/src/types/ScheduleEditor.ts
+++ b/commons/src/types/ScheduleEditor.ts
@@ -27,8 +27,8 @@ export interface Manifest extends NylasManifest {
   view_as?: "schedule" | "list";
   event_buffer: number;
   recurrence: "none" | "mandated" | "optional";
-  recurrence_cadence: string[]; // "none" | "daily" | "weekly" | "biweekly" | "monthly";
   capacity: number;
   date_format: "full" | "weekday" | "date" | "none";
   open_hours?: AvailabilityRule[];
+  recurrence_cadence: string[]; // "none" | "daily" | "weekdays" | "weekly" | "biweekly" | "monthly";
 }

--- a/commons/src/types/ScheduleEditor.ts
+++ b/commons/src/types/ScheduleEditor.ts
@@ -26,9 +26,9 @@ export interface Manifest extends NylasManifest {
   notification_subject?: string;
   view_as?: "schedule" | "list";
   event_buffer: number;
-  recurrence: "none" | "mandated" | "optional";
   capacity: number;
   date_format: "full" | "weekday" | "date" | "none";
   open_hours?: AvailabilityRule[];
+  recurrence: "none" | "required" | "optional";
   recurrence_cadence: string[]; // "none" | "daily" | "weekdays" | "weekly" | "biweekly" | "monthly";
 }

--- a/commons/src/types/Scheduler.ts
+++ b/commons/src/types/Scheduler.ts
@@ -16,6 +16,6 @@ export interface Manifest extends AvailabilityManifest {
   notification_mode?: NotificationMode;
   notification_message?: string;
   notification_subject?: string;
-  recurrence: "none" | "mandated" | "optional";
-  recurrence_cadence: string[]; // "none" | "daily" | "weekly" | "biweekly" | "monthly";
+  recurrence?: "none" | "mandated" | "optional";
+  recurrence_cadence?: string[]; // "none" | "daily" | "weekdays" | "weekly" | "biweekly" | "monthly";
 }

--- a/commons/src/types/Scheduler.ts
+++ b/commons/src/types/Scheduler.ts
@@ -16,4 +16,6 @@ export interface Manifest extends AvailabilityManifest {
   notification_mode?: NotificationMode;
   notification_message?: string;
   notification_subject?: string;
+  recurrence: "none" | "mandated" | "optional";
+  recurrence_cadence: string[]; // "none" | "daily" | "weekly" | "biweekly" | "monthly";
 }

--- a/commons/src/types/Scheduler.ts
+++ b/commons/src/types/Scheduler.ts
@@ -16,6 +16,6 @@ export interface Manifest extends AvailabilityManifest {
   notification_mode?: NotificationMode;
   notification_message?: string;
   notification_subject?: string;
-  recurrence?: "none" | "mandated" | "optional";
+  recurrence?: "none" | "required" | "optional";
   recurrence_cadence?: string[]; // "none" | "daily" | "weekdays" | "weekly" | "biweekly" | "monthly";
 }

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -41,7 +41,7 @@
   export let notification_subject: string;
   export let view_as: "schedule" | "list";
   export let recurrence: "none" | "mandated" | "optional";
-  export let recurrence_cadence: string[]; // "none" | "daily" | "weekly" | "biweekly" | "monthly";
+  export let recurrence_cadence: string[]; // "none" | "daily" | "weekdays" | "weekly" | "biweekly" | "monthly";
   export let capacity: number;
   export let open_hours: AvailabilityRule[];
 
@@ -589,6 +589,15 @@
           value="daily"
         />
         <span>Daily</span>
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          name="recurrence_cadence"
+          bind:group={recurrenceCadence}
+          value="weekdays"
+        />
+        <span>Daily, only on weekdays</span>
       </label>
       <label>
         <input

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -40,7 +40,7 @@
   export let notification_message: string;
   export let notification_subject: string;
   export let view_as: "schedule" | "list";
-  export let recurrence: "none" | "mandated" | "optional";
+  export let recurrence: "none" | "required" | "optional";
   export let recurrence_cadence: string[]; // "none" | "daily" | "weekdays" | "weekly" | "biweekly" | "monthly";
   export let capacity: number;
   export let open_hours: AvailabilityRule[];
@@ -570,12 +570,12 @@
         type="radio"
         name="recurrence"
         bind:group={manifestProperties.recurrence}
-        value="mandated"
+        value="required"
       />
       <span>Events Always Repeat</span>
     </label>
   </div>
-  {#if manifestProperties.recurrence === "mandated" || manifestProperties.recurrence === "optional"}
+  {#if manifestProperties.recurrence === "required" || manifestProperties.recurrence === "optional"}
     <div role="radiogroup" aria-labelledby="recurrence_cadence">
       <strong id="recurrence_cadence"
         >How often should events repeat{#if manifestProperties.recurrence === "optional"},

--- a/components/scheduler/src/Scheduler.svelte
+++ b/components/scheduler/src/Scheduler.svelte
@@ -180,7 +180,7 @@
         if (event.recurrence_cadence === "daily") {
           rrule = ["RRULE:FREQ=DAILY"];
         } else if (event.recurrence_cadence === "weekdays") {
-          rrule = ["RRULE:FREQ=DAIY;BYDAY=MO,TU,WE,TH,FR"];
+          rrule = ["RRULE:FREQ=DAILY;BYDAY=MO,TU,WE,TH,FR"];
         } else if (event.recurrence_cadence === "weekly") {
           rrule = ["RRULE:FREQ=WEEKLY"];
         } else if (event.recurrence_cadence === "biweekly") {
@@ -364,10 +364,6 @@
               <footer>
                 {#if recurrence === "optional"}
                   <strong>How often should this event repeat?</strong>
-                {:else if recurrence === "required"}
-                  <strong>Repeating {timeSlot.recurrence_cadence}</strong>
-                {/if}
-                {#if recurrence === "optional"}
                   <div class="cadences">
                     <label
                       class:checked={timeSlot.recurrence_cadence === "none"}
@@ -392,6 +388,8 @@
                       </label>
                     {/each}
                   </div>
+                {:else if recurrence === "required"}
+                  <strong>Repeating {timeSlot.recurrence_cadence}</strong>
                 {/if}
               </footer>
             {/if}

--- a/components/scheduler/src/Scheduler.svelte
+++ b/components/scheduler/src/Scheduler.svelte
@@ -41,7 +41,7 @@
   export let notification_mode: NotificationMode;
   export let notification_message: string;
   export let notification_subject: string;
-  export let recurrence: "none" | "mandated" | "optional";
+  export let recurrence: "none" | "required" | "optional";
   export let recurrence_cadence: string[]; // "none" | "daily" | "weekdays" | "weekly" | "biweekly" | "monthly";
 
   // #endregion props
@@ -139,7 +139,7 @@
   let show_success_notification = false;
   $: slotsToBook = slots_to_book.map((slot) => {
     if (!slot.recurrence_cadence) {
-      if (recurrence === "mandated") {
+      if (recurrence === "required") {
         slot.recurrence_cadence = recurrence_cadence[0];
       } else {
         slot.recurrence_cadence = "none";
@@ -300,9 +300,9 @@
             }
 
             .cadences {
-              display: grid;
+              display: flex;
+              flex-wrap: wrap;
               gap: 0.5rem;
-              grid-template-columns: repeat(auto-fit, minmax(0px, max-content));
 
               label {
                 padding: 0.25rem 0.5rem;
@@ -315,6 +315,10 @@
                 &.checked {
                   background-color: var(--blue);
                   color: white;
+                }
+
+                span {
+                  text-transform: capitalize;
                 }
               }
             }
@@ -360,7 +364,7 @@
               <footer>
                 {#if recurrence === "optional"}
                   <strong>How often should this event repeat?</strong>
-                {:else if recurrence === "mandated"}
+                {:else if recurrence === "required"}
                   <strong>Repeating {timeSlot.recurrence_cadence}</strong>
                 {/if}
                 {#if recurrence === "optional"}
@@ -373,7 +377,7 @@
                         value="none"
                         bind:group={timeSlot.recurrence_cadence}
                       />
-                      <span>Never</span>
+                      <span>never</span>
                     </label>
                     {#each recurrence_cadence as cadence}
                       <label

--- a/components/scheduler/src/Scheduler.svelte
+++ b/components/scheduler/src/Scheduler.svelte
@@ -227,8 +227,6 @@
     }
     availability_id = availability_id;
   }
-
-  $: console.log({ slotsToBook });
 </script>
 
 <style lang="scss">

--- a/components/scheduler/src/index.html
+++ b/components/scheduler/src/index.html
@@ -77,6 +77,8 @@
         scheduler.addEventListener("bookedEvents", () => {
           availability.reload(true, true);
         });
+
+        scheduler.recurrence_cadence = ["weekly", "monthly"];
       });
     </script>
     <style>
@@ -116,6 +118,7 @@
       <nylas-scheduler
         id="demo-scheduler"
         editor_id="demo-schedule-editor"
+        recurrence="optional"
       ></nylas-scheduler>
     </main>
   </body>

--- a/components/scheduler/src/index.html
+++ b/components/scheduler/src/index.html
@@ -78,7 +78,7 @@
           availability.reload(true, true);
         });
 
-        scheduler.recurrence_cadence = ["weekly", "biweekly", "monthly"];
+        scheduler.recurrence_cadence = ["daily", "weekdays", "weekly"];
       });
     </script>
     <style>
@@ -118,7 +118,7 @@
       <nylas-scheduler
         id="demo-scheduler"
         editor_id="demo-schedule-editor"
-        recurrence="mandated"
+        recurrence="optional"
       ></nylas-scheduler>
     </main>
   </body>

--- a/components/scheduler/src/index.html
+++ b/components/scheduler/src/index.html
@@ -78,7 +78,7 @@
           availability.reload(true, true);
         });
 
-        scheduler.recurrence_cadence = ["weekly", "monthly"];
+        scheduler.recurrence_cadence = ["weekly", "biweekly", "monthly"];
       });
     </script>
     <style>
@@ -118,7 +118,7 @@
       <nylas-scheduler
         id="demo-scheduler"
         editor_id="demo-schedule-editor"
-        recurrence="optional"
+        recurrence="mandated"
       ></nylas-scheduler>
     </main>
   </body>


### PR DESCRIPTION
- Application of the schedule-editor recurrence rules in #110 
- Adds a recurrence footer to all bookable events in the scheduler
- If `recurrence` is set to `optional`, gives the user the chance to select one of the provided cadences
- if `recurrence` is set to `mandated`, informs the user of the repeating schedule
- Side-effect: adds "weekdays" to the possible `recurrence_cadence` options

N.B.: I am not setting an upper limit on repeated events here; means they'll continue on until stopped on the provider side, or the heat-death of the universe, whichever comes first.

Big shoutout to http://jakubroztocil.github.io/rrule/ for helping me understand RRULE a bit better

## Screenshots
recurrence=mandated, recurrence_cadence=["weekly"]:

![CleanShot 2021-10-06 at 01 12 36](https://user-images.githubusercontent.com/713991/136144246-71b5f38d-8cf5-4e11-9a89-4310d288d5f1.png)

recurrence=optional, recurrence_cadence=["daily", "weekdays", "weekly"]:
![CleanShot 2021-10-06 at 01 13 54](https://user-images.githubusercontent.com/713991/136144330-aa3090bd-4155-4529-be76-af9b224b8ffa.png)

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
