### PR TITLE
[availability] Added props to limit the min / max number of days in the future that events can be booked

### DIFF
--- a/commons/src/types/Availability.ts
+++ b/commons/src/types/Availability.ts
@@ -4,36 +4,38 @@ import type {
 } from "@commons/enums/Availability";
 import type { Manifest as NylasManifest } from "@commons/types/Nylas";
 export interface Manifest extends NylasManifest {
-  start_hour: number;
-  end_hour: number;
-  slot_size: 15 | 30 | 60;
-  start_date: Date;
-  dates_to_show: number;
-  show_ticks: boolean;
-  calendars: Calendar[];
-  email_ids: string[];
   allow_booking: boolean;
-  max_bookable_slots: number;
-  partial_bookable_ratio: number;
-  show_as_week: boolean;
-  show_weekends: boolean;
-  attendees_to_show: number;
   allow_date_change: boolean;
-  required_participants: string[];
-  show_hosts: "show" | "hide";
-  partial_color: string;
-  free_color: string;
+  attendees_to_show: number;
   busy_color: string;
-  closed_color: string;
-  selected_color: string;
-  view_as: "schedule" | "list";
-  event_buffer: number;
+  calendars: Calendar[];
   capacity: number | null;
+  closed_color: string;
   date_format: "full" | "weekday" | "date" | "none";
-  show_header: boolean;
+  dates_to_show: number;
+  email_ids: string[];
+  end_hour: number;
+  event_buffer: number;
+  free_color: string;
+  mandate_top_of_hour: boolean;
+  max_bookable_slots: number;
+  max_book_ahead_days: number;
+  min_book_ahead_days: number;
   open_hours: AvailabilityRule[];
   overbooked_threshold: number;
-  mandate_top_of_hour: boolean;
+  partial_bookable_ratio: number;
+  partial_color: string;
+  required_participants: string[];
+  selected_color: string;
+  show_as_week: boolean;
+  show_header: boolean;
+  show_hosts: "show" | "hide";
+  show_ticks: boolean;
+  show_weekends: boolean;
+  slot_size: 15 | 30 | 60;
+  start_date: Date;
+  start_hour: number;
+  view_as: "schedule" | "list";
 }
 
 export interface AvailabilityRule {
@@ -106,7 +108,8 @@ export interface EventParticipant {
 }
 
 export interface Day {
+  epochs: any[]; // TODO typing
+  isBookable: boolean;
   slots: SelectableSlot[];
-  epochs: any[]; // TODO
   timestamp: Date;
 }

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -72,6 +72,8 @@
   export let free_color: string;
   export let mandate_top_of_hour: boolean;
   export let max_bookable_slots: number;
+  export let max_book_ahead_days: number;
+  export let min_book_ahead_days: number;
   export let open_hours: AvailabilityRule[];
   export let overbooked_threshold: number;
   export let partial_bookable_ratio: number;
@@ -89,35 +91,37 @@
   export let view_as: "schedule" | "list";
 
   const defaultValueMap = {
-    start_hour: 0,
-    end_hour: 24,
-    slot_size: 15,
-    start_date: new Date(),
-    dates_to_show: 1,
-    calendars: [],
-    show_ticks: true,
-    email_ids: [],
     allow_booking: false,
-    max_bookable_slots: 1,
-    partial_bookable_ratio: 0.01,
-    show_as_week: false,
-    show_weekends: true,
-    attendees_to_show: 5,
     allow_date_change: true,
-    required_participants: [],
+    attendees_to_show: 5,
     busy_color: "#EE3248cc",
+    calendars: [],
     closed_color: "#EE3248cc",
-    partial_color: "#FECA7Ccc",
-    free_color: "#078351cc",
-    selected_color: "#002db4",
-    show_hosts: "show",
-    view_as: "schedule",
-    event_buffer: 0,
-    show_header: true,
     date_format: "full",
+    dates_to_show: 1,
+    email_ids: [],
+    end_hour: 24,
+    event_buffer: 0,
+    free_color: "#078351cc",
+    mandate_top_of_hour: false,
+    max_bookable_slots: 1,
+    max_book_ahead_days: 30,
+    min_book_ahead_days: 0,
     open_hours: [],
     overbooked_threshold: 100,
-    mandate_top_of_hour: false,
+    partial_bookable_ratio: 0.01,
+    partial_color: "#FECA7Ccc",
+    required_participants: [],
+    selected_color: "#002db4",
+    show_as_week: false,
+    show_header: true,
+    show_hosts: "show",
+    show_ticks: true,
+    show_weekends: true,
+    slot_size: 15,
+    start_date: new Date(),
+    start_hour: 0,
+    view_as: "schedule",
   };
 
   $: hasError = Object.keys($ErrorStore).length ? true : false;
@@ -143,16 +147,15 @@
         );
       }
 
