### PR TITLE
Fix CSS Vars so overrides work

### DIFF
--- a/components/agenda/src/Agenda.svelte
+++ b/components/agenda/src/Agenda.svelte
@@ -912,18 +912,6 @@
   @import "../../theming/variables.scss";
 
   main {
-    --mainTextAndDeclinedEvents: #000000;
-    --calendarEventText: #ffffff;
-    --linesAndIcons: #d5d5d5;
-    --monthsOnMobileDropdown: #f1f1f1;
-    --primaryAndMainCalendar: #002db4;
-    --secondaryCalendar: #315df2;
-    --thirdCalendar: #078351;
-    --timeLine: #36d2ac;
-    --declinedEvent: #636671;
-    --alertWarningDeclined: #36d2ac;
-    --headerBackground: #ffffff;
-    --emptyEventBackground: #eeeeee;
     @import "./styles/agenda-themes.scss";
 
     text-align: center;

--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -573,6 +573,21 @@
       padding: 5px;
     }
   }
+
+  [class$="Icon"] {
+    fill: var(--composer-icons-color, #666774);
+    width: 10px;
+    height: 10px;
+  }
+  .ExpandIcon {
+    transform: translateY(1px);
+  }
+  .MinimizeIcon {
+    transform: translateY(4px);
+  }
+  .AttachmentIcon {
+    margin-right: 15px;
+  }
 </style>
 
 <nylas-error {id} />
@@ -601,23 +616,17 @@
           {#if show_minimize_button}
             {#if minimized}
               <button class="composer-btn" on:click={handleMinimize}>
-                <ExpandIcon
-                  style="fill: var(--composer-icons-color, #666774); width: 10px; height: 10px; transform: translateY(1px)"
-                />
+                <ExpandIcon class="ExpandIcon" />
               </button>
             {:else}
               <button class="composer-btn" on:click={handleMinimize}>
-                <MinimizeIcon
-                  style="fill: var(--composer-icons-color, #666774); width: 10px; height: 10px; transform: translateY(4px)"
-                />
+                <MinimizeIcon class="MinimizeIcon" />
               </button>
             {/if}
           {/if}
           {#if show_close_button}
             <button class="composer-btn" on:click={close}>
-              <CloseIcon
-                style="fill: var(--composer-icons-color, #666774); width: 10px; height: 10px;"
-              />
+              <CloseIcon class="CloseIcon" />
             </button>
           {/if}
         </div>
@@ -677,9 +686,7 @@
               }}
               aria-label="remove carbon copy field"
             >
-              <CloseIcon
-                style="fill: var(--composer-icons-color, #666774); width: 10px; height: 10px;"
-              />
+              <CloseIcon class="CloseIcon" />
             </button>
           </div>
         {/if}
@@ -700,9 +707,7 @@
               }}
               aria-label="remove blind carbon copy field"
             >
-              <CloseIcon
-                style="fill: var(--composer-icons-color, #666774); width: 10px; height: 10px;"
-              />
+              <CloseIcon class="CloseIcon" />
             </button>
           </div>
         {/if}
@@ -748,9 +753,7 @@
             style="margin-right: 10px; width: 32px; height: 32px;"
             on:click={() => fileSelector.click()}
           >
-            <AttachmentIcon
-              style="fill: var(--composer-icons-color, #666774); width: 16px; height: 16px; margin-right: 15px"
-            />
+            <AttachmentIcon class="AttachmentIcon" />
           </button>
         {/if}
         <div class="btn-group">

