### PR TITLE
Ensure access_token props are always passed through to request headers

### DIFF
--- a/commons/src/connections/neural.ts
+++ b/commons/src/connections/neural.ts
@@ -18,6 +18,7 @@ export const fetchCleanConversations = (
     `${getMiddlewareApiUrl(query.component_id)}/neural/conversation`,
     getFetchConfig({
       method: "PUT",
+      access_token: query.access_token,
       component_id: query.component_id,
       body: { message_id: query.message_id },
     }),
@@ -38,6 +39,7 @@ export const sendCleanConversationFeedback = (
     `${getMiddlewareApiUrl(query.component_id)}/neural/conversation/feedback`,
     getFetchConfig({
       method: "POST",
+      access_token: query.access_token,
       component_id: query.component_id,
       body: { message_id: query.message_id },
     }),

--- a/commons/src/types/Availability.ts
+++ b/commons/src/types/Availability.ts
@@ -2,7 +2,10 @@ import type {
   SelectionStatus,
   AvailabilityStatus,
 } from "@commons/enums/Availability";
-import type { Manifest as NylasManifest } from "@commons/types/Nylas";
+import type {
+  CommonQuery,
+  Manifest as NylasManifest,
+} from "@commons/types/Nylas";
 export interface Manifest extends NylasManifest {
   allow_booking: boolean;
   allow_date_change: boolean;
@@ -75,14 +78,12 @@ export interface SelectableSlot extends TimeSlot {
   hovering?: boolean;
 }
 
-export interface AvailabilityQuery {
+export interface AvailabilityQuery extends CommonQuery {
   body: {
     emails: string[];
     start_time: number;
     end_time: number;
   };
-  component_id: string;
-  access_token?: string;
   forceReload?: boolean;
 }
 
@@ -95,12 +96,10 @@ export interface AvailabilityResponse {
   email: string;
 }
 
-export interface EventQuery {
+export interface EventQuery extends CommonQuery {
   participants?: EventParticipant[];
   title?: string;
   location?: string;
-  access_token?: string;
-  component_id?: string;
 }
 
 export interface EventParticipant {

--- a/commons/src/types/Contacts.ts
+++ b/commons/src/types/Contacts.ts
@@ -1,4 +1,4 @@
-import type { WebPage } from "@commons/types/Nylas";
+import type { CommonQuery, WebPage } from "@commons/types/Nylas";
 
 export interface Contact {
   account_id: string;
@@ -56,15 +56,10 @@ export interface ContactPhoneNumber {
   type: string;
 }
 
-export interface ContactsQuery {
-  component_id: string;
-  access_token?: string;
-}
+export interface ContactsQuery extends CommonQuery {}
 
-export interface ContactSearchQuery {
-  component_id: string;
+export interface ContactSearchQuery extends CommonQuery {
   query: string;
-  access_token?: string;
 }
 
 export interface StoredContacts {

--- a/commons/src/types/Nylas.ts
+++ b/commons/src/types/Nylas.ts
@@ -5,6 +5,7 @@ import type {
   EmailUnreadStatus,
   MailboxActions,
 } from "@commons/enums/Nylas";
+
 export interface CommonQuery {
   component_id: string;
   access_token?: string;
@@ -18,10 +19,7 @@ export interface MailboxQuery extends CommonQuery {
   query: ThreadsQuery;
 }
 
-export interface AccountQuery {
-  component_id: string;
-  access_token?: string;
-}
+export interface AccountQuery extends CommonQuery {}
 
 export interface ThreadsQuery {
   limit?: number;
@@ -44,9 +42,7 @@ export interface ThreadsQuery {
   not_in?: string;
 }
 
-export interface SearchResultThreadsQuery {
-  component_id: string;
-  access_token?: string;
+export interface SearchResultThreadsQuery extends CommonQuery {
   keyword_to_search: string;
 }
 
@@ -55,13 +51,11 @@ export interface MessagesQuery extends CommonQuery {
   received_after?: number;
 }
 
-export interface CleanConversationQuery {
-  component_id: string;
+export interface CleanConversationQuery extends CommonQuery {
   message_id: string[]; // Note: singular name but expects array
 }
 
-export interface CleanConversationFeedbackQuery {
-  component_id: string;
+export interface CleanConversationFeedbackQuery extends CommonQuery {
   message_id: string;
 }
 
@@ -80,8 +74,7 @@ export interface StoredMessage {
   data: Message;
 }
 
-export interface SingularEmail {
-  component_id: string;
+export interface SingularEmail extends CommonQuery {
   message_id: string;
 }
 

--- a/components/conversation/src/Conversation.svelte
+++ b/components/conversation/src/Conversation.svelte
@@ -116,6 +116,7 @@
   let query: ConversationQuery;
 
   $: query = {
+    access_token,
     component_id: id,
     thread_id: thread_id,
   };
@@ -240,6 +241,7 @@
   //#region Clean Conversation
   function cleanConversation() {
     fetchCleanConversations({
+      access_token,
       component_id: id,
       message_id: conversationMessages
         .slice(-CONVERSATION_ENDPOINT_MAX_MESSAGES)

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -221,8 +221,9 @@
   }
   let query: ConversationQuery;
   $: query = {
+    access_token,
     component_id: id,
-    thread_id: thread_id,
+    thread_id,
   };
 
   let queryKey: string;
@@ -282,6 +283,7 @@
   function cleanConversation() {
     if (activeThread) {
       fetchCleanConversations({
+        access_token,
         component_id: id,
         message_id: activeThread.messages
           .slice(-CONVERSATION_ENDPOINT_MAX_MESSAGES)
@@ -516,7 +518,7 @@
 
   // For cases when someone wants to show just a single email message, rather than the full thread.
   function fetchOneMessage() {
-    fetchEmail({ component_id: id, message_id: message_id }).then((json) => {
+    fetchEmail({ access_token, component_id: id, message_id }).then((json) => {
       message = json;
       messageLoadStatus[0] = "loaded";
     });

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -243,6 +243,7 @@
   async function updateThreadStatus(updatedThread: any) {
     if (id && updatedThread && updatedThread.id) {
       const threadQuery = {
+        access_token,
         component_id: id,
         thread_id: updatedThread.id,
       };


### PR DESCRIPTION
# Code changes

- Ensure `access_token` props are always passed through to request headers
- Updated typing to ensure query types always include an `access_token`

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
