### PR TITLE
Fixed parallelization + fixed issue with failing tests for non-nylas users

### DIFF
--- a/.github/workflows/build-test-publish.yaml
+++ b/.github/workflows/build-test-publish.yaml
@@ -1,10 +1,13 @@
 name: Build & Test
 on:
   push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    types: [opened, synchronize]
 env:
-  API_GATEWAY: ${{secrets.API_GATEWAY}}
+  API_GATEWAY: "web-components.nylas.com/middleware"
   CYPRESS_RECORD_KEY: ${{secrets.CYPRESS_RECORD_KEY}}
-  PERCY_TOKEN: ${{secrets.PERCY_TOKEN}}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -78,6 +81,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
+      matrix:
+        containers: [1, 2, 3, 4, 5, 6, 7]
     needs: build
     steps:
       - name: Setup Node
@@ -96,8 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        containers: [1, 2, 3, 4]
+
     needs: build
     steps:
       - uses: actions/cache@v2
@@ -114,9 +118,9 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           working-directory: .
-          record: ${{ env.CYPRESS_RECORD_KEY != '' }} # Disable recording if PR is from a forked repo
+          record: true
+          parallel: true
           install: false # disable npm install because we are already running it in previous step
-          parallel: ${{ env.CYPRESS_RECORD_KEY != '' }}
           start: npm run start:ci
           wait-on: http://localhost:8000
           wait-on-timeout: 30


### PR DESCRIPTION
# Code changes

- [x] Hard-coded the API_GATEWAY key since that was missing due to it being a github secret.
- [x] Brought back the `pull_request` trigger, since it is the safest way to trigger GHA for outside contributors.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
