### PR TITLE
Fixed manifest properties not being set properly if no passed prop exists

### DIFF
--- a/components/agenda/src/Agenda.svelte
+++ b/components/agenda/src/Agenda.svelte
@@ -93,11 +93,13 @@
     manifest = ((await $ManifestStore[
       JSON.stringify({ component_id: id, access_token })
     ]) || {}) as AgendaProperties;
-    internalProps = buildInternalProps(
-      $$props,
-      manifest,
-      defaultValueMap,
-    ) as AgendaProperties;
+    updateInternalProps(
+      buildInternalProps(
+        $$props,
+        manifest,
+        defaultValueMap,
+      ) as AgendaProperties,
+    );
 
     setInterval(() => {
       now = new Date().getTime();
@@ -115,24 +117,28 @@
       defaultValueMap,
     ) as AgendaProperties;
     if (JSON.stringify(rebuiltProps) !== JSON.stringify(internalProps)) {
-      internalProps = rebuiltProps;
-
-      allow_date_change = internalProps.allow_date_change;
-      allow_event_creation = internalProps.allow_event_creation;
-      auto_time_box = internalProps.auto_time_box;
-      calendar_ids = internalProps.calendar_ids;
-      color_by = internalProps.color_by;
-      condensed_view = internalProps.condensed_view;
-      header_type = internalProps.header_type;
-      hide_current_time = internalProps.hide_current_time;
-      hide_all_day_events = internalProps.hide_all_day_events;
-      prevent_zoom = internalProps.prevent_zoom;
-      show_no_events_message = internalProps.show_no_events_message;
-      eagerly_fetch_events = internalProps.eagerly_fetch_events;
-      event_snap_interval = internalProps.event_snap_interval;
-      theme = internalProps.theme;
-      hide_ticks = internalProps.hide_ticks;
+      updateInternalProps(rebuiltProps);
     }
+  }
+
+  function updateInternalProps(updatedProps: AgendaProperties) {
+    internalProps = updatedProps;
+
+    allow_date_change = internalProps.allow_date_change;
+    allow_event_creation = internalProps.allow_event_creation;
+    auto_time_box = internalProps.auto_time_box;
+    calendar_ids = internalProps.calendar_ids;
+    color_by = internalProps.color_by;
+    condensed_view = internalProps.condensed_view;
+    header_type = internalProps.header_type;
+    hide_current_time = internalProps.hide_current_time;
+    hide_all_day_events = internalProps.hide_all_day_events;
+    prevent_zoom = internalProps.prevent_zoom;
+    show_no_events_message = internalProps.show_no_events_message;
+    eagerly_fetch_events = internalProps.eagerly_fetch_events;
+    event_snap_interval = internalProps.event_snap_interval;
+    theme = internalProps.theme;
+    hide_ticks = internalProps.hide_ticks;
   }
 
   let themeUrl: string;
@@ -1494,17 +1500,12 @@
                 class:expanded={expandedEventId === event.id}
                 class="event status-{event.attendeeStatus}"
                 data-calendar-id={calendarIDs.indexOf(event.calendar_id) + 1}
-                style="top: {event.relativeStartTime *
-                  100}%; height: 
+                style="top: {event.relativeStartTime * 100}%; height: 
               {condensed
                   ? `calc(${event.relativeRunTime * 100}% - 4px)`
-                  : `calc(${
-                      event.relativeRunTime * 100
-                    }%  - 4px)`};
-              left: {event.relativeOverlapOffset *
-                  100}%; 
-              width: calc({event.relativeOverlapWidth *
-                  100}% - 4px)"
+                  : `calc(${event.relativeRunTime * 100}%  - 4px)`};
+              left: {event.relativeOverlapOffset * 100}%; 
+              width: calc({event.relativeOverlapWidth * 100}% - 4px)"
               >
                 <div
                   class="inner"

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -224,11 +224,9 @@
     });
     manifest = (await $ManifestStore[storeKey]) || {};
 
