### PR TITLE
Add mandate-top-of-hour option for availability

### DIFF
--- a/commons/src/types/Availability.ts
+++ b/commons/src/types/Availability.ts
@@ -13,6 +13,7 @@ export interface Manifest extends NylasManifest {
   calendars: Calendar[];
   email_ids: string[];
   allow_booking: boolean;
+  mandate_top_hour: boolean;
   max_bookable_slots: number;
   partial_bookable_ratio: number;
   show_as_week: boolean;

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -107,6 +107,14 @@
           });
 
         document
+          .querySelectorAll('input[name="mandate-top-hour"]')
+          .forEach((elem) => {
+            elem.addEventListener("input", function (event) {
+              component.mandate_top_hour = JSON.parse(event.target.value);
+            });
+          });
+
+        document
           .querySelectorAll('input[name="allow-booking"]')
           .forEach((elem) => {
             elem.addEventListener("input", function (event) {
@@ -281,6 +289,18 @@
         </label>
         <label>
           <input type="radio" name="show-ticks" value="false" />
+          False
+        </label>
+      </fieldset>
+
+      <fieldset>
+        <legend>Mandate Top of Hour</legend>
+        <label>
+          <input type="radio" name="mandate-top-hour" value="true" />
+          True
+        </label>
+        <label>
+          <input checked type="radio" name="mandate-top-hour" value="false" />
           False
         </label>
       </fieldset>


### PR DESCRIPTION
This PR adds the `Mandate top of hour` option for availability component
# Readiness checklist

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
