### PR TITLE
[Mailbox][Email]: Style tweaks to respect parent container width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 2021-10-28
+
+## 1.0.12
+
+- README & components index: Updated with our new launched components (Email, Mailbox, Conversation) 🎉
+
+### Bug Fixes
+
+- Email: Fixed a bug where access_token prop was not being sent in the requests [Pull Request](https://github.com/nylas/components/pull/145)
+- Conversation: Fixed a bug where access_token prop was not being sent in the requests [Pull Request](https://github.com/nylas/components/pull/147)
+
 # 2021-10-25
 
 ## 1.0.11

--- a/commons/src/components/MessageBody.svelte
+++ b/commons/src/components/MessageBody.svelte
@@ -7,6 +7,13 @@
   export let message;
 </script>
 
+<style>
+  div {
+    width: 100%;
+    height: 100%;
+  }
+</style>
+
 <div>
   {#if message && message.body}
     {@html message.body}

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -92,7 +92,10 @@
 
     // Fetch Account
     if (id && !you.id && !emailManuallyPassed) {
-      you = await fetchAccount({ component_id: query.component_id, access_token });
+      you = await fetchAccount({
+        component_id: query.component_id,
+        access_token,
+      });
       userEmail = <string>you.email_address;
       // Initialize labels / folders
       const accountOrganizationUnitQuery = {
@@ -637,6 +640,7 @@
     height: 100%;
     width: 100%;
     position: relative;
+    display: grid;
     font-family: -apple-system, BlinkMacSystemFont, sans-serif;
     .email-row {
       background: var(--nylas-email-background, var(--grey-lightest));
@@ -1073,6 +1077,7 @@
                 width: 100%;
                 box-sizing: border-box;
                 padding: 0 $spacing-xl;
+                white-space: pre-wrap;
                 max-width: 95vw;
                 align-self: flex-start;
               }

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -85,7 +85,10 @@
 
     // Fetch Account
     if (id && !you.id && !all_threads) {
-      you = await fetchAccount({ component_id: query.component_id, access_token });
+      you = await fetchAccount({
+        component_id: query.component_id,
+        access_token,
+      });
     }
 
     const accountOrganizationUnitQuery = {
@@ -466,6 +469,7 @@
     width: 100%;
     position: relative;
     display: grid;
+    grid-auto-rows: max-content;
     font-family: -apple-system, BlinkMacSystemFont, sans-serif;
 
     $outline-style: 1px solid var(--grey-lighter);
@@ -584,13 +588,17 @@
 
   .mailbox-loader,
   .mailbox-empty {
-    width: calc(100vw - 16px);
+    width: calc(100% - 16px);
     height: 100vh;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
     box-shadow: none;
+  }
+
+  .mailbox-loader {
+    position: absolute;
   }
 
   @keyframes rotate {


### PR DESCRIPTION
# Code changes

- Updated styles in Mailbox, Email & MessageBody components to respect the parent container width.

# Screenshot:
![image](https://user-images.githubusercontent.com/16315004/139338272-76e9539d-6d23-4177-80b4-68577a41b631.png)
![image](https://user-images.githubusercontent.com/16315004/139338346-6ce9139a-3731-498a-82e0-222b524221f7.png)
![image](https://user-images.githubusercontent.com/16315004/139338597-691e4e12-d8f1-436f-ab32-9504b844106a.png)


# Readiness checklist

- [X] Cypress tests passing?
- [X] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
