### PR TITLE
chore: explicit IP host and prettier plugin path fix

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "plugins": ["prettier-plugin-svelte"],
+  "plugins": ["./node_modules/prettier-plugin-svelte"],
   "trailingComma": "all",
   "tabWidth": 2,
   "semi": true,

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "release:canary": "lerna version prerelease --no-private",
     "release:stable": "lerna version --force-publish --no-private",
     "snapshot": "build-storybook --quiet && percy-storybook --widths=320,1280",
-    "start": "concurrently \"live-server . --host=localhost --port=8000\" \"yarn dev\"",
+    "start": "concurrently \"live-server . --host=0.0.0.0 --port=8000\" \"yarn dev\"",
     "start:ci": "sirv . --port 8000 public",
     "storybook": "start-storybook --quiet -p 6006 -s ./public",
     "storybook:ci": "yarn run storybook -- --ci",


### PR DESCRIPTION
<!-- Add information about your PR here -->
- Fixes unable to locate `prettier-plugin-svelte` plugin

![image](https://user-images.githubusercontent.com/34139730/137791678-9b94cebd-b548-434e-97ce-f55145fd73f8.png)

- Fixes testing locally on mobile device



# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
