### PR TITLE
Pass through `access_token` on `Email.svelte`

### DIFF
--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -92,7 +92,7 @@
 
     // Fetch Account
     if (id && !you.id && !emailManuallyPassed) {
-      you = await fetchAccount({ component_id: query.component_id });
+      you = await fetchAccount({ component_id: query.component_id, access_token });
       userEmail = <string>you.email_address;
       // Initialize labels / folders
       const accountOrganizationUnitQuery = {


### PR DESCRIPTION
Same as https://github.com/nylas/components/pull/142, but for the thread component.

# Code changes

- Pass through `access_token` to `fetchAccount` for the Email component's initialization. This is needed to avoid 422 errors (`x-access-token` missing request header).

# Readiness checklist

- [] New property added? make sure to update `component/src/properties.json`
- [] Cypress tests passing?
- [] New cypress tests added?
- [] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
