### PR TITLE
[Email][Bug-fix]: Component thread's message body overflows container

### DIFF
--- a/commons/src/components/MessageBody.svelte
+++ b/commons/src/components/MessageBody.svelte
@@ -9,7 +9,7 @@
 
 <style>
   div {
-    width: 100%;
+    width: inherit;
   }
 </style>
 

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -847,7 +847,8 @@
           div.message-head {
             display: flex;
             justify-content: space-between;
-            align-items: center;
+            align-items: baseline;
+            gap: $spacing-xs;
           }
           div.message-date {
             display: flex;
@@ -878,13 +879,15 @@
               div.message-to {
                 color: gray;
                 max-width: 150px;
-                overflow: hidden;
-                text-overflow: ellipsis;
                 margin-left: calc(32px + 0.7rem);
-                span {
-                  display: flex;
-                  align-items: center;
-                  gap: 0.5rem;
+                div {
+                  display: grid;
+                  grid-template-columns: 1fr 16px;
+
+                  span {
+                    text-overflow: ellipsis;
+                    overflow: hidden;
+                  }
                 }
               }
             }
@@ -1090,8 +1093,18 @@
                 div.message-from-to {
                   margin: $spacing-xs 0;
                   div.message-to {
-                    max-width: unset;
+                    max-width: inherit;
                     overflow: inherit;
+                    div {
+                      display: grid;
+                      grid-template-columns: 1fr 16px;
+                      align-items: center;
+
+                      span {
+                        text-overflow: ellipsis;
+                        overflow: hidden;
+                      }
+                    }
                   }
                 }
               }
@@ -1249,15 +1262,17 @@
                         </div>
                         <div class="message-to">
                           {#each message.to as to, i}
-                            <span>
+                            <div>
                               {#if to.name || to.email}
-                                to&colon;&nbsp;{userEmail &&
-                                to.email === userEmail
-                                  ? "me"
-                                  : to.name || to.email}
-                                {#if i !== message.to.length - 1}
-                                  &nbsp;&comma;
-                                {/if}
+                                <span
+                                  >to&colon;&nbsp;{userEmail &&
+                                  to.email === userEmail
+                                    ? "me"
+                                    : to.name || to.email}
+                                  {#if i !== message.to.length - 1}
+                                    &nbsp;&comma;
+                                  {/if}
+                                </span>
                                 <!-- tooltip component -->
                                 <nylas-tooltip
                                   on:toggleTooltip={setTooltip}
@@ -1267,7 +1282,7 @@
                                   content={to.email}
                                 />
                               {/if}
-                            </span>
+                            </div>
                           {/each}
                         </div>
                       </div>
@@ -1518,14 +1533,16 @@
 
               <div class="message-to">
                 {#each message.to as to, i}
-                  <span>
+                  <div>
                     {#if to.name || to.email}
-                      to&colon;&nbsp;{userEmail && to.email === userEmail
-                        ? "me"
-                        : to.name || to.email}
-                      {#if i !== message.to.length - 1}
-                        &nbsp;&comma;
-                      {/if}
+                      <span
+                        >to&colon;&nbsp;{userEmail && to.email === userEmail
+                          ? "me"
+                          : to.name || to.email}
+                        {#if i !== message.to.length - 1}
+                          &nbsp;&comma;
+                        {/if}
+                      </span>
                       <!-- tooltip component -->
                       <nylas-tooltip
                         on:toggleTooltip={setTooltip}
@@ -1535,7 +1552,7 @@
                         content={to.email}
                       />
                     {/if}
-                  </span>
+                  </div>
                 {/each}
               </div>
             </div>

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -879,7 +879,6 @@
                 color: gray;
                 max-width: 150px;
                 overflow: hidden;
-                white-space: nowrap;
                 text-overflow: ellipsis;
                 margin-left: calc(32px + 0.7rem);
                 span {
@@ -1054,6 +1053,7 @@
           flex-direction: column;
           box-sizing: border-box;
           width: 100%;
+          overflow: hidden;
           header {
             padding: $spacing-m $spacing-xl;
           }


### PR DESCRIPTION
# Code changes

- Added `text-overflow: ellipsis` to the `to` field email so that it wraps nicely for smaller parent container widths
- Added `width: inherit;` to MessageBody component
- Extracted the text content under `message-to` element into a span and replaced the previous span with a div styled as a grid
- Added min width to avatar so it does not get squished for smaller widths

# Screenshot
![image](https://user-images.githubusercontent.com/16315004/141000149-7c93a6ba-c14f-4e36-918e-851b2ae9fcfc.png)


# Readiness checklist

- [X] Cypress tests passing?
- [X] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
