### PR TITLE
[Conversation][Bug-fix]: Initialize component with thread_id stored in manifest if exists & messages not passed manually

### DIFF
--- a/components/conversation/src/Conversation.svelte
+++ b/components/conversation/src/Conversation.svelte
@@ -95,7 +95,7 @@
     );
     show_reply = getPropertyValue(internalProps.show_reply, show_reply, false);
     // Assign thread_id with threadID stored in the manifest only when passing a thread_id
-    const internalPropThreadID = !(messages.length > 0)
+    const internalPropThreadID = messages.length === 0
       ? internalProps.thread_id
       : "";
     thread_id = getPropertyValue(internalPropThreadID, thread_id, "");


### PR DESCRIPTION
# What is done:
- Initialized thread_id prop with the thread_id stored in manifest, if one exists & messages are not passed manually

# Readiness checklist

- [X] Cypress tests passing?

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
