### PR TITLE
Percy references removed

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,2 +1,1 @@
 API_GATEWAY=web-components.nylas.com/middleware
-PERCY_TOKEN=Yo! check here: https://percy.io/f91f79cd/Components/settings

--- a/.github/workflows/build-test-publish.yaml
+++ b/.github/workflows/build-test-publish.yaml
@@ -96,24 +96,6 @@ jobs:
       - name: Run unit tests
         run: npm run test
 
-  test-percy-snapshot:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-    needs: build
-    steps:
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: "14"
-      - uses: actions/cache@v2
-        id: restore-build
-        with:
-          path: ./*
-          key: ${{ github.sha }}
-      - name: Run percy snapshots
-        run: npm run snapshot
-
   test-cypress:
     runs-on: ubuntu-latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -142,7 +142,6 @@ After installing, run `yarn start`, go to `http://localhost:8000` in your browse
 
 `yarn cy:open` will launch our end-to-end tests in a browser
 tests will automatically be run on push from push.yaml
-snapshot (visual) diff tests are fun using Percy by running `yarn snapshot`
 
 ### Push some Code
 

--- a/components/agenda/README.md
+++ b/components/agenda/README.md
@@ -131,7 +131,6 @@ Please refer to our [Contributing Guidelines](CONTRIBUTING.md) for information a
 
 `yarn cy:open` will launch our end-to-end tests in a browser
 tests will automatically be run on push from push.yaml
-snapshot (visual) diff tests are fun using Percy by running `yarn snapshot`
 
 ## Additional Documentation
 

--- a/components/composer/README.md
+++ b/components/composer/README.md
@@ -94,7 +94,6 @@ Please refer to our [Contributing Guidelines](CONTRIBUTING.md) for information a
 
 `yarn cy:open` will launch our end-to-end tests in a browser
 tests will automatically be run on push from push.yaml
-snapshot (visual) diff tests are fun using Percy by running `yarn snapshot`
 
 ## Additional Documentation
 

--- a/components/contact-list/README.md
+++ b/components/contact-list/README.md
@@ -126,7 +126,6 @@ Please refer to our [Contributing Guidelines](CONTRIBUTING.md) for information a
 
 `yarn cy:open` will launch our end-to-end tests in a browser
 tests will automatically be run on push from push.yaml
-snapshot (visual) diff tests are fun using Percy by running `yarn run snapshot`
 
 ## Additional Documentation
 

--- a/components/conversation/README.md
+++ b/components/conversation/README.md
@@ -179,7 +179,6 @@ Please refer to our [Contributing Guidelines](CONTRIBUTING.md) for information a
 
 `yarn cy:open` will launch our end-to-end tests in a browser
 tests will automatically be run on push from push.yaml
-snapshot (visual) diff tests are fun using Percy by running `yarn snapshot`
 
 ## Additional Documentation
 

--- a/components/email/README.md
+++ b/components/email/README.md
@@ -170,7 +170,6 @@ Please refer to our [Contributing Guidelines](CONTRIBUTING.md) for information a
 
 `yarn cy:open` will launch our end-to-end tests in a browser
 tests will automatically be run on push from push.yaml
-snapshot (visual) diff tests are fun using Percy by running `yarn snapshot`
 
 ## Additional Documentation
 

--- a/components/mailbox/README.md
+++ b/components/mailbox/README.md
@@ -165,7 +165,6 @@ Please refer to our [Contributing Guidelines](CONTRIBUTING.md) for information a
 
 `yarn cy:open` will launch our end-to-end tests in a browser
 tests will automatically be run on push from push.yaml
-snapshot (visual) diff tests are fun using Percy by running `yarn snapshot`
 
 ## Additional Documentation
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "publish": "lerna publish",
     "release:canary": "lerna version prerelease --no-private",
     "release:stable": "lerna version --force-publish --no-private",
-    "snapshot": "build-storybook --quiet && percy-storybook --widths=320,1280",
     "start": "concurrently \"live-server . --host=0.0.0.0 --port=8000\" \"yarn dev\"",
     "start:ci": "sirv . --port 8000 public",
     "storybook": "start-storybook --quiet -p 6006 -s ./public",
@@ -40,8 +39,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.11.1",
-    "@percy-io/in-percy": "^0.1.11",
-    "@percy/storybook": "^3.3.1",
     "@rollup/plugin-alias": "3.1.2",
     "@rollup/plugin-commonjs": "^14.0.0",
     "@rollup/plugin-json": "^4.1.0",

--- a/scripts/template/README.md
+++ b/scripts/template/README.md
@@ -135,7 +135,6 @@ Please refer to our [Contributing Guidelines](CONTRIBUTING.md) for information a
 
 `yarn cy:open` will launch our end-to-end tests in a browser
 tests will automatically be run on push from push.yaml
-snapshot (visual) diff tests are fun using Percy by running `yarn snapshot`
 
 ## Additional Documentation
 


### PR DESCRIPTION
Removes the onus on contributing users to have a PERCY_TOKEN.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
