### PR TITLE
Pass-through `access_token` to `fetchAccounts`

### DIFF
--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -85,7 +85,7 @@
 
     // Fetch Account
     if (id && !you.id && !all_threads) {
-      you = await fetchAccount({ component_id: query.component_id });
+      you = await fetchAccount({ component_id: query.component_id, access_token });
     }
 
     const accountOrganizationUnitQuery = {


### PR DESCRIPTION
Noticed that our application was received 422 errors as `x-access-token` was not being set on the request header even though I had passed it as an attribute to the `nylas-mailbox` component. Digging around, it seems that this is because `access_token` is not being passed as a parameter to `fetchAccounts` on init.

# Code changes

- Modify `Mailbox.svelte` to pass through `access_token` attribute through to `fetchAccounts`.

# Readiness checklist

- [] New property added? make sure to update `component/src/properties.json`
- [] Cypress tests passing?
- [] New cypress tests added?
- [] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