-    internalProps = buildInternalProps(
-      $$props,
-      manifest,
-      defaultValueMap,
-    ) as Manifest;
+    updateInternalProps(
+      buildInternalProps($$props, manifest, defaultValueMap) as Manifest,
+    );
 
     const calendarQuery: CalendarQuery = {
       access_token,
@@ -264,41 +262,45 @@
       defaultValueMap,
     ) as Manifest;
     if (JSON.stringify(rebuiltProps) !== JSON.stringify(internalProps)) {
-      internalProps = rebuiltProps;
-
-      allow_booking = internalProps.allow_booking;
-      allow_date_change = internalProps.allow_date_change;
-      attendees_to_show = internalProps.attendees_to_show;
-      busy_color = internalProps.busy_color;
-      calendars = internalProps.calendars;
-      capacity = internalProps.capacity;
-      closed_color = internalProps.closed_color;
-      date_format = internalProps.date_format;
-      dates_to_show = internalProps.dates_to_show;
-      email_ids = internalProps.email_ids;
-      end_hour = internalProps.end_hour;
-      event_buffer = internalProps.event_buffer;
-      free_color = internalProps.free_color;
-      mandate_top_of_hour = internalProps.mandate_top_of_hour;
-      max_bookable_slots = internalProps.max_bookable_slots;
-      max_book_ahead_days = internalProps.max_book_ahead_days;
-      min_book_ahead_days = internalProps.min_book_ahead_days;
-      open_hours = internalProps.open_hours;
-      overbooked_threshold = internalProps.overbooked_threshold;
-      partial_bookable_ratio = internalProps.partial_bookable_ratio;
-      partial_color = internalProps.partial_color;
-      required_participants = internalProps.required_participants;
-      selected_color = internalProps.selected_color;
-      show_as_week = internalProps.show_as_week;
-      show_header = internalProps.show_header;
-      show_hosts = internalProps.show_hosts;
-      show_ticks = internalProps.show_ticks;
-      show_weekends = internalProps.show_weekends;
-      slot_size = internalProps.slot_size;
-      start_date = internalProps.start_date;
-      start_hour = internalProps.start_hour;
-      view_as = internalProps.view_as;
+      updateInternalProps(rebuiltProps);
     }
+  }
+
+  function updateInternalProps(updatedProps: Manifest) {
+    internalProps = updatedProps;
+
+    allow_booking = internalProps.allow_booking;
+    allow_date_change = internalProps.allow_date_change;
+    attendees_to_show = internalProps.attendees_to_show;
+    busy_color = internalProps.busy_color;
+    calendars = internalProps.calendars;
+    capacity = internalProps.capacity;
+    closed_color = internalProps.closed_color;
+    date_format = internalProps.date_format;
+    dates_to_show = internalProps.dates_to_show;
+    email_ids = internalProps.email_ids;
+    end_hour = internalProps.end_hour;
+    event_buffer = internalProps.event_buffer;
+    free_color = internalProps.free_color;
+    mandate_top_of_hour = internalProps.mandate_top_of_hour;
+    max_bookable_slots = internalProps.max_bookable_slots;
+    max_book_ahead_days = internalProps.max_book_ahead_days;
+    min_book_ahead_days = internalProps.min_book_ahead_days;
+    open_hours = internalProps.open_hours;
+    overbooked_threshold = internalProps.overbooked_threshold;
+    partial_bookable_ratio = internalProps.partial_bookable_ratio;
+    partial_color = internalProps.partial_color;
+    required_participants = internalProps.required_participants;
+    selected_color = internalProps.selected_color;
+    show_as_week = internalProps.show_as_week;
+    show_header = internalProps.show_header;
+    show_hosts = internalProps.show_hosts;
+    show_ticks = internalProps.show_ticks;
+    show_weekends = internalProps.show_weekends;
+    slot_size = internalProps.slot_size;
+    start_date = internalProps.start_date;
+    start_hour = internalProps.start_hour;
+    view_as = internalProps.view_as;
   }
 
   async function getContact(email: string) {

--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -156,11 +156,13 @@
         show_from = false;
       }
     }
