### PR TITLE
Fix: Publishing packages fails with a 404 error

### DIFF
--- a/.github/workflows/build-test-publish.yaml
+++ b/.github/workflows/build-test-publish.yaml
@@ -149,7 +149,7 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     env:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # This is how we have to set the NPM_TOKEN because the `actions/setup-node@v1` requires it.
     steps:
       - name: Check out source code
         uses: actions/checkout@v2
@@ -173,16 +173,13 @@ jobs:
           npm config set access public
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@users.noreply.github.com"
-          
-      - name: Configure NPM Token
-        run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
 
       - name: Publish (canary)
         if: contains(github.ref, 'canary') == true
         run: |
-          npm run lerna -- changed && npm run lerna -- publish from-git --no-verify-access --dist-tag canary --canary --preid canary --yes
+          npm run lerna -- changed && npm run lerna -- publish from-git --no-git-reset --no-verify-access --dist-tag canary --canary --preid canary --yes
 
       - name: Publish (stable)
         if: contains(github.ref, 'canary') == false
         run: |
-          npm run lerna -- changed && npm run lerna -- publish from-git --no-verify-access --yes
+          npm run lerna -- changed && npm run lerna -- publish from-git --no-git-reset --no-verify-access --yes


### PR DESCRIPTION
# Implementation
- [x] Setup-node changes the location for `.npmrc` file. Upon testing, we realized we do not need to write to our own `.npmrc` file and just need to set the variable `NODE_AUTH_TOKEN` at the job level.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
