### PR TITLE
[scheduler] Added the ability to set a recurrence_expiry prop

### DIFF
--- a/commons/src/types/Scheduler.ts
+++ b/commons/src/types/Scheduler.ts
@@ -18,4 +18,5 @@ export interface Manifest extends AvailabilityManifest {
   notification_subject?: string;
   recurrence?: "none" | "required" | "optional";
   recurrence_cadence?: string[]; // "none" | "daily" | "weekdays" | "weekly" | "biweekly" | "monthly";
+  recurrence_expiry?: Date | number | undefined;
 }


### PR DESCRIPTION
Added `recurrence_expiry` prop that can be passed as either a number or a date. A number value defines the number of recurrences to book, and a date value defines the date that recurrences will end at.

This PR was originally going to include a UI change to allow users to set the expiry through the UI, but I'm going to have that be part of a separate PR to reduce the size.


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