-    internalProps = buildInternalProps(
-      $$props,
-      manifest,
-      defaultValueMap,
-    ) as ComposerProperties;
+    updateInternalProps(
+      buildInternalProps(
+        $$props,
+        manifest,
+        defaultValueMap,
+      ) as ComposerProperties,
+    );
     if (tracking) {
       // Set tracking on message object
       update("tracking", tracking);
@@ -177,7 +179,7 @@
       defaultValueMap,
     ) as ComposerProperties;
     if (JSON.stringify(rebuiltProps) !== JSON.stringify(internalProps)) {
-      internalProps = rebuiltProps;
+      updateInternalProps(rebuiltProps);
     }
   }
 
@@ -186,6 +188,11 @@
   }
 
   $: {
+  }
+
+  function updateInternalProps(updatedProps: ComposerProperties) {
+    internalProps = updatedProps;
+
     show_to = internalProps.show_to;
     show_from = internalProps.show_from;
     minimized = internalProps.minimized;

--- a/components/contact-list/src/ContactList.svelte
+++ b/components/contact-list/src/ContactList.svelte
@@ -72,11 +72,13 @@
     manifest = ((await $ManifestStore[
       JSON.stringify({ component_id: id, access_token })
     ]) || {}) as ContactListProperties;
-    internalProps = buildInternalProps(
-      $$props,
-      manifest,
-      defaultValueMap,
-    ) as ContactListProperties;
+    updateInternalProps(
+      buildInternalProps(
+        $$props,
+        manifest,
+        defaultValueMap,
+      ) as ContactListProperties,
+    );
 
     if (contacts) {
       hydratedContacts = contacts as HydratedContact[];
@@ -100,16 +102,20 @@
       defaultValueMap,
     ) as ContactListProperties;
     if (JSON.stringify(rebuiltProps) !== JSON.stringify(internalProps)) {
-      internalProps = rebuiltProps;
-
-      theme = internalProps.theme;
-      click_action = internalProps.click_action;
-      sort_by = internalProps.sort_by;
-      show_filter = internalProps.show_filter;
-      default_photo = internalProps.default_photo;
-      show_names = internalProps.show_names;
-      contacts_to_load = internalProps.contacts_to_load;
+      updateInternalProps(rebuiltProps);
     }
+  }
+
+  function updateInternalProps(updatedProps: ContactListProperties) {
+    internalProps = updatedProps;
+
+    theme = internalProps.theme;
+    click_action = internalProps.click_action;
+    sort_by = internalProps.sort_by;
+    show_filter = internalProps.show_filter;
+    default_photo = internalProps.default_photo;
+    show_names = internalProps.show_names;
+    contacts_to_load = internalProps.contacts_to_load;
   }
 
   let themeUrl: string;

--- a/components/conversation/src/Conversation.svelte
+++ b/components/conversation/src/Conversation.svelte
@@ -60,11 +60,13 @@
       JSON.stringify({ component_id: id, access_token })
     ]) || {}) as ConversationProperties;
 
-    internalProps = buildInternalProps(
-      $$props,
-      manifest,
-      defaultValueMap,
-    ) as ConversationProperties;
+    updateInternalProps(
+      buildInternalProps(
+        $$props,
+        manifest,
+        defaultValueMap,
+      ) as ConversationProperties,
+    );
 
     // Fetch Account
     if (id && !you.id && !conversationManuallyPassed) {
@@ -94,15 +96,19 @@
       defaultValueMap,
     ) as ConversationProperties;
     if (JSON.stringify(rebuiltProps) !== JSON.stringify(internalProps)) {
-      internalProps = rebuiltProps;
-
-      theme = internalProps.theme;
-      show_avatars = internalProps.show_avatars;
-      show_reply = internalProps.show_reply;
-      const internalPropThreadID =
-        messages.length === 0 ? internalProps.thread_id : "";
-      thread_id = internalPropThreadID;
+      updateInternalProps(rebuiltProps);
     }
