### PR TITLE
[Mailbox]: Added dispatch events for on select actions coming from email component

### DIFF
--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -413,7 +413,8 @@
     });
     if (click_action !== "mailbox") {
       if (trashLabelID) {
-        activeThread.label_ids = [trashLabelID];
+        const existingLabelIds = activeThread.labels?.map((i) => i.id) || [];
+        activeThread.label_ids = [...existingLabelIds, trashLabelID];
       } else if (trashFolderID) {
         activeThread.folder_id = trashFolderID;
       }

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -264,6 +264,9 @@
   }
 
   function toggleThreadUnreadStatus(event: CustomEvent) {
+    if (selectedThreads.has(event.detail.thread)) {
+      dispatchEvent("onChangeSelectedReadStatus", { event, selectedThreads });
+    }
     event.detail.thread.unread = !event.detail.thread.unread;
     updateThreadStatus(event.detail.thread);
     if (event.detail.thread.unread) {
@@ -328,6 +331,10 @@
   }
 
   async function threadStarred(event: CustomEvent) {
+    dispatchEvent("onStarSelected", {
+      event,
+      selectedThreads: event.detail.thread,
+    });
     if (starredThreads.has(event.detail.thread)) {
       starredThreads.delete(event.detail.thread);
       event.detail.thread.starred = false;
@@ -409,7 +416,8 @@
 
   async function deleteThread(thread: Thread) {
     if (trashLabelID) {
-      thread.label_ids = [trashLabelID];
+      const existingLabelIds = thread.labels?.map((i) => i.id) || [];
+      thread.label_ids = [...existingLabelIds, trashLabelID];
     } else if (trashFolderID) {
       thread.folder_id = trashFolderID;
     }
@@ -441,7 +449,11 @@
       }
     }
 
-    return (inboxThreads = inboxThreads), (selectedThreads = selectedThreads);
+    return (
+      (inboxThreads = inboxThreads),
+      (selectedThreads = selectedThreads),
+      (threads = threads)
+    );
   }
   //#endregion actions
 


### PR DESCRIPTION
- Added dispatch events for `threadStarred` and `toggleThreadUnreadStatus`, these events are bubbled up from email component and we need a way to communicate this to our users from within mailbox
- Also updated the logic to move threads to trash folder by appending the trash label instead of replacing (This was causing an error when we try to delete a thread in `sent` folder)

# Readiness checklist

- [X] Cypress tests passing?

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
