### PR TITLE
Agenda bug fix: timezone offset makes previous-day events show as as "early" point in auto_time_box

### DIFF
--- a/components/agenda/src/Agenda.svelte
+++ b/components/agenda/src/Agenda.svelte
@@ -155,7 +155,7 @@
   let selectedDate: Date;
   $: selectedDate = (() => {
     if (selected_date) {
-      const date = new Date(selected_date);
+      const date = convertToUTC(new Date(selected_date));
       date.setHours(0, 0, 0, 0);
       return date;
     } else if (allowedDates.length) {
@@ -167,8 +167,8 @@
     }
   })();
 
-  function convertToUTC(date: Date): number {
-    return date.setMinutes(date.getMinutes() - date.getTimezoneOffset());
+  function convertToUTC(date: Date): Date {
+    return new Date(date.getTime() + date.getTimezoneOffset() * 60000);
   }
 
   $: hideCurrentTime =
@@ -233,9 +233,9 @@
   let endOfDay: number;
 
   $: startOfDay =
-    convertToUTC(new Date(new Date(selectedDate).setHours(0, 0, 0, 0))) / 1000;
+    new Date(new Date(selectedDate).setHours(0, 0, 0, 0)).getTime() / 1000;
   $: endOfDay =
-    convertToUTC(new Date(new Date(selectedDate).setHours(24, 0, 0, 0))) / 1000;
+    new Date(new Date(selectedDate).setHours(24, 0, 0, 0)).getTime() / 1000;
 
   // #endregion time constants
 
@@ -289,10 +289,10 @@
         access_token: access_token,
         calendarIDs: calendarIDs,
         starts_after:
-          convertToUTC(new Date(new Date(previousDate).setHours(0, 0, 0, 0))) /
+          new Date(new Date(previousDate).setHours(0, 0, 0, 0)).getTime() /
           1000,
         ends_before:
-          convertToUTC(new Date(new Date(previousDate).setHours(24, 0, 0, 0))) /
+          new Date(new Date(previousDate).setHours(24, 0, 0, 0)).getTime() /
           1000,
       },
       {
@@ -300,11 +300,9 @@
         access_token: access_token,
         calendarIDs: calendarIDs,
         starts_after:
-          convertToUTC(new Date(new Date(nextDate).setHours(0, 0, 0, 0))) /
-          1000,
+          new Date(new Date(nextDate).setHours(0, 0, 0, 0)).getTime() / 1000,
         ends_before:
-          convertToUTC(new Date(new Date(nextDate).setHours(24, 0, 0, 0))) /
-          1000,
+          new Date(new Date(nextDate).setHours(24, 0, 0, 0)).getTime() / 1000,
       },
     ];
   }
@@ -1496,12 +1494,17 @@
                 class:expanded={expandedEventId === event.id}
                 class="event status-{event.attendeeStatus}"
                 data-calendar-id={calendarIDs.indexOf(event.calendar_id) + 1}
-                style="top: {event.relativeStartTime * 100}%; height: 
+                style="top: {event.relativeStartTime *
+                  100}%; height: 
               {condensed
                   ? `calc(${event.relativeRunTime * 100}% - 4px)`
-                  : `calc(${event.relativeRunTime * 100}%  - 4px)`};
-              left: {event.relativeOverlapOffset * 100}%; 
-              width: calc({event.relativeOverlapWidth * 100}% - 4px)"
+                  : `calc(${
+                      event.relativeRunTime * 100
+                    }%  - 4px)`};
+              left: {event.relativeOverlapOffset *
+                  100}%; 
+              width: calc({event.relativeOverlapWidth *
+                  100}% - 4px)"
               >
                 <div
                   class="inner"


### PR DESCRIPTION
Bug: in the eastern time zone (GMT-4), a 10pm event would mistakenly show up as, effectively, "tomorrow at negative-two o'clock".

We can correct this by forcing the start_date date to be interpreted as UTC no matter what. That is, when someone says "show the agenda on October 28th", and the end user is visiting from Shanghai (China standard time; GMT+8) making an event on my (eastern, gmt-4) calendar at 6pm would show up at 6am the following day -- and therefor not be shown at all on the 28th, until they click the next date button.

The fix here is to repurpose `convertToUTC` to no longer be used when determining our start_time / end_time on `GET /events` requests, but to instead use it only when parsing the intended date passed in as `selected_date` from the implementing dev.

---
### A good way to test this:
- In Chrome's dev tools, click More Tools -> Sensors: 
![CleanShot 2021-10-28 at 17 00 32](https://user-images.githubusercontent.com/713991/139334935-9c9931da-66db-4f6e-bba1-caccf76f1830.png)

- Select a different time zone
- pass in a specific date as `selected_date` on the component, like `agenda.selected_date = new Date('2021-10-28')`
- No matter your time zone that should be the date that shows up.
- Then, try it without passing in a specific date
- Today's date **in that time zone** should be the one that shows up

and of course, zooming out from auto_time_box should not reveal any events that weren't included in the time box.


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