+  }
+
+  function updateInternalProps(updatedProps: ConversationProperties) {
+    internalProps = updatedProps;
+
+    theme = internalProps.theme;
+    show_avatars = internalProps.show_avatars;
+    show_reply = internalProps.show_reply;
+    const internalPropThreadID =
+      messages.length === 0 ? internalProps.thread_id : "";
+    thread_id = internalPropThreadID;
   }
 
   $: hideAvatars = show_avatars === false || show_avatars === "false"; // can be boolean or string, for developer experience reasons. Awkward for us, better for them.

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -84,11 +84,9 @@
       JSON.stringify({ component_id: id, access_token })
     ]) || {}) as EmailProperties;
 
-    internalProps = buildInternalProps(
-      $$props,
-      manifest,
-      defaultValueMap,
-    ) as EmailProperties;
+    updateInternalProps(
+      buildInternalProps($$props, manifest, defaultValueMap) as EmailProperties,
+    );
 
     // Fetch Account
     if (id && !you.id && !emailManuallyPassed) {
@@ -188,28 +186,32 @@
       defaultValueMap,
     ) as EmailProperties;
     if (JSON.stringify(rebuiltProps) !== JSON.stringify(internalProps)) {
-      internalProps = rebuiltProps;
+      updateInternalProps(rebuiltProps);
+    }
+  }
 
-      theme = internalProps.theme;
-      show_received_timestamp = internalProps.show_received_timestamp;
-      show_number_of_messages = internalProps.show_number_of_messages;
-      show_star = internalProps.show_star;
-      unread = internalProps.unread;
-      click_action = internalProps.click_action;
+  function updateInternalProps(updatedProps: EmailProperties) {
+    internalProps = updatedProps;
 
-      // Assign thread_id to threadID stored in the manifest only when passing a thread_id
-      const internalPropThreadID =
-        !thread && !message_id && !message ? internalProps.thread_id : "";
-      thread_id = internalPropThreadID;
-      show_contact_avatar = internalProps.show_contact_avatar;
-      show_expanded_email_view_onload =
-        internalProps.show_expanded_email_view_onload;
-      clean_conversation = internalProps.clean_conversation;
+    theme = internalProps.theme;
+    show_received_timestamp = internalProps.show_received_timestamp;
+    show_number_of_messages = internalProps.show_number_of_messages;
+    show_star = internalProps.show_star;
+    unread = internalProps.unread;
+    click_action = internalProps.click_action;
 
-      if (activeThread && click_action === "mailbox") {
-        // enables bulk starring action in mailbox to immediately reflect visually
-        activeThread = activeThread;
-      }
+    // Assign thread_id to threadID stored in the manifest only when passing a thread_id
+    const internalPropThreadID =
+      !thread && !message_id && !message ? internalProps.thread_id : "";
+    thread_id = internalPropThreadID;
+    show_contact_avatar = internalProps.show_contact_avatar;
+    show_expanded_email_view_onload =
+      internalProps.show_expanded_email_view_onload;
+    clean_conversation = internalProps.clean_conversation;
+
+    if (activeThread && click_action === "mailbox") {
+      // enables bulk starring action in mailbox to immediately reflect visually
+      activeThread = activeThread;
     }
   }
 

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -77,11 +77,13 @@
     manifest = ((await $ManifestStore[
       JSON.stringify({ component_id: id, access_token })
     ]) || {}) as MailboxProperties;
