### PR TITLE
[availability] show first/last name for account in attendee overlay

### DIFF
--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -811,7 +811,7 @@
     for (const user of consolidatedAvailabilityForGivenDay) {
       if (!user.firstName && !user.lastName) {
         const contact = await getContact(user.email);
-        if (Object.keys(contact).length) {
+        if (!!contact) {
           user.account = {
             firstName: contact.given_name,
             lastName: contact.surname,


### PR DESCRIPTION
# Changes

Added a function, `getContact()`, to the Availability component. It uses the `ContactStore` to fetch a contact by email if the user associated with its respective email in `email_ids` does not have a `firstName` or `lastName`.

If the contact does not exist, or if a `given_name` or `surname` property is not set, the element containing the name in the UI will not show any text. If there is a value for `given_name` or `surname`, it will render it in the UI (see second screenshot).

# Screenshots
## Before
<img width="251" alt="Screen Shot 2021-10-15 at 5 27 25 PM" src="https://user-images.githubusercontent.com/55773810/137555515-15cf91ce-fb35-40fa-989a-0647e32a1ffc.png">

## If a `given_name` property is set
<img width="258" alt="Screen Shot 2021-10-15 at 5 10 04 PM" src="https://user-images.githubusercontent.com/55773810/137555416-baf10150-c932-43f8-b8bd-2cd68cc9cae2.png">

## If the email matches a contact
<img width="269" alt="Screen Shot 2021-10-15 at 5 11 08 PM" src="https://user-images.githubusercontent.com/55773810/137555413-59fcc9b7-c8a0-4dd6-8f57-320d3506a914.png">

# Readiness checklist

- [] Cypress tests passing?
- [] New cypress tests added?
- [] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
