### PR TITLE
Scheduler: save custom fields as metadata

### DIFF
--- a/components/scheduler/src/Scheduler.svelte
+++ b/components/scheduler/src/Scheduler.svelte
@@ -179,6 +179,17 @@
         },
       };
 
+      if (customFieldResponses["Email Address"]) {
+        postableEvent.participants?.push({
+          email: customFieldResponses["Email Address"],
+          name: customFieldResponses["Your Name"],
+        });
+      }
+
+      if (Object.keys(customFieldResponses).length) {
+        postableEvent.metadata = customFieldResponses;
+      }
+
       if (event.recurrence_cadence && event.recurrence_cadence !== "none") {
         let rrule: string = "";
         if (event.recurrence_cadence === "daily") {


### PR DESCRIPTION
Builds off the custom fields work started in #176 

- Saves all custom field responses as `event.metadata` ( see: https://www.nylas.com/blog/event-metadata )
- For the `Email Address` field (default custom field), also adds the user to the `event.participants` list

<img width="970" alt="CleanShot 2021-11-08 at 21 57 06@2x" src="https://user-images.githubusercontent.com/713991/140853657-e643e147-f8eb-45ae-9847-a53cbb1c6469.png">

## Event booked with user-provided participant: 
<img width="478" alt="CleanShot 2021-11-08 at 21 55 09@2x" src="https://user-images.githubusercontent.com/713991/140853463-afefe9e9-feb8-47aa-8895-f9e3d46c18a5.png">

## Event response showing `event.metadata`:
<img width="569" alt="CleanShot 2021-11-08 at 21 55 35@2x" src="https://user-images.githubusercontent.com/713991/140853498-84f98403-d8b0-44e2-a348-3f4ad078ed96.png">


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
