### PR TITLE
[email] Fixed emails height sometimes causing content to overflow

### DIFF
--- a/commons/src/components/MessageBody.svelte
+++ b/commons/src/components/MessageBody.svelte
@@ -10,7 +10,6 @@
 <style>
   div {
     width: 100%;
-    height: 100%;
   }
 </style>
 


### PR DESCRIPTION
# Code changes

- Removed `height: 100%` in message body

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
