### PR TITLE
[Scheduler / Availability] Removed editor_id and subsequent manifest fetching

### DIFF
--- a/commons/src/store/manifest.ts
+++ b/commons/src/store/manifest.ts
@@ -22,28 +22,7 @@ function initialize(): Writable<ManifestStore> {
       const fetchPromise = fetchManifest(
         accessor.component_id,
         accessor.access_token,
-      ).then((manifest) => {
-        if (!accessor.external_manifest_ids) {
-          return manifest;
-        }
-
-        const filteredIds = accessor.external_manifest_ids.filter((id) => !!id);
-        if (filteredIds.length === 0) {
-          return manifest;
-        }
-
-        const mergeManifestPromises = [];
-        for (const manifestId of filteredIds) {
-          mergeManifestPromises.push(
-            fetchManifest(manifestId, accessor.access_token),
-          );
-        }
-
-        return Promise.all(mergeManifestPromises).then((manifestsToMerge) => {
-          // TODO - not sure if this is exactly how we want to merge
-          return Object.assign({}, manifest, ...manifestsToMerge);
-        });
-      });
+      );
       store.update((store) => {
         store[key] = fetchPromise;
         return store;

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -47,7 +47,6 @@
   //#region props
   export let id: string = "";
   export let access_token: string = "";
-  export let editor_id: string;
   export let start_hour: number;
   export let end_hour: number;
   export let slot_size: number; // in minutes
@@ -144,7 +143,6 @@
     const storeKey = JSON.stringify({
       component_id: id,
       access_token,
-      external_manifest_ids: [editor_id],
     });
     manifest = (await $ManifestStore[storeKey]) || {};
 

--- a/components/scheduler/src/Scheduler.svelte
+++ b/components/scheduler/src/Scheduler.svelte
@@ -30,7 +30,6 @@
   export let id: string = "";
   export let access_token: string = "";
   export let availability_id: string;
-  export let editor_id: string;
   export let email_ids: string[];
   export let booking_label: string;
   export let event_title: string;
@@ -55,7 +54,6 @@
     const storeKey = JSON.stringify({
       component_id: id,
       access_token,
-      external_manifest_ids: [editor_id],
     });
     manifest = (await $ManifestStore[storeKey]) || {};
 
@@ -78,7 +76,6 @@
       availability_id,
       "",
     );
-    editor_id = getPropertyValue(internalProps.editor_id, editor_id, "");
     email_ids = getPropertyValue(internalProps.email_ids, email_ids, []);
     booking_label = getPropertyValue(
       internalProps.booking_label,

--- a/components/scheduler/src/index.html
+++ b/components/scheduler/src/index.html
@@ -107,7 +107,6 @@
         show_as_week="true"
         allow_booking="true"
         id="demo-availability"
-        editor_id="demo-schedule-editor"
         slot_size="15"
         start_hour="9"
         end_hour="17"
@@ -117,7 +116,6 @@
       </nylas-availability>
       <nylas-scheduler
         id="demo-scheduler"
-        editor_id="demo-schedule-editor"
         recurrence="optional"
       ></nylas-scheduler>
     </main>

--- a/components/scheduler/src/init.spec.js
+++ b/components/scheduler/src/init.spec.js
@@ -26,16 +26,6 @@ describe("scheduler component", () => {
           cy.get("h3").contains("Meeting:");
         });
     });
-    it("inherits event title from manifest", () => {
-      cy.document().then(($document) => {
-        $document.getElementsByTagName("nylas-scheduler")[0].remove();
-        let newScheduler = $document.createElement("nylas-scheduler");
-        newScheduler.id = "demo-scheduler";
-        newScheduler.slots_to_book = slots_to_book;
-        $document.body.getElementsByTagName("main")[0].append(newScheduler);
-      });
-      cy.get("h3").contains("Scheduler Manifest Driven Event Title:");
-    });
     it("inherits event title from editor-manifest", () => {
       cy.document().then(($document) => {
         $document.getElementsByTagName("nylas-scheduler")[0].remove();


### PR DESCRIPTION
Removed in favour of middleware merging in `editor_id` manifest props for these components.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