-      $AvailabilityStore[
-        JSON.stringify(getAvailabilityQuery())
-      ] = $AvailabilityStore[JSON.stringify(getAvailabilityQuery())].then(
-        (availability) => {
-          for (const calendar of availability) {
-            calendar.time_slots.push(...selectedSlots);
-          }
-          return availability;
-        },
-      );
+      $AvailabilityStore[JSON.stringify(getAvailabilityQuery())] =
+        $AvailabilityStore[JSON.stringify(getAvailabilityQuery())].then(
+          (availability) => {
+            for (const calendar of availability) {
+              calendar.time_slots.push(...selectedSlots);
+            }
+            return availability;
+          },
+        );
 
       await getAvailability();
     }
@@ -263,36 +266,38 @@
     if (JSON.stringify(rebuiltProps) !== JSON.stringify(internalProps)) {
       internalProps = rebuiltProps;
 
-      start_hour = internalProps.start_hour;
-      end_hour = internalProps.end_hour;
-      slot_size = internalProps.slot_size;
-      start_date = internalProps.start_date;
-      dates_to_show = internalProps.dates_to_show;
-      calendars = internalProps.calendars;
-      show_ticks = internalProps.show_ticks;
-      email_ids = internalProps.email_ids;
       allow_booking = internalProps.allow_booking;
-      max_bookable_slots = internalProps.max_bookable_slots;
-      partial_bookable_ratio = internalProps.partial_bookable_ratio;
-      show_as_week = internalProps.show_as_week;
-      show_weekends = internalProps.show_weekends;
-      attendees_to_show = internalProps.attendees_to_show;
       allow_date_change = internalProps.allow_date_change;
-      required_participants = internalProps.required_participants;
+      attendees_to_show = internalProps.attendees_to_show;
       busy_color = internalProps.busy_color;
-      closed_color = internalProps.closed_color;
-      partial_color = internalProps.partial_color;
-      free_color = internalProps.free_color;
-      selected_color = internalProps.selected_color;
-      show_hosts = internalProps.show_hosts;
-      view_as = internalProps.view_as;
-      event_buffer = internalProps.event_buffer;
+      calendars = internalProps.calendars;
       capacity = internalProps.capacity;
-      show_header = internalProps.show_header;
+      closed_color = internalProps.closed_color;
       date_format = internalProps.date_format;
+      dates_to_show = internalProps.dates_to_show;
+      email_ids = internalProps.email_ids;
+      end_hour = internalProps.end_hour;
+      event_buffer = internalProps.event_buffer;
+      free_color = internalProps.free_color;
+      mandate_top_of_hour = internalProps.mandate_top_of_hour;
+      max_bookable_slots = internalProps.max_bookable_slots;
+      max_book_ahead_days = internalProps.max_book_ahead_days;
+      min_book_ahead_days = internalProps.min_book_ahead_days;
       open_hours = internalProps.open_hours;
       overbooked_threshold = internalProps.overbooked_threshold;
-      mandate_top_of_hour = internalProps.mandate_top_of_hour;
+      partial_bookable_ratio = internalProps.partial_bookable_ratio;
+      partial_color = internalProps.partial_color;
+      required_participants = internalProps.required_participants;
+      selected_color = internalProps.selected_color;
+      show_as_week = internalProps.show_as_week;
+      show_header = internalProps.show_header;
+      show_hosts = internalProps.show_hosts;
+      show_ticks = internalProps.show_ticks;
+      show_weekends = internalProps.show_weekends;
+      slot_size = internalProps.slot_size;
+      start_date = internalProps.start_date;
+      start_hour = internalProps.start_hour;
+      view_as = internalProps.view_as;
     }
   }
 
