### PR TITLE
Schedule Editor: Custom Fields CRUD

### DIFF
--- a/commons/src/constants/custom-fields.ts
+++ b/commons/src/constants/custom-fields.ts
@@ -1,0 +1,13 @@
+export const DefaultCustomFields = [
+  {
+    title: "Your Name",
+    type: "text",
+    required: false,
+  },
+  {
+    title: "Email Address",
+    type: "text",
+    required: true,
+    placeholder: "you@example.com",
+  },
+];

--- a/commons/src/types/ScheduleEditor.ts
+++ b/commons/src/types/ScheduleEditor.ts
@@ -1,6 +1,7 @@
 import type { Manifest as NylasManifest } from "@commons/types/Nylas";
 import type { NotificationMode } from "@commons/enums/Scheduler";
 import type { AvailabilityRule } from "@commons/types/Availability";
+import type { CustomField } from "./Scheduler";
 
 export interface Manifest extends NylasManifest {
   event_title: string;
@@ -43,4 +44,7 @@ export interface Manifest extends NylasManifest {
   show_preview: boolean;
   timezone: string;
   screen_bookings: boolean;
+  max_book_ahead_days: number;
+  min_book_ahead_days: number;
+  custom_fields: CustomField[];
 }

--- a/commons/src/types/Scheduler.ts
+++ b/commons/src/types/Scheduler.ts
@@ -9,7 +9,7 @@ export interface CustomField {
   description?: string;
   type: "text" | "checkbox" | "email";
   required: boolean;
-  placeholder: string;
+  placeholder?: string;
 }
 
 export interface Manifest extends AvailabilityManifest {

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -309,6 +309,7 @@
   function removeCustomField(field: CustomField) {
     customFields = customFields.filter((f: CustomField) => f !== field);
   }
+  let newCustomField = {};
   $: console.log({ customFields });
   $: console.log({ custom_fields });
   //#endregion custom fields
@@ -776,6 +777,22 @@
                     >
                   </tr>
                 {/each}
+                <tr class="add-new">
+                  <td
+                    ><input
+                      type="text"
+                      placeholder="Title"
+                      bind:value={newCustomField.title}
+                    /></td
+                  >
+                  <td
+                    ><input
+                      type="text"
+                      placeholder="Description"
+                      bind:value={newCustomField.description}
+                    /></td
+                  >
+                </tr>
               </tbody>
             </table>
           {/if}

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -306,12 +306,25 @@
 
   //#region custom fields
   const customFieldKeys = ["title", "description", "type", "required"];
+  const emptyCustomField: CustomField = {
+    title: "",
+    description: "",
+    type: "text",
+    required: false,
+  };
+
+  let newFieldTitleElement: HTMLElement;
+  let newCustomField: CustomField = { ...emptyCustomField };
+
   function removeCustomField(field: CustomField) {
     customFields = customFields.filter((f: CustomField) => f !== field);
   }
-  let newCustomField = {};
-  $: console.log({ customFields });
-  $: console.log({ custom_fields });
+
+  function addNewField(field: CustomField) {
+    customFields = [...customFields, field];
+    newCustomField = { ...emptyCustomField };
+    newFieldTitleElement.focus();
+  }
   //#endregion custom fields
 </script>
 
@@ -757,12 +770,12 @@
         </p>
         <div class="contents">
           {#if customFields}
-            <table>
+            <table cellspacing="0" cellpadding="0">
               <thead>
                 {#each customFieldKeys as key}
                   <th>{key}</th>
                 {/each}
-                <th>Remove</th>
+                <th />
               </thead>
               <tbody>
                 {#each customFields as field}
@@ -778,42 +791,47 @@
                   </tr>
                 {/each}
                 <tr class="add-new">
-                  <td
-                    ><input
+                  <td>
+                    <input
                       type="text"
                       placeholder="Title"
+                      bind:this={newFieldTitleElement}
                       bind:value={newCustomField.title}
-                    /></td
-                  >
-                  <td
-                    ><input
+                    />
+                  </td>
+                  <td>
+                    <input
                       type="text"
                       placeholder="Description"
                       bind:value={newCustomField.description}
-                    /></td
-                  >
+                    />
+                  </td>
+                  <td>
+                    <select bind:value={newCustomField.type}>
+                      <option value="text">Text</option>
+                      <option value="checkbox">Checkbox</option>
+                    </select>
+                  </td>
+                  <td>
+                    <label>
+                      <input
+                        type="checkbox"
+                        bind:checked={newCustomField.required}
+                      />
+                      <span>Required</span>
+                    </label>
+                  </td>
+                  <td>
+                    <button
+                      disabled={!newCustomField.title || !newCustomField.type}
+                      on:click={() => addNewField(newCustomField)}
+                      class="add-custom-field">Add Field</button
+                    >
+                  </td>
                 </tr>
               </tbody>
             </table>
           {/if}
-          <!-- <div role="checkbox">
-            <label>
-              <input
-                type="checkbox"
-                bind:checked={customFieldsIncludeNameAndEmail}
-              />
-              <span>Ask for Name and Email Address (default behaviour)</span>
-            </label>
-          </div>
-          <label>
-            <strong>Maximum slots that can be booked at once</strong>
-            <input
-              type="number"
-              min={1}
-              max={20}
-              bind:value={internalProps.max_bookable_slots}
-            />
-          </label> -->
         </div>
       </section>
 

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -795,6 +795,7 @@
                     <input
                       type="text"
                       placeholder="Title"
+                      aria-label="Title"
                       bind:this={newFieldTitleElement}
                       bind:value={newCustomField.title}
                     />
@@ -803,11 +804,15 @@
                     <input
                       type="text"
                       placeholder="Description"
+                      aria-label="Description"
                       bind:value={newCustomField.description}
                     />
                   </td>
                   <td>
-                    <select bind:value={newCustomField.type}>
+                    <select
+                      bind:value={newCustomField.type}
+                      aria-label="Input Type"
+                    >
                       <option value="text">Text</option>
                       <option value="checkbox">Checkbox</option>
                     </select>
@@ -816,6 +821,7 @@
                     <label>
                       <input
                         type="checkbox"
+                        aria-label="Required Field?"
                         bind:checked={newCustomField.required}
                       />
                       <span>Required</span>

--- a/components/schedule-editor/src/index.html
+++ b/components/schedule-editor/src/index.html
@@ -16,9 +16,7 @@
     <script>
       document.addEventListener("DOMContentLoaded", function () {
         const component = document.querySelector("nylas-schedule-editor");
-        /*
-      component.email_ids = ["nylascypresstest@gmail.com"];
-      */
+        component.email_ids = ["nylascypresstest@gmail.com"];
       });
     </script>
   </head>

--- a/components/schedule-editor/src/index.html
+++ b/components/schedule-editor/src/index.html
@@ -17,11 +17,12 @@
       document.addEventListener("DOMContentLoaded", function () {
         const component = document.querySelector("nylas-schedule-editor");
         /*
-        component.email_ids = ["nylascypresstest@gmail.com"];
-        */
+      component.email_ids = ["nylascypresstest@gmail.com"];
+      */
       });
     </script>
   </head>
+
   <body>
     <main>
       <nylas-schedule-editor id="demo-schedule-editor"></nylas-schedule-editor>

--- a/components/schedule-editor/src/styles/schedule-editor.scss
+++ b/components/schedule-editor/src/styles/schedule-editor.scss
@@ -42,6 +42,50 @@ section {
     gap: 24px;
     margin-bottom: 24px;
 
+    table {
+      border-collapse: colapse;
+
+      tr.add-new td {
+        background-color: var(--grey-light);
+      }
+      th,
+      td {
+        text-align: left;
+        border-bottom: 1px solid rgba(0, 0, 0, 0.25);
+        padding: 0.25rem;
+
+        input[type="text"],
+        select {
+          padding: 0.25rem;
+        }
+
+        label {
+          display: block;
+          white-space: nowrap;
+        }
+
+        button {
+          background-color: var(--red);
+          &.add-custom-field {
+            background-color: var(--blue);
+
+            &:disabled {
+              background-color: var(--grey-warm);
+              cursor: not-allowed;
+            }
+          }
+        }
+      }
+      th {
+        text-transform: capitalize;
+        border-bottom: 2px solid black;
+      }
+
+      tr:last-child td {
+        border-bottom: none;
+      }
+    }
+
     label {
       display: flex;
       flex-direction: column;
@@ -65,18 +109,6 @@ section {
     }
   }
 
-  table {
-    th {
-      text-transform: capitalize;
-      border-bottom: 2px solid black;
-    }
-    th,
-    td {
-      text-align: left;
-      border-bottom: 1px soild rgba(0, 0, 0, 0.25);
-      padding: 0.25rem;
-    }
-  }
   button {
     align-self: flex-end;
     padding: 8px 16px;

--- a/components/schedule-editor/src/styles/schedule-editor.scss
+++ b/components/schedule-editor/src/styles/schedule-editor.scss
@@ -31,6 +31,11 @@ section {
   display: flex;
   flex-direction: column;
   margin-bottom: 96px;
+  .intro {
+    margin-top: 0;
+    padding-top: 0;
+    margin-bottom: 2rem;
+  }
   .contents {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
@@ -57,6 +62,19 @@ section {
     }
     & > .available-hours {
       grid-column: -1 / 1;
+    }
+  }
+
+  table {
+    th {
+      text-transform: capitalize;
+      border-bottom: 2px solid black;
+    }
+    th,
+    td {
+      text-align: left;
+      border-bottom: 1px soild rgba(0, 0, 0, 0.25);
+      padding: 0.25rem;
     }
   }
   button {

--- a/components/scheduler/src/Scheduler.svelte
+++ b/components/scheduler/src/Scheduler.svelte
@@ -9,6 +9,8 @@
     getEventDispatcher,
   } from "@commons/methods/component";
 
+  import { DefaultCustomFields } from "@commons/constants/custom-fields";
+
   import type { Manifest, CustomField } from "@commons/types/Scheduler";
   import type { TimeSlot } from "@commons/types/Availability";
   import type { EventQuery, TimespanEvent } from "@commons/types/Events";
@@ -70,19 +72,7 @@
     notification_subject: "Invitation",
     recurrence: "none",
     recurrence_cadence: ["none"],
-    custom_fields: [
-      {
-        title: "Your Name",
-        type: "text",
-        required: false,
-      },
-      {
-        title: "Email Address",
-        type: "text",
-        required: true,
-        placeholder: "you@example.com",
-      },
-    ],
+    custom_fields: DefaultCustomFields,
   };
 
   let internalProps: Manifest = <any>{};


### PR DESCRIPTION
Adds the ability for a user to add, modify, and delete custom fields for their scheduler.

![CleanShot 2021-11-09 at 22 11 27](https://user-images.githubusercontent.com/713991/141042780-7c4a8c36-fd62-4d06-8e86-12c5fad8a007.png)

allows them to show up in the scheduler (from #176):
![image](https://user-images.githubusercontent.com/713991/141042903-db19f2c2-7030-4b0b-9fa4-fae9995744ac.png)


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
