### PR TITLE
[Conversation][Bug-fix]: Fix header and reply-box relative to container not viewport

### DIFF
--- a/components/conversation/src/Conversation.svelte
+++ b/components/conversation/src/Conversation.svelte
@@ -308,7 +308,7 @@
 
   main {
     height: 100%;
-    min-height: 100vh;
+    max-height: 100vh;
     width: 100%;
     overflow: auto;
     position: relative;
@@ -339,7 +339,7 @@
     gap: $headerHorizontalSpacing;
     color: var(--black);
     font-size: var(--fs-14);
-    position: fixed;
+    position: sticky;
     width: 100%;
     top: 0;
     z-index: 1;
@@ -514,7 +514,7 @@
   }
 
   .reply-box {
-    position: fixed;
+    position: sticky;
     width: 100%;
     bottom: 0;
     z-index: 1;


### PR DESCRIPTION
# Implementation:
- Changed `position: fixed` to `position: sticky`. This allows us to fix the header to the top and the reply-box to the bottom of the container instead of the viewport itself.

# Screenshots
### Before:
![image](https://user-images.githubusercontent.com/16315004/137372038-37465467-1d07-4426-8587-9582d3f9cf53.png)

### After:
![image](https://user-images.githubusercontent.com/16315004/137372370-c6dc8a78-d9cc-4a82-a17a-a7b73052f9a7.png)


# Readiness checklist

- [X] Cypress tests passing?
- [X] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