--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -366,46 +366,19 @@
 
 <style lang="scss">
   .nylas-composer {
-    // Default composer theme (when theme property is not set)
-    --font: sans-serif;
-    --font-size: 14px;
-    --font-size-small: 12px;
-
-    // Colors
-    --background: white;
-    --background-muted: #f0f2ff;
-    --text: black;
-    --text-light: #6e6e7a;
-    --text-secondary: #2247ff;
-    --border: #f7f7f7;
-    --icons: #666774;
-    --header-background: var(--background);
-    --primary: #5c77ff;
-    --primary-light: #f0f2ff;
-    --primary-dark: #294dff;
-    --danger: #ff5c5c;
-    --danger-light: #ffe3e3;
-    --success: var(--background);
-    --success-light: var(--primary);
-    --info: var(--primary);
-    --info-light: var(--primary-light);
-
-    --border-radius: 6px;
-    --shadow: 0 1px 10px rgba(0, 0, 0, 0.11), 0 3px 36px rgba(0, 0, 0, 0.12);
-    --outer-padding: 15px;
-    --editor--max-height: 480px;
-    // Newly added
-    --button-active-text: #fff;
-
     width: var(--width, 100%);
     min-width: 300px;
     height: var(--height, 100%);
     min-height: 300px;
-    background: var(--background);
-    border-radius: var(--border-radius);
-    box-shadow: var(--shadow);
-    font-family: var(--font);
-    font-size: var(--font-size);
+    background: var(--composer-background-color, white);
+    border-radius: var(--composer-border-radius, 6px);
+    box-shadow: var(
+      --composer-shadow,
+      0 1px 10px rgba(0, 0, 0, 0.11),
+      0 3px 36px rgba(0, 0, 0, 0.12)
+    );
+    font-family: var(--composer-font, sans-serif);
+    font-size: var(--composer-font-size, 14px);
     position: relative;
     display: grid;
     grid-template-rows: auto 1fr auto;
@@ -419,11 +392,11 @@
       min-height: 0;
     }
     &__loader {
-      height: var(--editor--max-height);
+      height: var(--composer-editor-max-height, 480px);
       display: flex;
       align-items: center;
       justify-content: center;
-      color: var(--text-light);
+      color: var(--composer-text-light-color, #6e6e7a);
       box-shadow: none;
     }
     &__spinner {
@@ -432,7 +405,7 @@
       animation: rotate 2s linear infinite;
     }
     *:focus {
-      outline: 5px auto var(--primary);
+      outline: 5px auto var(--composer-primary-color, #5c77ff);
     }
   }
   @keyframes rotate {
@@ -445,27 +418,30 @@
     overflow: auto;
   }
   input {
-    font-family: var(--font);
+    font-family: var(--composer-font, sans-serif);
   }
   header {
-    border-top-left-radius: var(--border-radius);
-    border-top-right-radius: var(--border-radius);
-    border-bottom: 1px solid var(--border);
-    color: var(--text);
-    padding: 15px var(--outer-padding);
+    border-top-left-radius: var(--composer-border-radius, 6px);
+    border-top-right-radius: var(--composer-border-radius, 6px);
+    border-bottom: 1px solid var(--composer-border-color, #f7f7f7);
+    color: var(--composer-text-color, black);
+    padding: 15px var(--composer-outer-padding, 15px);
     display: flex;
     font-weight: 600;
     align-items: center;
     justify-content: space-between;
-    background: var(--header-background);
+    background: var(
+      --composer-header-background-color,
+      var(--composer-background-color, white)
+    );
     &.minimized {
-      border-bottom-left-radius: var(--border-radius);
-      border-bottom-right-radius: var(--border-radius);
+      border-bottom-left-radius: var(--composer-border-radius, 6px);
+      border-bottom-right-radius: var(--composer-border-radius, 6px);
     }
   }
   footer {
-    padding: 15px var(--outer-padding);
-    border-top: 1px solid var(--border);
+    padding: 15px var(--composer-outer-padding, 15px);
+    border-top: 1px solid var(--composer-border-color, #f7f7f7);
     display: flex;
     align-items: center;
     justify-content: flex-end;
@@ -473,13 +449,13 @@
   }
   .send-btn {
     border: 0;
-    background: var(--primary);
+    background: var(--composer-primary-color, #5c77ff);
     color: white;
     cursor: pointer;
     padding: 10px 25px;
     font-weight: bold;
-    border-radius: var(--border-radius);
-    font-family: var(--font);
+    border-radius: var(--composer-border-radius, 6px);
+    font-family: var(--composer-font, sans-serif);
     transition: background-color 0.3s;
     // border-top-right-radius: 0;
     // border-bottom-right-radius: 0;
@@ -488,11 +464,11 @@
       opacity: 0.5;
     }
     &:hover {
-      background: var(--primary-dark);
+      background: var(--composer-primary-dark-color, #294dff);
     }
     &.send-later {
       padding: 10px 10px;
-      border-radius: var(--border-radius);
+      border-radius: var(--composer-border-radius, 6px);
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
       margin-left: -4px;
@@ -501,15 +477,15 @@
 
   .subject {
     display: block;
-    font-size: var(--font-size);
+    font-size: var(--composer-font-size, 14px);
     border: none;
-    border-bottom: 1px solid var(--border);
-    color: var(--text);
+    border-bottom: 1px solid var(--composer-border-color, #f7f7f7);
+    color: var(--composer-text-color, black);
     width: 100%;
     background: var(--bg);
     font-weight: 600;
     box-sizing: border-box;
-    padding: 15px var(--outer-padding);
+    padding: 15px var(--composer-outer-padding, 15px);
     outline: 0;
     &::placeholer {
       font-weight: 500;
@@ -519,7 +495,7 @@
   .contacts-wrapper {
     position: relative;
     text-decoration: none;
-    color: var(--text);
+    color: var(--composer-text-color, black);
   }
   .close-btn {
     background: none;
@@ -533,10 +509,10 @@
     outline: 0;
     width: 28px;
     height: 28px;
-    border-radius: var(--border-radius);
+    border-radius: var(--composer-border-radius, 6px);
     cursor: pointer;
     &:hover {
-      background: var(--background-muted);
+      background: var(--composer-background-muted-color, #f0f2ff);
     }
   }
 
@@ -547,22 +523,22 @@
 
   .attachments-wrapper {
     display: flex;
-    padding: 15px var(--outer-padding);
+    padding: 15px var(--composer-outer-padding, 15px);
     flex-direction: column;
   }
   .addons {
-    font-size: var(--font-size-small);
+    font-size: var(--composer-font-size-small, 12px);
     letter-spacing: 1.2px;
     font-weight: 600;
     position: absolute;
     right: 10px;
     bottom: 16px;
-    color: var(--text-light);
+    color: var(--composer-text-light-color, #6e6e7a);
     button {
       background: transparent;
       box-shadow: none;
       border: none;
-      color: var(--text-light);
+      color: var(--composer-text-light-color, #6e6e7a);
       cursor: pointer;
       margin-right: 10px;
       padding: 5px;
@@ -580,9 +556,9 @@
     }
   }
   .attachments-caption {
-    font-size: var(--font-size--small);
+    font-size: var(--composer-font-size-small, 12px);
     margin-bottom: 5px;
-    color: var(--text-light);
+    color: var(--composer-text-light-color, #6e6e7a);
   }
   @media only screen and (max-width: 600px) {
     .nylas-composer {
@@ -626,13 +602,13 @@
             {#if minimized}
               <button class="composer-btn" on:click={handleMinimize}>
                 <ExpandIcon
-                  style="fill: var(--icons); width: 10px; height: 10px; transform: translateY(1px)"
+                  style="fill: var(--composer-icons-color, #666774); width: 10px; height: 10px; transform: translateY(1px)"
                 />
               </button>
             {:else}
               <button class="composer-btn" on:click={handleMinimize}>
                 <MinimizeIcon
-                  style="fill: var(--icons); width: 10px; height: 10px; transform: translateY(4px)"
+                  style="fill: var(--composer-icons-color, #666774); width: 10px; height: 10px; transform: translateY(4px)"
                 />
               </button>
             {/if}
@@ -640,7 +616,7 @@
           {#if show_close_button}
             <button class="composer-btn" on:click={close}>
               <CloseIcon
-                style="fill: var(--icons); width: 10px; height: 10px;"
+                style="fill: var(--composer-icons-color, #666774); width: 10px; height: 10px;"
               />
             </button>
           {/if}
@@ -702,7 +678,7 @@
               aria-label="remove carbon copy field"
             >
               <CloseIcon
-                style="fill: var(--icons); width: 10px; height: 10px;"
+                style="fill: var(--composer-icons-color, #666774); width: 10px; height: 10px;"
               />
             </button>
           </div>
@@ -725,7 +701,7 @@
               aria-label="remove blind carbon copy field"
             >
               <CloseIcon
-                style="fill: var(--icons); width: 10px; height: 10px;"
+                style="fill: var(--composer-icons-color, #666774); width: 10px; height: 10px;"
               />
             </button>
           </div>
@@ -773,7 +749,7 @@
             on:click={() => fileSelector.click()}
           >
             <AttachmentIcon
-              style="fill: var(--icons); width: 16px; height: 16px; margin-right: 15px"
+              style="fill: var(--composer-icons-color, #666774); width: 16px; height: 16px; margin-right: 15px"
             />
           </button>
         {/if}

--- a/components/composer/src/components/AlertBar.svelte
+++ b/components/composer/src/components/AlertBar.svelte
@@ -14,11 +14,11 @@
 
 <style lang="scss">
   .alert-bar {
-    padding: var(--outer-padding);
+    padding: var(--composer-outer-padding, 15px);
     text-align: center;
-    font-size: var(--font-size-small);
-    border-bottom-left-radius: var(--border-radius);
-    border-bottom-right-radius: var(--border-radius);
+    font-size: var(--composer-font-size-small, 12px);
+    border-bottom-left-radius: var(--composer-border-color, #f7f7f7-radius);
+    border-bottom-right-radius: var(--composer-border-radius, 6px);
     &__container {
       display: flex;
       align-items: center;
@@ -44,24 +44,39 @@
     }
     // Modifiers
     &.success {
-      background: var(--success-light);
-      color: var(--success);
+      background: var(
+        --composer-success-light-color,
+        var(--composer-primary-color, #5c77ff)
+      );
+      color: var(
+        --composer-success-color,
+        var(--composer-background-color, white)
+      );
       .alert-bar__close {
-        color: var(--success);
+        color: var(
+          --composer-success-color,
+          var(--composer-background-color, white)
+        );
       }
     }
     &.danger {
-      background: var(--danger-light);
-      color: var(--danger);
+      background: var(--composer-danger-light-color, #ffe3e3);
+      color: var(--composer-danger-color, #ff5c5c);
       .alert-bar__close {
-        color: var(--danger);
+        color: var(--composer-danger-color, #ff5c5c);
       }
     }
     &.info {
-      background: var(--info-light);
-      color: var(--info);
+      background: var(
+        --composer-info-light-color,
+        var(--composer-primary-light-color, #f0f2ff)
+      );
+      color: var(--composer-info-color, var(--composer-primary-color, #5c77ff));
       .alert-bar__close {
-        color: var(--info);
+        color: var(
+          --composer-info-color,
+          var(--composer-primary-color, #5c77ff)
+        );
       }
     }
   }

--- a/components/composer/src/components/Attachment.svelte
+++ b/components/composer/src/components/Attachment.svelte
@@ -78,6 +78,18 @@
       transform: rotate(360deg);
     }
   }
+
+  .LoadingIcon {
+    fill: var(--composer-icons-color, #666774);
+    width: 15px;
+    height: 15px;
+    animation: rotate 0.5s infinite linear;
+  }
+  .CloseIcon {
+    fill: var(--composer-icons-color, #666774);
+    width: 10px;
+    height: 10px;
+  }
 </style>
 
 {#if attachment}
@@ -89,16 +101,12 @@
       </div>
       <div class="file-info__right">
         {#if attachment.loading}
-          <LoadingIcon
-            style="fill: var(--composer-icons-color, #666774); width: 15px; height: 15px; animation: rotate 0.5s infinite linear;"
-          />
+          <LoadingIcon class="LoadingIcon" />
         {/if}
         {#if attachment.error}<span class="file-info__error">Error</span>{/if}
         {#if !attachment.loading}
           <button class="close-btn" on:click={() => remove(attachment)}>
-            <CloseIcon
-              style="fill: var(--composer-icons-color, #666774); width: 10px; height: 10px;"
-            />
+            <CloseIcon class="CloseIcon" />
           </button>
         {/if}
       </div>

--- a/components/composer/src/components/Attachment.svelte
+++ b/components/composer/src/components/Attachment.svelte
@@ -27,10 +27,10 @@
     align-items: center;
     justify-content: space-between;
     padding: 0.8rem;
-    color: var(--text);
+    color: var(--composer-text-color, black);
     font-weight: 700;
-    background: var(--background-muted);
-    border-radius: var(--border-radius);
+    background: var(--composer-background-muted-color, #f0f2ff);
+    border-radius: var(--composer-border-radius, 6px);
   }
 
   .close-btn {
@@ -48,12 +48,12 @@
 
   .file-info {
     display: flex;
-    color: var(--text);
+    color: var(--composer-text-color, black);
     align-items: center;
     max-width: 90%;
     &__error {
-      color: var(--danger);
-      font-size: var(--font-size-small);
+      color: var(--composer-danger-color, #ff5c5c);
+      font-size: var(--composer-font-size-small, 12px);
       margin-right: 5px;
     }
     &__right {
@@ -68,9 +68,9 @@
   .file-item__size {
     flex-shrink: 0;
     word-break: keep-all;
-    color: var(--text-light);
+    color: var(composer-text-light-color, #6e6e7a);
     margin-left: 5px;
-    font-size: var(--font-size-small);
+    font-size: var(--composer-font-size-small, 12px);
   }
 
   @keyframes rotate {
@@ -90,13 +90,15 @@
       <div class="file-info__right">
         {#if attachment.loading}
           <LoadingIcon
-            style="fill: var(--icons); width: 15px; height: 15px; animation: rotate 0.5s infinite linear;"
+            style="fill: var(--composer-icons-color, #666774); width: 15px; height: 15px; animation: rotate 0.5s infinite linear;"
           />
         {/if}
         {#if attachment.error}<span class="file-info__error">Error</span>{/if}
         {#if !attachment.loading}
           <button class="close-btn" on:click={() => remove(attachment)}>
-            <CloseIcon style="fill: var(--icons); width: 10px; height: 10px;" />
+            <CloseIcon
+              style="fill: var(--composer-icons-color, #666774); width: 10px; height: 10px;"
+            />
           </button>
         {/if}
       </div>

--- a/components/composer/src/components/DatepickerModal.svelte
+++ b/components/composer/src/components/DatepickerModal.svelte
@@ -31,13 +31,17 @@
   /* Modal Content/Box */
   .modal-content {
     display: block; /* Hidden by default */
-    box-shadow: var(--shadow);
-    border-radius: var(--border-radius);
+    box-shadow: var(
+      --composer-shadow,
+      0 1px 10px rgba(0, 0, 0, 0.11),
+      0 3px 36px rgba(0, 0, 0, 0.12)
+    );
+    border-radius: var(--composer-border-radius, 6px);
   }
 
   /* The Close Button */
   .close {
-    color: var(--text-light);
+    color: var(composer-text-light-color, #6e6e7a);
     float: right;
     padding-right: 10px;
     font-size: 28px;
@@ -46,34 +50,35 @@
 
   .close:hover,
   .close:focus {
-    color: var(--text);
+    color: var(--composer-text-color, black);
     text-decoration: none;
     cursor: pointer;
   }
 
   .save-btn {
     border: 0;
-    background: var(--primary);
+    background: var(--composer-primary-color, #5c77ff);
     width: 100%;
     color: white;
     cursor: pointer;
     padding: 10px 25px;
     font-weight: bold;
-    border-radius: 0 0 var(--border-radius) var(--border-radius);
-    font-family: var(--font);
+    border-radius: 0 0 var(--composer-border-radius, 6px)
+      var(--composer-border-radius, 6px);
+    font-family: var(--composer-font, sans-serif);
     &:disabled {
       opacity: 0.5;
     }
     &:hover {
-      background: var(--primary-dark);
+      background: var(--composer-primary-dark-color, #294dff);
     }
   }
 
   .datepicker-modal {
     position: absolute;
-    bottom: calc(var(--outer-padding) * 0.85);
-    right: calc(var(--outer-padding) * 0.85);
-    left: calc(var(--outer-padding) * 0.85);
+    bottom: calc(var(--composer-outer-padding, 15px) * 0.85);
+    right: calc(var(--composer-outer-padding, 15px) * 0.85);
+    left: calc(var(--composer-outer-padding, 15px) * 0.85);
   }
 </style>
 
@@ -82,7 +87,9 @@
 <div class="datepicker-modal">
   <div class="modal-content">
     <span class="close" on:click={close}>
-      <CloseIcon style="fill: var(--icons); width: 10px; height: 10px;" />
+      <CloseIcon
+        style="fill: var(--composer-icons-color, #666774); width: 10px; height: 10px;"
+      />
     </span>
     <nylas-datepicker {change} timepicker={true} min={new Date()} />
     <button class="save-btn" on:click={submit}> Schedule send </button>

--- a/components/composer/src/components/DatepickerModal.svelte
+++ b/components/composer/src/components/DatepickerModal.svelte
@@ -80,6 +80,12 @@
     right: calc(var(--composer-outer-padding, 15px) * 0.85);
     left: calc(var(--composer-outer-padding, 15px) * 0.85);
   }
+
+  .CloseIcon {
+    fill: var(--composer-icons-color, #666774);
+    width: 10px;
+    height: 10px;
+  }
 </style>
 
 <!-- Modal content -->
@@ -87,9 +93,7 @@
 <div class="datepicker-modal">
   <div class="modal-content">
     <span class="close" on:click={close}>
-      <CloseIcon
-        style="fill: var(--composer-icons-color, #666774); width: 10px; height: 10px;"
-      />
+      <CloseIcon class="CloseIcon" />
     </span>
     <nylas-datepicker {change} timepicker={true} min={new Date()} />
     <button class="save-btn" on:click={submit}> Schedule send </button>

--- a/components/composer/src/components/HTMLEditor.svelte
+++ b/components/composer/src/components/HTMLEditor.svelte
@@ -91,24 +91,25 @@
 
 <style lang="scss">
   .html-editor {
-    min-height: var(--editor-height, 220px);
-    max-height: var(--editor-max-height);
+    min-height: var(--composer-editor-min-height, 220px);
+    max-height: var(--composer-editor-max-height, 480px);
     *:focus {
-      outline: 5px auto var(--primary);
+      outline: 5px auto var(--composer-primary-color, #5c77ff);
     }
   }
   a {
-    color: var(--primary);
+    color: var(--composer-primary-color, #5c77ff);
     &:hover {
-      color: var(--primary-dark);
+      color: var(--composer-primary-dark-color, #294dff);
     }
   }
   [contenteditable] {
-    padding: var(--outer-padding) var(--outer-padding);
+    padding: var(--composer-outer-padding, 15px)
+      var(--composer-outer-padding, 15px);
     margin: 0;
     outline: 0;
     line-height: 1.3;
-    color: var(--text);
+    color: var(--composer-text-color, black);
     overflow-y: auto;
   }
   .toolbar {
@@ -116,11 +117,11 @@
     font-size: 10px;
     align-items: center;
     justify-content: flex-start;
-    border-bottom: 1px solid var(--border);
-    padding: 0 calc(var(--outer-padding) / 2);
+    border-bottom: 1px solid var(--composer-border-color, #f7f7f7);
+    padding: 0 calc(var(--composer-outer-padding, 15px) / 2);
 
     button {
-      color: var(--text-light);
+      color: var(composer-text-light-color, #6e6e7a);
       background: none;
       border: 0;
       cursor: pointer;
@@ -128,17 +129,17 @@
       padding: 8px;
       margin: 2px;
       outline: 0;
-      border-radius: calc(var(--border-radius) / 2);
+      border-radius: calc(var(--composer-border-radius, 6px) / 2);
       transition: background-color 0.3s;
 
       &.active {
-        background: var(--background-muted);
+        background: var(--composer-background-muted-color, #f0f2ff);
       }
       &:first-child {
         margin-left: 0;
       }
       &:hover {
-        background: var(--background-muted);
+        background: var(--composer-background-muted-color, #f0f2ff);
       }
     }
   }
@@ -157,7 +158,7 @@
             <svelte:component
               this={item.icon}
               class="icon"
-              style="fill: var(--icons) !important; width: 12px; height: 12px;"
+              style="fill: var(--composer-icons-color, #666774) !important; width: 12px; height: 12px;"
             />
           {:else}{item.title.charAt(0)}{/if}
         </button>

--- a/components/composer/src/components/HTMLEditor.svelte
+++ b/components/composer/src/components/HTMLEditor.svelte
@@ -143,6 +143,12 @@
       }
     }
   }
+
+  .icon {
+    fill: var(--composer-icons-color, #666774) !important;
+    width: 12px;
+    height: 12px;
+  }
 </style>
 
 <!-- Toolbar -->
@@ -155,11 +161,7 @@
           class={item.state && item.state() ? "active" : ""}
         >
           {#if item.icon}
-            <svelte:component
-              this={item.icon}
-              class="icon"
-              style="fill: var(--composer-icons-color, #666774) !important; width: 12px; height: 12px;"
-            />
+            <svelte:component this={item.icon} class="icon" />
           {:else}{item.title.charAt(0)}{/if}
         </button>
       {/each}

--- a/components/composer/src/dark.css
+++ b/components/composer/src/dark.css
@@ -1,26 +1,26 @@
 .nylas-composer {
-  --background: rgb(40, 43, 43);
-  --background-muted: #454949;
-  --text: #fff;
-  --text-light: #b0b0c0;
-  --text-secondary: #ffffff;
-  --font: lato, sans-serif;
-  --font-size: 14px;
-  --font-size-small: 12px;
+  --composer-background-color: rgb(40, 43, 43);
+  --composer-background-muted-color: #454949;
+  --composer-text-color: #fff;
+  --composer-text-light-color: #b0b0c0;
+  --composer-text-secondary-color: #ffffff;
+  --composer-font: lato, sans-serif;
+  --composer-font-size: 14px;
+  --composer-font-size-small: 12px;
 
-  --border: #282828;
-  --primary: #00c1a0;
-  --primary-light: #434343;
-  --primary-dark: #00a88b;
-  --icons: #8e8e98;
-  --header-background: var(--background);
+  --composer-border-color: #282828;
+  --composer-primary-color: #00c1a0;
+  --composer-primary-light-color: #434343;
+  --composer-primary-dark-color: #00a88b;
+  --composer-icons-color: #8e8e98;
+  --composer-header-background-color: var(--composer-background-color);
 
-  --success: white;
-  --success-light: var(--primary);
+  --composer-success-color: white;
+  --composer-success-light-color: var(--composer-primary-color);
 
-  --danger: #ffffff;
-  --danger-light: #ff5454;
+  --composer-danger-color: #ffffff;
+  --composer-danger-light-color: #ff5454;
 
-  --info: white;
-  --info-light: var(--primary-light);
+  --composer-info-color: white;
+  --composer-info-light-color: var(--composer-primary-light-color);
 }

--- a/components/contact-list/src/ContactList.svelte
+++ b/components/contact-list/src/ContactList.svelte
@@ -250,14 +250,6 @@
     width: 100%;
     overflow: auto;
     position: relative;
-
-    // theme-1 default
-    --mainText: #000000;
-    --linesAndIcons: #d5d5d5;
-    --contactColor: #002db4;
-    --contactTextColor: white;
-    --selectColor: #36d2ac;
-    --hoverColor: #eee;
   }
 
   @import "./themes/theme-1";

--- a/components/contacts-search/src/ContactsSearch.svelte
+++ b/components/contacts-search/src/ContactsSearch.svelte
@@ -217,7 +217,7 @@
     margin-bottom: 2px;
   }
   .contact-item > button {
-    color: var(--text-secondary);
+    color: var(--composer-text-secondary-color, #2247ff);
     border: none;
     background: none;
     padding: 2px 4px;
@@ -226,7 +226,7 @@
     cursor: pointer;
   }
   .contact-item__name {
-    color: var(--text-secondary);
+    color: var(--composer-text-secondary-color, #2247ff);
     font-size: 12px;
     padding-right: 0.75rem;
   }

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -49,8 +49,10 @@
   // query_string format => "in=trash from=phil.r@nylas.com"
   export let query_string: string | null; // Allowed query parameter list https://developer.nylas.com/docs/api/#get/threads
   export let items_per_page: number = 13;
-  export let onSelectThread: (event: MouseEvent, t: Thread) => void =
-    onSelectOne;
+  export let onSelectThread: (
+    event: MouseEvent,
+    t: Thread,
+  ) => void = onSelectOne;
 
   const defaultValueMap = {
     show_star: false,
@@ -479,7 +481,7 @@
     grid-auto-rows: max-content;
     font-family: -apple-system, BlinkMacSystemFont, sans-serif;
 
-    $outline-style: 1px solid var(--grey-lighter);
+    $outline-style: 1px solid var(--mailbox-outline-color, var(--grey-lighter));
     @mixin barStyle {
       outline: $outline-style;
       display: flex;
@@ -539,7 +541,7 @@
         }
 
         &.starred:before {
-          color: #ffc107;
+          color: var(--mailbox-star-color, #ffc107);
         }
       }
     }
@@ -557,7 +559,8 @@
 
       &:hover {
         $hover-outline-width: 1px;
-        outline: $hover-outline-width solid var(--grey-warm);
+        outline: $hover-outline-width solid
+          var(--mailbox-outline-color, var(--grey-warm));
         cursor: pointer;
       }
 
@@ -569,17 +572,17 @@
       // #region define background styles
       --nylas-email-background: transparent;
       &:not(.unread) {
-        background: var(--grey-lightest);
+        background: var(--mailbox-read-email-color, var(--grey-lightest));
       }
       &.unread {
-        background: white;
+        background: var(--mailbox-unread-email-color, white);
       }
       // #endregion define background styles
 
       // #region define checked styles
       &.checked {
-        border-left: 4px solid var(--blue);
-        background: var(--blue-lighter);
+        border-left: 4px solid var(--mailbox-checked-border-color, var(--blue));
+        background: var(--mailbox-checked-color, var(--blue-lighter));
 
         .checkbox-container.thread-checkbox {
           padding-left: 13px;
@@ -630,7 +633,7 @@
       div.starred {
         button {
           &:hover:before {
-            color: #ffc107;
+            color: var(--mailbox-star-color, #ffc107);
           }
         }
       }

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -481,7 +481,7 @@
     grid-auto-rows: max-content;
     font-family: -apple-system, BlinkMacSystemFont, sans-serif;
 
-    $outline-style: 1px solid var(--mailbox-outline-color, var(--grey-lighter));
+    $outline-style: 1px solid var(--grey-lighter);
     @mixin barStyle {
       outline: $outline-style;
       display: flex;
@@ -541,7 +541,7 @@
         }
 
         &.starred:before {
-          color: var(--mailbox-star-color, #ffc107);
+          color: #ffc107;
         }
       }
     }
@@ -559,8 +559,7 @@
 
       &:hover {
         $hover-outline-width: 1px;
-        outline: $hover-outline-width solid
-          var(--mailbox-outline-color, var(--grey-warm));
+        outline: $hover-outline-width solid var(--grey-warm);
         cursor: pointer;
       }
 
@@ -572,17 +571,17 @@
       // #region define background styles
       --nylas-email-background: transparent;
       &:not(.unread) {
-        background: var(--mailbox-read-email-color, var(--grey-lightest));
+        background: var(--grey-lightest);
       }
       &.unread {
-        background: var(--mailbox-unread-email-color, white);
+        background: white;
       }
       // #endregion define background styles
 
       // #region define checked styles
       &.checked {
-        border-left: 4px solid var(--mailbox-checked-border-color, var(--blue));
-        background: var(--mailbox-checked-color, var(--blue-lighter));
+        border-left: 4px solid var(--blue);
+        background: var(--blue-lighter);
 
         .checkbox-container.thread-checkbox {
           padding-left: 13px;
@@ -633,7 +632,7 @@
       div.starred {
         button {
           &:hover:before {
-            color: var(--mailbox-star-color, #ffc107);
+            color: #ffc107;
           }
         }
       }


### PR DESCRIPTION
Our previous implementation accidentally broke this feature. But now we know how to do it, I guess! For CSS var overrides to work, the variable can't be set in the file. 2 ways to set defaults

### 1. use theme prop to set defaults via classes
```
<main class={theme ?? "default-theme"}>
```
```
main.default-theme {
  --css-var: white;
```
this way the developer can just replace the theme prop with something custom, and set all the vars in their code 
```
<component theme="custom">
```
```
:root, component, body { // anywhere in their app should work
  --css-var: black;
```

### 2. use css var fallbacks
```
main {
  padding: var(--css-var, 10px);
```
The dev can either set css vars the same way, but doesn't have to worry about the theme prop.


# Code changes
- [x] updating css vars to one of the 2 implementations above in Agenda, Composer (+ files) & Contact List


# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
