### PR TITLE
[Email][Mailbox][Conversation]: Fix tests for components (after deleting messages)

### DIFF
--- a/commons/src/connections/threads.ts
+++ b/commons/src/connections/threads.ts
@@ -25,7 +25,13 @@ export const fetchThreads = async (query: MailboxQuery): Promise<Thread[]> => {
   return await fetch(queryString, getFetchConfig(query))
     .then((response) => handleResponse<MiddlewareResponse<Thread[]>>(response))
     .then((json) => {
-      return json.response;
+      return json.response.filter((thread) => {
+        if (thread && thread.messages) {
+          return thread?.messages?.length > 0;
+        } else {
+          return false;
+        }
+      });
     })
     .catch((error) => handleError(query.component_id, error));
 };

--- a/commons/src/connections/threads.ts
+++ b/commons/src/connections/threads.ts
@@ -25,13 +25,9 @@ export const fetchThreads = async (query: MailboxQuery): Promise<Thread[]> => {
   return await fetch(queryString, getFetchConfig(query))
     .then((response) => handleResponse<MiddlewareResponse<Thread[]>>(response))
     .then((json) => {
-      return json.response.filter((thread) => {
-        if (thread && thread.messages) {
-          return thread?.messages?.length > 0;
-        } else {
-          return false;
-        }
-      });
+      return json.response.filter((thread) =>
+        thread && thread.messages ? thread?.messages?.length > 0 : false,
+      );
     })
     .catch((error) => handleError(query.component_id, error));
 };

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -602,7 +602,7 @@
     return (
       messages &&
       participants &&
-      messages.length >= 1 &&
+      messages.length > 0 &&
       messages[messages.length - 1].from.length
     );
   }

--- a/components/email/src/index.html
+++ b/components/email/src/index.html
@@ -253,7 +253,8 @@
       <nylas-email
         id="demo-email"
         thread_id="80m65o362s5332dwotpocuy6a"
-        click_action="default">
+        click_action="default"
+      >
       </nylas-email>
     </div>
     <div class="demo">
@@ -271,7 +272,7 @@
       <p class="demo-description demo-head">
         Fetching a single message for the passed message_id prop
       </p>
-      <nylas-email id="demo-email" message_id="3r5mx1zidx0a424j34jocc3no">
+      <nylas-email id="demo-email" message_id="affxolvozy2pcqh4303w7pc9n">
       </nylas-email>
     </div>
 

--- a/components/email/src/init.spec.js
+++ b/components/email/src/init.spec.js
@@ -219,7 +219,7 @@ describe("Email component", () => {
         component.id = "demo-email";
         component.thread_id = undefined;
         component.thread = undefined;
-        component.message_id = "3r5mx1zidx0a424j34jocc3no";
+        component.message_id = "affxolvozy2pcqh4303w7pc9n";
         cy.get(component)
           .find(".email-row.expanded.singular header")
           .should("exist");

--- a/components/email/src/init.spec.js
+++ b/components/email/src/init.spec.js
@@ -229,7 +229,7 @@ describe("Email component", () => {
         cy.get(component).find(".message-body").should("exist");
         cy.get("nylas-message-body").then((nylasMessageBody) => {
           const messageBody = nylasMessageBody[0];
-          cy.get(messageBody).find("div").should("contain", "Bye!");
+          cy.get(messageBody).find("div").should("contain", "Allo bonjour");
         });
         cy.get(component).find(".name").should("exist");
         cy.get(component).find(".name").should("contain", "Test User");

--- a/components/email/src/init.spec.js
+++ b/components/email/src/init.spec.js
@@ -225,7 +225,7 @@ describe("Email component", () => {
           .should("exist");
         cy.get(component)
           .find(".email-row.expanded.singular header")
-          .should("contain", "Re: Demo Thread");
+          .should("contain", "Demo Thread");
         cy.get(component).find(".message-body").should("exist");
         cy.get("nylas-message-body").then((nylasMessageBody) => {
           const messageBody = nylasMessageBody[0];
@@ -249,10 +249,8 @@ describe("Email component", () => {
         cy.get(component).find(".message-date span").should("exist");
         cy.get(component)
           .find(".message-date span")
-          .should("contain", "July 7");
-        cy.get(component)
-          .find(".message-to span")
-          .should("contain", "Pooja Guggari");
+          .should("contain", "October 21");
+        cy.get(component).find(".message-to span").should("contain", "me");
       });
   });
   it("Shows a thread even when message_id is passed", (done) => {
@@ -377,7 +375,7 @@ describe("Email component", () => {
             cy.get(secondTooltip).find(".tooltip").should("exist");
             cy.get(secondTooltip)
               .find(".tooltip")
-              .should("contain", "pooja.g@nylas.com");
+              .should("contain", "nylascypresstest@gmail.com");
             cy.get(firstTooltip).find(".tooltip-trigger").click();
             cy.get(firstTooltip).find(".tooltip").should("exist");
             cy.get(firstTooltip)


### PR DESCRIPTION
# Code changes

- Fixed message id, as the old one was deleted.
- Added code to filter the threads fetched to have at least 1 message in the messages array
- Updated test for email


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