-    internalProps = buildInternalProps(
-      $$props,
-      manifest,
-      defaultValueMap,
-    ) as MailboxProperties;
+    updateInternalProps(
+      buildInternalProps(
+        $$props,
+        manifest,
+        defaultValueMap,
+      ) as MailboxProperties,
+    );
 
     // Fetch Account
     if (id && !you.id && !all_threads) {
@@ -156,16 +158,20 @@
       defaultValueMap,
     ) as MailboxProperties;
     if (JSON.stringify(rebuiltProps) !== JSON.stringify(internalProps)) {
-      internalProps = rebuiltProps;
-
-      show_star = internalProps.show_star;
-      unread_status = internalProps.unread_status;
-      items_per_page = parseInt(internalProps.items_per_page);
-      header = internalProps.header;
-      query_string = internalProps.query_string;
-      keyword_to_search = internalProps.keyword_to_search;
-      actions_bar = internalProps.actions_bar;
+      updateInternalProps(rebuiltProps);
     }
+  }
+
+  function updateInternalProps(updatedProps: MailboxProperties) {
+    internalProps = updatedProps;
+
+    show_star = internalProps.show_star;
+    unread_status = internalProps.unread_status;
+    items_per_page = parseInt(internalProps.items_per_page);
+    header = internalProps.header;
+    query_string = internalProps.query_string;
+    keyword_to_search = internalProps.keyword_to_search;
+    actions_bar = internalProps.actions_bar;
   }
 
   // Reactive statement to continuously fetch all_threads

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -104,11 +104,9 @@
       setManifestDefaults(manifest);
     }
 
-    internalProps = buildInternalProps(
-      $$props,
-      manifest,
-      defaultValueMap,
-    ) as Manifest;
+    updateInternalProps(
+      buildInternalProps($$props, manifest, defaultValueMap) as Manifest,
+    );
   });
 
   $: {
@@ -118,39 +116,43 @@
       defaultValueMap,
     ) as Manifest;
     if (JSON.stringify(rebuiltProps) !== JSON.stringify(internalProps)) {
-      internalProps = rebuiltProps;
-
-      allow_booking = internalProps.allow_booking;
-      attendees_to_show = internalProps.attendees_to_show;
-      capacity = internalProps.capacity;
-      dates_to_show = internalProps.dates_to_show;
-      email_ids = internalProps.email_ids;
-      end_hour = internalProps.end_hour;
-      event_conferencing = internalProps.event_conferencing;
-      event_description = internalProps.event_description;
-      event_location = internalProps.event_location;
-      event_title = internalProps.event_title;
-      mandate_top_of_hour = internalProps.mandate_top_of_hour;
-      max_bookable_slots = internalProps.max_bookable_slots;
-      max_book_ahead_days = internalProps.max_book_ahead_days;
-      min_book_ahead_days = internalProps.min_book_ahead_days;
-      notification_message = internalProps.notification_message;
-      notification_mode = internalProps.notification_mode;
-      notification_subject = internalProps.notification_subject;
-      open_hours = internalProps.open_hours;
-      partial_bookable_ratio = internalProps.partial_bookable_ratio;
-      recurrence = internalProps.recurrence;
-      recurrence_cadence = internalProps.recurrence_cadence;
-      show_as_week = internalProps.show_as_week;
-      show_hosts = internalProps.show_hosts;
-      show_preview = internalProps.show_preview;
-      show_ticks = internalProps.show_ticks;
-      show_weekends = internalProps.show_weekends;
-      slot_size = internalProps.slot_size;
-      start_date = internalProps.start_date;
-      start_hour = internalProps.start_hour;
-      view_as = internalProps.view_as;
+      updateInternalProps(rebuiltProps);
     }
