### PR TITLE
[devops] temp use from-package instead of from-git to publish packages

### DIFF
--- a/.github/workflows/build-test-publish.yaml
+++ b/.github/workflows/build-test-publish.yaml
@@ -156,9 +156,9 @@ jobs:
       - name: Publish (canary)
         if: contains(github.ref, 'canary') == true
         run: |
-          npm run lerna -- publish from-git --no-git-reset --no-verify-access --dist-tag canary --canary --preid canary --yes
+          npm run lerna -- publish from-package --no-git-reset --no-verify-access --dist-tag canary --canary --preid canary --yes
 
       - name: Publish (stable)
         if: contains(github.ref, 'canary') == false
         run: |
-          npm run lerna -- publish from-git --no-git-reset --no-verify-access --yes
+          npm run lerna -- publish from-package --no-git-reset --no-verify-access --yes

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "list": "lerna list",
     "new-component": "node ./scripts/new.js",
     "postinstall": "husky install",
+    "prepublishOnly": "yarn run build",
     "publish": "lerna publish",
     "release:canary": "lerna version prerelease --no-private",
     "release:stable": "lerna version --force-publish --no-private",


### PR DESCRIPTION
# Code changes

Should prevent this issue of [pre-existing versions](https://github.com/nylas/components/runs/4170950988?check_suite_focus=true#step:6:19) attempting to be published on the registry
- [x] temporarily switch to `from-package` which publishes packages on latest commit if they are not present on npm
- Any versions not present in the registry will be published

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
