### PR TITLE
[Mailbox]: Removed query params from window url in the requests for threads

### DIFF
--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -59,7 +59,6 @@
     actions_bar: [],
   };
 
-  let queryParams: ThreadsQuery;
   let openedEmailData: Thread | null;
   let hasComponentLoaded = false;
 
@@ -70,9 +69,6 @@
 
   onMount(async () => {
     await tick();
-    queryParams = Object.fromEntries(
-      new URLSearchParams(window.location.search),
-    );
 
     manifest = ((await $ManifestStore[
       JSON.stringify({ component_id: id, access_token })
@@ -127,13 +123,6 @@
     hasComponentLoaded = true;
   });
 
-  $: queryParams = {
-    ...queryParams,
-    ...Object.fromEntries(
-      new URLSearchParams(query_string?.replaceAll(" ", "&")),
-    ),
-  };
-
   let inboxThreads: Thread[]; // threads currently in the inbox
   $: if (threads) {
     inboxThreads = threads;
@@ -186,7 +175,9 @@
   $: query = {
     component_id: id,
     access_token,
-    query: queryParams,
+    query: Object.fromEntries(
+      new URLSearchParams(query_string?.replaceAll(" ", "&")),
+    ),
   };
 
   let queryKey: string;


### PR DESCRIPTION
# Background
Currently we allow filtering the threads using query parameter in the window url in addition to the `query_string` prop passed in. This can cause an issue when user app had a bunch of unrelated query parameters that will result in an error for fetching the threads. Hence removing the feature to filter the threads using window url query params.

# Code changes
- Removed logic for reading query parameters from window url

# Screenshot
![image](https://user-images.githubusercontent.com/16315004/140801234-2f22707b-e658-4f69-a62d-87c13b30d1ab.png)


# Readiness checklist
- [X] Cypress tests passing?
- [X] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
