### PR TITLE
Fixed props not being properly coerced to boolean values

### DIFF
--- a/commons/src/methods/component.ts
+++ b/commons/src/methods/component.ts
@@ -35,15 +35,16 @@ export function buildInternalProps<T extends Manifest>(
   defaultValueMap: Record<string, any>,
 ): T {
   return new Proxy(properties, {
-    // set: () => {
-    // },
     get: (properties, name: keyof Manifest | "toJSON" | "toString") => {
       if (name === "toString" || name === "toJSON") {
         return () => JSON.stringify(properties);
       }
 
       if (Reflect.get(properties, name) !== undefined) {
-        return Reflect.get(properties, name);
+        return getPropertyValue(
+          Reflect.get(properties, name),
+          defaultValueMap[name],
+        );
       }
 
       if (name in properties) {


### PR DESCRIPTION
The recent addition of reflecting existing props inside of `internalProps` wasn't coercing boolean values.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