@@ -435,9 +440,7 @@
               }
             }
           }
-        }
 
-        if (allCalendars.length) {
           if (freeCalendars.length) {
             if (freeCalendars.length === allCalendars.length) {
               availability = AvailabilityStatus.FREE;
@@ -704,12 +707,22 @@
 
   let days: Day[];
   $: days = dayRange.map((timestamp: Date) => {
-    let slots = checkOverbooked(
+    const slots = checkOverbooked(
       generateDaySlots(timestamp, start_hour, end_hour),
     ); // TODO: include other potential post-all-slots-established checks, like overbooked, in a single secondary run here.
+
+    const today = new Date(new Date().setHours(0, 0, 0, 0)).getTime();
+    const dayOffset = Math.ceil(
+      (new Date(timestamp).getTime() - today) / (1000 * 60 * 60 * 24),
+    );
+
     return {
-      slots,
       epochs: generateEpochs(slots, partial_bookable_ratio),
+      isBookable:
+        dayOffset >= 0 &&
+        dayOffset >= min_book_ahead_days &&
+        dayOffset <= max_book_ahead_days,
+      slots,
       timestamp,
     };
   });
@@ -809,21 +822,23 @@
     let consolidatedAvailabilityForGivenDay: AvailabilityResponse[] = [];
 
     if (Array.isArray(email_ids) && email_ids.length > 0) {
-      consolidatedAvailabilityForGivenDay = consolidatedAvailabilityForGivenDay.concat(
-        await $AvailabilityStore[
-          JSON.stringify({ ...getAvailabilityQuery(), forceReload })
-        ],
-      );
+      consolidatedAvailabilityForGivenDay =
+        consolidatedAvailabilityForGivenDay.concat(
+          await $AvailabilityStore[
+            JSON.stringify({ ...getAvailabilityQuery(), forceReload })
+          ],
+        );
     }
     if (booking_user_email && booking_user_token) {
-      consolidatedAvailabilityForGivenDay = consolidatedAvailabilityForGivenDay.concat(
-        await $AvailabilityStore[
-          JSON.stringify({
-            ...getAvailabilityQuery([booking_user_email], booking_user_token),
-            forceReload,
-          })
-        ],
-      );
+      consolidatedAvailabilityForGivenDay =
+        consolidatedAvailabilityForGivenDay.concat(
+          await $AvailabilityStore[
+            JSON.stringify({
+              ...getAvailabilityQuery([booking_user_email], booking_user_token),
+              forceReload,
+            })
+          ],
+        );
     }
 
     loading = false;
@@ -1099,7 +1114,7 @@
     : [];
 
   function startDrag(slot: SelectableSlot, day: Day) {
-    if (allow_booking) {
+    if (allow_booking && day.isBookable) {
       // Retain the initially-clicked slot and day, so we can adjust if you've moved across dates, etc.
       dragStartSlot = slot;
       dragStartDay = day;
@@ -1122,7 +1137,7 @@
   }
 
   function addToDrag(slot: SelectableSlot, day: Day) {
-    if (mouseIsDown || touchIsDown) {
+    if (day.isBookable && (mouseIsDown || touchIsDown)) {
       if (draggingExistingBlock && dragStartSlot && dragStartDay) {
         // dragStartSlot && dragStartDay are superfluous here, but type errors are thrown if we don't explicitly check for them
 
@@ -1294,10 +1309,8 @@
       event.touches.length === 1 &&
       event.changedTouches.length === 1 // check if there is a single touch point
     ) {
-      const {
-        pageX: touchPositionX,
-        pageY: touchPositionY,
-      } = event.changedTouches[0];
+      const { pageX: touchPositionX, pageY: touchPositionY } =
+        event.changedTouches[0];
 
       const currentTouchedDayPosition = Object.entries(dayXPositions).find(
         ([_, dayPosition]) => dayPosition.x > touchPositionX,
@@ -1422,18 +1435,9 @@
   class:hide-header={!show_header}
   on:mouseleave={() => endDrag(null)}
   style="
-  --busy-color-lightened: {lightenHexColour(
-    busy_color,
-    90,
-  )};
-  --closed-color-lightened: {lightenHexColour(
-    closed_color,
-    90,
-  )};
-  --selected-color-lightened: {lightenHexColour(
-    selected_color,
-    60,
-  )}; 
+  --busy-color-lightened: {lightenHexColour(busy_color, 90)};
+  --closed-color-lightened: {lightenHexColour(closed_color, 90)};
+  --selected-color-lightened: {lightenHexColour(selected_color, 60)}; 
 --free-color: {free_color}; --busy-color: {busy_color}; --closed-color: {closed_color}; --partial-color: {partial_color}; --selected-color: {selected_color};"
 >
   <header class:dated={allow_date_change}>
@@ -1587,10 +1591,8 @@
                     event.changedTouches.length === 1;
 
                   if (isLastTouch) {
-                    const {
-                      pageX,
-                      pageY: touchPositionY,
-                    } = event.changedTouches[0];
+                    const { pageX, pageY: touchPositionY } =
+                      event.changedTouches[0];
 
                     const currentTouchedSlotPosition = Object.entries(
                       slotYPositions,
@@ -1599,9 +1601,8 @@
                     );
 
                     if (currentTouchedSlotPosition) {
-                      const [
-                        currentTouchedSlotIndex,
-                      ] = currentTouchedSlotPosition;
+                      const [currentTouchedSlotIndex] =
+                        currentTouchedSlotPosition;
 
                       currentTouchedSlot =
                         day.slots[Number(currentTouchedSlotIndex)];

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -152,6 +152,22 @@
         });
 
         document
+          .querySelectorAll('input[name="max-book-ahead"]')
+          .forEach((elem) => {
+            elem.addEventListener("input", function (event) {
+              component.max_book_ahead_days = JSON.parse(event.target.value);
+            });
+          });
+
+        document
+          .querySelectorAll('input[name="min-book-ahead"]')
+          .forEach((elem) => {
+            elem.addEventListener("input", function (event) {
+              component.min_book_ahead_days = JSON.parse(event.target.value);
+            });
+          });
+
+        document
           .querySelector('input[name="capacity"]')
           .addEventListener("input", (event) => {
             component.capacity = JSON.parse(event.target.value);
@@ -468,6 +484,20 @@
         <label>
           Max Bookable Slots
           <input type="number" name="max-slots" min="1" value="1" />
+        </label>
+      </fieldset>
+
+      <fieldset>
+        <label>
+          Max Book Ahead Days
+          <input type="number" name="max-book-ahead" min="1" value="30" />
+        </label>
+      </fieldset>
+
+      <fieldset>
+        <label>
+          Min Book Ahead Days
+          <input type="number" name="min-book-ahead" min="0" value="0" />
         </label>
       </fieldset>
 

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -344,26 +344,28 @@ describe("availability component", () => {
 
   describe("selecting avaialble time slots", () => {
     let selectedTimeslots = [];
+    let availabilityComponent;
 
-    const consecutiveSlotEndTime = new Date(
-      `${new Date().toLocaleDateString()} 15:30:00`,
-    ).toISOString();
-    const singularSlotStartTime = new Date(
-      `${new Date().toLocaleDateString()} 15:45:00`,
-    ).toISOString();
-    const singularSlotEndTime = new Date(
-      `${new Date().toLocaleDateString()} 16:00:00`,
-    ).toISOString();
-
-    it("should combine consecutive time slots", (done) => {
+    beforeEach(() => {
+      selectedTimeslots = [];
       cy.get("nylas-availability").then((element) => {
         const component = element[0];
+        availabilityComponent = component;
         component.allow_booking = true;
         component.max_bookable_slots = 3;
+
         component.calendars = [
           {
             availability: "free",
             timeslots: [
+              {
+                start_time: new Date(new Date().setHours(15 - 24, 0, 0, 0)),
+                end_time: new Date(new Date().setHours(16 - 24, 0, 0, 0)),
+              },
+              {
+                start_time: new Date(new Date().setHours(16 - 24, 0, 0, 0)),
+                end_time: new Date(new Date().setHours(17 - 24, 0, 0, 0)),
+              },
               {
                 start_time: new Date(new Date().setHours(15, 0, 0, 0)),
                 end_time: new Date(new Date().setHours(16, 0, 0, 0)),
@@ -371,6 +373,14 @@ describe("availability component", () => {
               {
                 start_time: new Date(new Date().setHours(16, 0, 0, 0)),
                 end_time: new Date(new Date().setHours(17, 0, 0, 0)),
+              },
+              {
+                start_time: new Date(new Date().setHours(15 + 24, 0, 0, 0)),
+                end_time: new Date(new Date().setHours(16 + 24, 0, 0, 0)),
+              },
+              {
+                start_time: new Date(new Date().setHours(16 + 24, 0, 0, 0)),
+                end_time: new Date(new Date().setHours(17 + 24, 0, 0, 0)),
               },
             ],
             account: {
@@ -385,12 +395,28 @@ describe("availability component", () => {
             availability: "free",
             timeslots: [
               {
+                start_time: new Date(new Date().setHours(15 - 24, 0, 0, 0)),
+                end_time: new Date(new Date().setHours(16 - 24, 0, 0, 0)),
+              },
+              {
+                start_time: new Date(new Date().setHours(16 - 24, 0, 0, 0)),
+                end_time: new Date(new Date().setHours(17 - 24, 0, 0, 0)),
+              },
+              {
                 start_time: new Date(new Date().setHours(15, 0, 0, 0)),
                 end_time: new Date(new Date().setHours(16, 0, 0, 0)),
               },
               {
                 start_time: new Date(new Date().setHours(16, 0, 0, 0)),
                 end_time: new Date(new Date().setHours(17, 0, 0, 0)),
+              },
+              {
+                start_time: new Date(new Date().setHours(15 + 24, 0, 0, 0)),
+                end_time: new Date(new Date().setHours(16 + 24, 0, 0, 0)),
+              },
+              {
+                start_time: new Date(new Date().setHours(16 + 24, 0, 0, 0)),
+                end_time: new Date(new Date().setHours(17 + 24, 0, 0, 0)),
               },
             ],
             account: {
@@ -405,12 +431,28 @@ describe("availability component", () => {
             availability: "free",
             timeslots: [
               {
+                start_time: new Date(new Date().setHours(15 - 24, 0, 0, 0)),
+                end_time: new Date(new Date().setHours(16 - 24, 0, 0, 0)),
+              },
+              {
+                start_time: new Date(new Date().setHours(16 - 24, 0, 0, 0)),
+                end_time: new Date(new Date().setHours(17 - 24, 0, 0, 0)),
+              },
+              {
                 start_time: new Date(new Date().setHours(15, 0, 0, 0)),
                 end_time: new Date(new Date().setHours(16, 0, 0, 0)),
               },
               {
                 start_time: new Date(new Date().setHours(16, 0, 0, 0)),
                 end_time: new Date(new Date().setHours(17, 0, 0, 0)),
+              },
+              {
+                start_time: new Date(new Date().setHours(15 + 24, 0, 0, 0)),
+                end_time: new Date(new Date().setHours(16 + 24, 0, 0, 0)),
+              },
+              {
+                start_time: new Date(new Date().setHours(16 + 24, 0, 0, 0)),
+                end_time: new Date(new Date().setHours(17 + 24, 0, 0, 0)),
               },
             ],
             account: {
@@ -427,8 +469,20 @@ describe("availability component", () => {
           selectedTimeslots = event.detail.timeSlots;
         });
       });
-
       cy.wait(1000); // TODO: have this as a wait for render to be complete instead of a timer
+    });
+
+    it("should combine consecutive time slots", (done) => {
+      const consecutiveSlotEndTime = new Date(
+        `${new Date().toLocaleDateString()} 15:30:00`,
+      ).toISOString();
+      const singularSlotStartTime = new Date(
+        `${new Date().toLocaleDateString()} 15:45:00`,
+      ).toISOString();
+      const singularSlotEndTime = new Date(
+        `${new Date().toLocaleDateString()} 16:00:00`,
+      ).toISOString();
+
       cy.get(".slot.free").should("exist");
       expect(selectedTimeslots).to.have.lengthOf(0);
       cy.get(".slot.free")
@@ -455,6 +509,93 @@ describe("availability component", () => {
                   expect(selectedTimeslots[1].end_time.toISOString()).eq(
                     singularSlotEndTime,
                   );
+                  done();
+                });
+            });
+        });
+    });
+
+    it("should prevent booking events in the past", () => {
+      // Change to previous date
+      cy.get("div.change-dates").should("exist");
+      cy.get(".change-dates button:eq(0)").click();
+
+      cy.get(".slot.free").should("exist");
+      expect(selectedTimeslots).to.have.lengthOf(0);
+      cy.get(".slot.free")
+        .eq(0)
+        .click()
+        .then(() => {
+          expect(selectedTimeslots).to.have.lengthOf(0);
+        });
+    });
+
+    it("should prevent booking on days before min_book_ahead_days", (done) => {
+      // Check that we can book on current date if min_book_ahead_days is 0
+      availabilityComponent.min_book_ahead_days = 0;
+      cy.get(".slot.free").should("exist");
+      expect(selectedTimeslots).to.have.lengthOf(0);
+      cy.get(".slot.free")
+        .eq(0)
+        .click()
+        .then(() => {
+          expect(selectedTimeslots).to.have.lengthOf(1);
+
+          // Check that min_book_ahead_days is respected
+          availabilityComponent.min_book_ahead_days = 1;
+          cy.get(".slot.free").should("exist");
+          expect(selectedTimeslots).to.have.lengthOf(0);
+          cy.get(".slot.free")
+            .eq(0)
+            .click()
+            .then(() => {
+              expect(selectedTimeslots).to.have.lengthOf(0);
+
+              // Change to next date
+              cy.get("div.change-dates").should("exist");
+              cy.get(".change-dates button:eq(1)").click();
+
+              expect(selectedTimeslots).to.have.lengthOf(0);
+              cy.get(".slot.free")
+                .eq(0)
+                .click()
+                .then(() => {
+                  expect(selectedTimeslots).to.have.lengthOf(1);
+                  done();
+                });
+            });
+        });
+    });
+
+    it("should prevent booking on dates after max_book_ahead_days", (done) => {
+      // Check that we can book on current date if max_book_ahead_days is 0
+      availabilityComponent.max_book_ahead_days = 0;
+      cy.get(".slot.free").should("exist");
+      expect(selectedTimeslots).to.have.lengthOf(0);
+      cy.get(".slot.free")
+        .eq(0)
+        .click()
+        .then(() => {
+          expect(selectedTimeslots).to.have.lengthOf(1);
+          selectedTimeslots = [];
+
+          // Change to next date
+          cy.get("div.change-dates").should("exist");
+          cy.get(".change-dates button:eq(1)").click();
+
+          expect(selectedTimeslots).to.have.lengthOf(0);
+          cy.get(".slot.free")
+            .eq(0)
+            .click()
+            .then(() => {
+              expect(selectedTimeslots).to.have.lengthOf(0);
+
+              availabilityComponent.max_book_ahead_days = 1;
+              cy.get(".slot.free")
+                .eq(0)
+                .click()
+                .then(() => {
+                  expect(selectedTimeslots).to.have.lengthOf(1);
                   done();
                 });
             });

--- a/components/availability/src/properties.json
+++ b/components/availability/src/properties.json
@@ -79,6 +79,20 @@
     "value": 1
   },
   {
+    "label": "max_book_ahead_days",
+    "title": "Maximum days ahead that are bookable",
+    "type": "number",
+    "options": [1, 2, 3],
+    "value": 1
+  },
+  {
+    "label": "min_book_ahead_days",
+    "title": "Minimum days ahead that are bookable",
+    "type": "number",
+    "options": [1, 2, 3],
+    "value": 1
+  },
+  {
     "label": "partial_bookable_ratio",
     "title": "Partial bookable ratio",
     "type": "number",

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -21,28 +21,26 @@
 
   export let id: string = "";
   export let access_token: string = "";
-  export let event_title: string;
+
+  export let allow_booking: boolean;
+  export let attendees_to_show: number;
+  export let capacity: number | null;
+  export let dates_to_show: number;
+  export let email_ids: string[];
+  export let end_hour: number;
+  export let event_conferencing: string;
   export let event_description: string;
   export let event_location: string;
-  export let event_conferencing: string;
-  export let show_hosts: "show" | "hide";
-  export let start_hour: number;
-  export let end_hour: number;
-  export let slot_size: number; // in minutes
-  export let start_date: Date;
-  export let dates_to_show: number;
-  export let show_ticks: boolean;
-  export let email_ids: string[];
-  export let allow_booking: boolean;
+  export let event_title: string;
+  export let mandate_top_of_hour: boolean;
   export let max_bookable_slots: number;
-  export let partial_bookable_ratio: number;
-  export let show_as_week: boolean;
-  export let show_weekends: boolean;
-  export let attendees_to_show: number;
-  export let notification_mode: NotificationMode;
+  export let max_book_ahead_days: number;
+  export let min_book_ahead_days: number;
   export let notification_message: string;
+  export let notification_mode: NotificationMode;
   export let notification_subject: string;
-  export let view_as: "schedule" | "list";
+  export let open_hours: AvailabilityRule[];
+  export let partial_bookable_ratio: number;
   export let recurrence: "none" | "required" | "optional";
   export let recurrence_cadence: (
     | "none"
@@ -52,39 +50,46 @@
     | "biweekly"
     | "monthly"
   )[];
-  export let capacity: number | null;
-  export let open_hours: AvailabilityRule[];
-  export let mandate_top_of_hour: boolean;
+  export let show_as_week: boolean;
+  export let show_hosts: "show" | "hide";
   export let show_preview: boolean;
+  export let show_ticks: boolean;
+  export let show_weekends: boolean;
+  export let slot_size: number; // in minutes
+  export let start_date: Date;
+  export let start_hour: number;
+  export let view_as: "schedule" | "list";
 
   const defaultValueMap = {
-    event_title: "Meeting",
-    event_description: "",
-    event_conferencing: "",
-    event_location: "",
-    view_as: "schedule",
-    show_hosts: "show",
-    start_hour: 9,
+    allow_booking: false,
+    attendees_to_show: 5,
+    capacity: 1,
+    dates_to_show: 1,
+    email_ids: [],
     end_hour: 17,
+    event_conferencing: "",
+    event_description: "",
+    event_location: "",
+    event_title: "Meeting",
+    mandate_top_of_hour: false,
+    max_bookable_slots: 1,
+    max_book_ahead_days: 30,
+    min_book_ahead_days: 0,
+    notification_message: "Thank you for scheduling!",
+    notification_mode: NotificationMode.SHOW_MESSAGE,
+    notification_subject: "Invitation",
+    open_hours: [],
+    partial_bookable_ratio: 0.01,
+    recurrence_cadence: ["none"],
+    recurrence: "none",
+    show_as_week: false,
+    show_hosts: "show",
+    show_ticks: true,
+    show_weekends: true,
     slot_size: 15,
     start_date: new Date(),
-    dates_to_show: 1,
-    show_ticks: true,
-    email_ids: [],
-    allow_booking: false,
-    max_bookable_slots: 1,
-    partial_bookable_ratio: 0.01,
-    show_as_week: false,
-    show_weekends: true,
-    attendees_to_show: 5,
-    notification_mode: NotificationMode.SHOW_MESSAGE,
-    notification_message: "Thank you for scheduling!",
-    notification_subject: "Invitation",
-    recurrence: "none",
-    recurrence_cadence: ["none"],
-    capacity: 1,
-    open_hours: [],
-    mandate_top_of_hour: false,
+    start_hour: 9,
+    view_as: "schedule",
   };
 
   //#region mount and prop initialization
@@ -115,34 +120,36 @@
     if (JSON.stringify(rebuiltProps) !== JSON.stringify(internalProps)) {
       internalProps = rebuiltProps;
 
-      event_title = internalProps.event_title;
-      event_description = internalProps.event_description;
-      event_conferencing = internalProps.event_conferencing;
-      event_location = internalProps.event_location;
-      view_as = internalProps.view_as;
-      show_hosts = internalProps.show_hosts;
-      start_hour = internalProps.start_hour;
-      end_hour = internalProps.end_hour;
-      slot_size = internalProps.slot_size;
-      start_date = internalProps.start_date;
-      dates_to_show = internalProps.dates_to_show;
-      show_ticks = internalProps.show_ticks;
-      email_ids = internalProps.email_ids;
       allow_booking = internalProps.allow_booking;
-      max_bookable_slots = internalProps.max_bookable_slots;
-      partial_bookable_ratio = internalProps.partial_bookable_ratio;
-      show_as_week = internalProps.show_as_week;
-      show_weekends = internalProps.show_weekends;
       attendees_to_show = internalProps.attendees_to_show;
-      notification_mode = internalProps.notification_mode;
+      capacity = internalProps.capacity;
+      dates_to_show = internalProps.dates_to_show;
+      email_ids = internalProps.email_ids;
+      end_hour = internalProps.end_hour;
+      event_conferencing = internalProps.event_conferencing;
+      event_description = internalProps.event_description;
+      event_location = internalProps.event_location;
+      event_title = internalProps.event_title;
+      mandate_top_of_hour = internalProps.mandate_top_of_hour;
+      max_bookable_slots = internalProps.max_bookable_slots;
+      max_book_ahead_days = internalProps.max_book_ahead_days;
+      min_book_ahead_days = internalProps.min_book_ahead_days;
       notification_message = internalProps.notification_message;
+      notification_mode = internalProps.notification_mode;
       notification_subject = internalProps.notification_subject;
+      open_hours = internalProps.open_hours;
+      partial_bookable_ratio = internalProps.partial_bookable_ratio;
       recurrence = internalProps.recurrence;
       recurrence_cadence = internalProps.recurrence_cadence;
-      capacity = internalProps.capacity;
-      open_hours = internalProps.open_hours;
-      mandate_top_of_hour = internalProps.mandate_top_of_hour;
+      show_as_week = internalProps.show_as_week;
+      show_hosts = internalProps.show_hosts;
       show_preview = internalProps.show_preview;
+      show_ticks = internalProps.show_ticks;
+      show_weekends = internalProps.show_weekends;
+      slot_size = internalProps.slot_size;
+      start_date = internalProps.start_date;
+      start_hour = internalProps.start_hour;
+      view_as = internalProps.view_as;
     }
   }
 
@@ -742,8 +749,8 @@
         <nylas-availability
           {...internalProps}
           capacity={null}
-          on:timeSlotChosen={(e) => {
-            slots_to_book = e.detail.timeSlots;
+          on:timeSlotChosen={(event) => {
+            slots_to_book = event.detail.timeSlots;
           }}
           calendars={!internalProps.email_ids
             ? [


### PR DESCRIPTION
# Code changes

- Added an `isBookable` prop to Days that determines whether they should be bookable
- Prevent booking on days that are in the past
- Prevent booking on days before `min_book_ahead_days` or after `max_book_ahead_days`
- Chore: Sorted some more prop definitions

![days](https://user-images.githubusercontent.com/8049234/139141016-0dfb7eb4-80ef-45f7-87d5-c2679eea1ded.gif)


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
