### PR TITLE
Disables cypress recordings for non-nylas org users & fixed cypress dashboard commit messages

### DIFF
--- a/.github/workflows/build-test-publish.yaml
+++ b/.github/workflows/build-test-publish.yaml
@@ -1,10 +1,6 @@
 name: Build & Test
 on:
   push:
-    branches: [main]
-    tags: ["v*"]
-  pull_request:
-    types: [opened]
 env:
   API_GATEWAY: ${{secrets.API_GATEWAY}}
   CYPRESS_RECORD_KEY: ${{secrets.CYPRESS_RECORD_KEY}}

--- a/.github/workflows/build-test-publish.yaml
+++ b/.github/workflows/build-test-publish.yaml
@@ -4,6 +4,7 @@ on:
     branches: [main]
     tags: ["v*"]
   pull_request:
+    types: [opened]
 env:
   API_GATEWAY: ${{secrets.API_GATEWAY}}
   CYPRESS_RECORD_KEY: ${{secrets.CYPRESS_RECORD_KEY}}

--- a/.github/workflows/build-test-publish.yaml
+++ b/.github/workflows/build-test-publish.yaml
@@ -120,7 +120,7 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           working-directory: .
-          record: true
+          record: ${{ github.event.pull_request.head.repo.full_name == github.repository }} # Disable recording if PR is from a forked repo
           install: false # disable npm install because we are already running it in previous step
           start: npm run start:ci
           wait-on: http://localhost:8000

--- a/.github/workflows/build-test-publish.yaml
+++ b/.github/workflows/build-test-publish.yaml
@@ -116,7 +116,7 @@ jobs:
           working-directory: .
           record: ${{ github.event.pull_request.head.repo.full_name == github.repository }} # Disable recording if PR is from a forked repo
           install: false # disable npm install because we are already running it in previous step
-          parallel: true
+          parallel: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
           start: npm run start:ci
           wait-on: http://localhost:8000
           wait-on-timeout: 30

--- a/.github/workflows/build-test-publish.yaml
+++ b/.github/workflows/build-test-publish.yaml
@@ -4,7 +4,6 @@ on:
     branches: [main]
     tags: ["v*"]
   pull_request:
-    types: [opened, synchronize]
 env:
   API_GATEWAY: ${{secrets.API_GATEWAY}}
   CYPRESS_RECORD_KEY: ${{secrets.CYPRESS_RECORD_KEY}}
@@ -99,13 +98,11 @@ jobs:
   test-cypress:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
+      matrix:
+        containers: [1, 2, 3, 4]
     needs: build
     steps:
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: "14"
       - uses: actions/cache@v2
         id: restore-build
         with:
@@ -122,6 +119,7 @@ jobs:
           working-directory: .
           record: ${{ github.event.pull_request.head.repo.full_name == github.repository }} # Disable recording if PR is from a forked repo
           install: false # disable npm install because we are already running it in previous step
+          parallel: true
           start: npm run start:ci
           wait-on: http://localhost:8000
           wait-on-timeout: 30

--- a/.github/workflows/build-test-publish.yaml
+++ b/.github/workflows/build-test-publish.yaml
@@ -114,9 +114,9 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           working-directory: .
-          record: ${{ github.event.pull_request.head.repo.full_name == github.repository }} # Disable recording if PR is from a forked repo
+          record: ${{ env.CYPRESS_RECORD_KEY != '' }} # Disable recording if PR is from a forked repo
           install: false # disable npm install because we are already running it in previous step
-          parallel: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          parallel: ${{ env.CYPRESS_RECORD_KEY != '' }}
           start: npm run start:ci
           wait-on: http://localhost:8000
           wait-on-timeout: 30


### PR DESCRIPTION
# Background
Currently if a non-nylas user contributes to this repo by creating a new PR, cypress tests will fail. This is because GitHub by default does not share Github Secrets with PRs coming from forked repos. This means that the CYPRESS_RECORD_KEY is unavailable.

# Code changes

- [x] Updated the github action to set `record: false` if the PR is coming from a forked repo 
- [x] Added 4 parallel runs for cypress tests to improve run times (only affects builds by nylas users)
- [x] Removed the `pull_request` github action trigger. This was causing pull requests to be made from [refs/remotes/pull/##/merge](https://frontside.com/blog/2020-05-26-github-actions-pull_request/#how-does-pull_request-affect-actionscheckout) causing our cypress dashboard commit messages to be associated with seemingly random Merge commits and not the PR itself

# Screenshots
<img width="858" alt="Screen Shot 2021-11-09 at 4 18 34 PM" src="https://user-images.githubusercontent.com/314152/141006343-f67b3acc-40c4-4a47-b722-b83c724299c2.png">

<img width="324" alt="Screen Shot 2021-11-09 at 4 19 01 PM" src="https://user-images.githubusercontent.com/314152/141006388-60bf636e-c4ff-49d7-8530-5a7ecfc0462b.png">

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
