### PR TITLE
[Email][MessageBody]: Added overflow auto to the message body for cases where the body of the html content exceeds the parent width

### DIFF
--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -809,6 +809,11 @@
           box-sizing: border-box;
           padding: $spacing-xs;
 
+          div.message-body {
+            overflow: auto;
+            display: inline-flex;
+          }
+
           &.condensed {
             div.snippet {
               text-overflow: ellipsis;


### PR DESCRIPTION
# Code changes

- Added `overflow: auto` to Email component's `message-body` class

# Screenshot

https://user-images.githubusercontent.com/16315004/141823972-6fa63c1f-47a0-462d-adc9-e4b5946046ec.mp4



# Readiness checklist

- [X] Cypress tests passing?
- [X] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
