### PR TITLE
FIX - Hide filter by email while loading contact list

### DIFF
--- a/components/contact-list/src/ContactList.svelte
+++ b/components/contact-list/src/ContactList.svelte
@@ -493,7 +493,7 @@
       </span>
     {/if}
 
-    {#if show_filter}
+    {#if show_filter && status !== "loading"}
       <label class="entry filter">
         Filter by email: <input
           id="show-filter-input"


### PR DESCRIPTION
<!-- Add information about your PR here -->
# What this PR changes? 

This PR adds a fix to the `filter by email` field appearing before the contact list is fetched. 

# Readiness checklist

- [X] Cypress tests passing?
- [] New cypress tests added?
- [X] Included before/after screenshots, if the change is visual

# Screenshots

## Before 

![before](https://user-images.githubusercontent.com/30182454/136596665-c8383f44-1c39-4851-a46a-7180f7a5851c.png)

## After

<img width="575" alt="after" src="https://user-images.githubusercontent.com/30182454/136596701-9b1ab01c-9e2e-4b5c-93a9-6c17484eec29.png">


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