+  }
+
+  function updateInternalProps(updatedProps: Manifest) {
+    internalProps = updatedProps;
+
+    allow_booking = internalProps.allow_booking;
+    attendees_to_show = internalProps.attendees_to_show;
+    capacity = internalProps.capacity;
+    dates_to_show = internalProps.dates_to_show;
+    email_ids = internalProps.email_ids;
+    end_hour = internalProps.end_hour;
+    event_conferencing = internalProps.event_conferencing;
+    event_description = internalProps.event_description;
+    event_location = internalProps.event_location;
+    event_title = internalProps.event_title;
+    mandate_top_of_hour = internalProps.mandate_top_of_hour;
+    max_bookable_slots = internalProps.max_bookable_slots;
+    max_book_ahead_days = internalProps.max_book_ahead_days;
+    min_book_ahead_days = internalProps.min_book_ahead_days;
+    notification_message = internalProps.notification_message;
+    notification_mode = internalProps.notification_mode;
+    notification_subject = internalProps.notification_subject;
+    open_hours = internalProps.open_hours;
+    partial_bookable_ratio = internalProps.partial_bookable_ratio;
+    recurrence = internalProps.recurrence;
+    recurrence_cadence = internalProps.recurrence_cadence;
+    show_as_week = internalProps.show_as_week;
+    show_hosts = internalProps.show_hosts;
+    show_preview = internalProps.show_preview;
+    show_ticks = internalProps.show_ticks;
+    show_weekends = internalProps.show_weekends;
+    slot_size = internalProps.slot_size;
+    start_date = internalProps.start_date;
+    start_hour = internalProps.start_hour;
+    view_as = internalProps.view_as;
   }
 
   // Manifest properties requiring further manipulation:

--- a/components/scheduler/src/Scheduler.svelte
+++ b/components/scheduler/src/Scheduler.svelte
@@ -81,11 +81,9 @@
     });
     manifest = (await $ManifestStore[storeKey]) || {};
 
-    internalProps = buildInternalProps(
-      $$props,
-      manifest,
-      defaultValueMap,
-    ) as Manifest;
+    updateInternalProps(
+      buildInternalProps($$props, manifest, defaultValueMap) as Manifest,
+    );
   });
 
   $: {
@@ -95,23 +93,27 @@
       defaultValueMap,
     ) as Manifest;
     if (JSON.stringify(rebuiltProps) !== JSON.stringify(internalProps)) {
-      internalProps = rebuiltProps;
-
-      availability_id = internalProps.availability_id;
-      email_ids = internalProps.email_ids;
-      booking_label = internalProps.booking_label;
-      event_title = internalProps.event_title;
-      event_description = internalProps.event_description;
-      event_location = internalProps.event_location;
-      event_conferencing = internalProps.event_conferencing;
-      slots_to_book = internalProps.slots_to_book;
-      notification_mode = internalProps.notification_mode;
-      notification_message = internalProps.notification_message;
-      notification_subject = internalProps.notification_subject;
-      recurrence = internalProps.recurrence;
-      recurrence_cadence = internalProps.recurrence_cadence;
-      recurrence_expiry = internalProps.recurrence_expiry;
+      updateInternalProps(rebuiltProps);
     }
+  }
+
+  function updateInternalProps(updatedProps: Manifest) {
+    internalProps = updatedProps;
+
+    availability_id = internalProps.availability_id;
+    email_ids = internalProps.email_ids;
+    booking_label = internalProps.booking_label;
+    event_title = internalProps.event_title;
+    event_description = internalProps.event_description;
+    event_location = internalProps.event_location;
+    event_conferencing = internalProps.event_conferencing;
+    slots_to_book = internalProps.slots_to_book;
+    notification_mode = internalProps.notification_mode;
+    notification_message = internalProps.notification_message;
+    notification_subject = internalProps.notification_subject;
+    recurrence = internalProps.recurrence;
+    recurrence_cadence = internalProps.recurrence_cadence;
+    recurrence_expiry = internalProps.recurrence_expiry;
   }
 
   const dispatchEvent = getEventDispatcher(get_current_component());


### PR DESCRIPTION
# Code changes

Created `updateInternalProps` method that contains the logic used to set component props to their `internalProps` values, which will be called after the manifest is loaded in the `onMount`.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
