### PR TITLE
[email] Fixed case where creating a new email component in the same parent app as a fully loaded email would cause an infinite loop

### DIFF
--- a/commons/src/index.ts
+++ b/commons/src/index.ts
@@ -26,7 +26,7 @@ export { ContactStore } from "./store/contacts";
 export { ContactAvatarStore } from "./store/contact-avatar";
 export { ConversationStore } from "./store/conversations";
 export { EventStore } from "./store/events";
-export { MailboxStore, Threads } from "./store/threads";
+export { MailboxStore } from "./store/mailbox";
 export { MessageStore } from "./store/messages";
 export { ManifestStore } from "./store/manifest";
 export {

--- a/commons/src/store/mailbox.ts
+++ b/commons/src/store/mailbox.ts
@@ -1,4 +1,4 @@
-import { derived, writable } from "svelte/store";
+import { writable } from "svelte/store";
 import {
   fetchThread,
   fetchThreads,
@@ -73,7 +73,10 @@ function initializeThreads() {
         threads[queryKey] = threadsMap[queryKey];
         return { ...threads };
       });
-      return threadsMap[queryKey];
+      return threadsMap[queryKey][0];
+    },
+    getFlatThreads: () => {
+      return Object.values(threadsMap).flat();
     },
 
     reset: () => {
@@ -108,8 +111,3 @@ function initializeThreads() {
 }
 
 export const MailboxStore = initializeThreads();
-
-export const Threads = derived(MailboxStore, ($mailboxes) => {
-  // console.log('Threads deriving', $mailboxes);
-  return Object.values($mailboxes).flat();
-});

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -3,7 +3,6 @@
 <script lang="ts">
   import {
     MailboxStore,
-    Threads,
     ManifestStore,
     fetchAccount,
     updateThread,
@@ -108,6 +107,7 @@
     }
   });
   let contacts: any = null;
+  let activeThreadContact = {};
   $: activeThreadContact =
     activeThread && contacts
       ? contacts[
@@ -238,37 +238,28 @@
   // #region thread intake and set
   // The trick is to always ensure that activeThread is in the store; that way if we need to do fetches to update its messages, it too will be updated for free.
   // TODO: this feels like it could be a "$: activeThread =" reactive prop declaration instead of a conditional block. -Phil
-  $: if (thread && thread.id) {
-    // Thread is being passed in directly. We won't need to do an initial fetch.
-    // Is it in the store already? (via <nylas-mailbox>, for example)
-    let foundThread = $Threads.find(
-      (storedThread) => storedThread && storedThread.id === thread?.id,
-    ) as Conversation;
-    if (!foundThread) {
-      // Thread does not exist in the store, assume it was passed in
-      activeThread = thread as Conversation;
-    } else {
-      // It's already in the store! Great.
-      activeThread = foundThread;
-    }
-    // This is for Email component demo purpose, where we want to show expanded threads by default on load.
-    if (show_expanded_email_view_onload) {
-      activeThread.expanded = show_expanded_email_view_onload;
-    }
-  } else if (thread_id) {
-    // We don't have a passed thread, but we do have a thread_id. Let's fetch it.
-    MailboxStore.getThread(query).then(() => {
-      let foundThread = $Threads.find(
-        (storedThread) => storedThread.id === thread_id,
-      ) as Conversation;
-      if (foundThread) {
-        activeThread = foundThread;
-        if (show_expanded_email_view_onload) {
-          activeThread.expanded = show_expanded_email_view_onload;
-        }
+  $: (async () => {
+    if (thread && thread.id) {
+      // Is it in the store already? (via <nylas-mailbox>, for example)
+      const localThread: Conversation =
+        (MailboxStore.getFlatThreads().find(
+          (storedThread) => storedThread && storedThread.id === thread?.id,
+        ) as Conversation) ?? thread;
+
+      // This is for Email component demo purpose, where we want to show expanded threads by default on load.
+      if (show_expanded_email_view_onload) {
+        localThread.expanded = show_expanded_email_view_onload;
       }
-    });
-  }
+      activeThread = localThread;
+    } else if (thread_id) {
+      const thread = await MailboxStore.getThread(query);
+
+      if (show_expanded_email_view_onload) {
+        thread.expanded = show_expanded_email_view_onload;
+      }
+      activeThread = thread as Conversation;
+    }
+  })();
 
   // #endregion thread intake and set
   let emailManuallyPassed: boolean;
@@ -1135,7 +1126,7 @@
 >
   {#if thread || thread_id}
     {#await activeThread}
-      Loading Component...
+      Loading...
     {:then thread}
       {#if thread && activeThread}
         {#if activeThread.expanded}

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -7,7 +7,7 @@
     buildInternalProps,
     getEventDispatcher,
   } from "@commons/methods/component";
-  import { MailboxStore } from "@commons/store/threads";
+  import { MailboxStore } from "@commons/store/mailbox";
   import "../../email/src/Email.svelte";
   import "./components/PaginationNav.svelte";
   import { fetchMessage } from "@commons/connections/messages";
@@ -810,7 +810,7 @@
         class="spinner"
         style="height:18px; animation: rotate 2s linear infinite; margin:10px;"
       />
-      Loading component...
+      Loading...
     </div>
   {/if}
 </main>


### PR DESCRIPTION
# Code changes

- Removed `Thread` derived store
- Added `getFlatThreads` method to Mailbox store to avoid calling `$MailboxStore` directly from components
- Refactored reactive method for setting `activeThread` in email component to avoid infinite loop

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
