### PR TITLE
barbershop 2021

### DIFF
--- a/components/scheduler/src/Scheduler.svelte
+++ b/components/scheduler/src/Scheduler.svelte
@@ -223,7 +223,7 @@
     });
     const eventBookings = await Promise.all(bookings);
 
-    dispatchEvent("bookedEvents", {});
+    dispatchEvent("bookedEvents", { eventBookings });
 
     if (notification_mode === NotificationMode.SEND_MESSAGE) {
       eventBookings.map((event, i) => {

--- a/components/scheduler/src/barbershop.html
+++ b/components/scheduler/src/barbershop.html
@@ -10,26 +10,22 @@
       const custom_fields = [
         {
           required: true,
-          title:
-            "Location ('Downtown Barbershop' or 'West Toronto Barbershop')",
+          title: "Location ('Downtown'/'West Toronto')",
           type: "text",
         },
         {
           required: true,
-          title:
-            "Do you currently have one or more of the COVID-19 symptoms below that are new or worsening?  fever and/or chills, cough or barking cough (croup), shortness of breath, decrease or loss of smell or taste fatigue and/or muscle aches/joint pain (for adults), nausea/vomiting, and/or diarrhea (for <18 years of age) ('Yes' or 'No')",
+          title: "Do you have COVID symptoms? ('Yes'/'No')",
           type: "text",
         },
         {
           required: true,
-          title:
-            "Has a doctor, health care provider, or public health unit told you that you should currently be isolating (staying at home)? ('Yes' or 'No')",
+          title: "Should you be isolating? ('Yes'/'No')",
           type: "text",
         },
         {
           required: true,
-          title:
-            "Do you live with someone who has been told by a doctor, health care provider, or public health unit that they should currently be isolating? ('Yes' or 'No')",
+          title: "Living with isolating person? 'Yes'/'No'",
           type: "text",
         },
       ];
@@ -106,7 +102,7 @@
         show_as_week="true"
         allow_booking="true"
         booking_label="Schedule Ninja Barber"
-        id="cf221443-2613-4191-8e28-0481bc258b66"
+        id="71bdd4b8-b0b7-4ede-a208-34e96d68e735"
         slot_size="30"
         start_hour="9"
         end_hour="17"
@@ -116,7 +112,7 @@
       >
       </nylas-availability>
       <nylas-scheduler
-        id="71bdd4b8-b0b7-4ede-a208-34e96d68e735"
+        id="93a0b73f-48c0-44fe-b4cc-fce85a01483f"
         recurrence="none"
         notification_mode="show_message"
       >

--- a/components/scheduler/src/barbershop.html
+++ b/components/scheduler/src/barbershop.html
@@ -7,6 +7,33 @@
     <script src="../index.js"></script>
     <script src="../../availability/index.js"></script>
     <script>
+      const custom_fields = [
+        {
+          required: true,
+          title:
+            "Location ('Downtown Barbershop' or 'West Toronto Barbershop')",
+          type: "text",
+        },
+        {
+          required: true,
+          title:
+            "Do you currently have one or more of the COVID-19 symptoms below that are new or worsening?  fever and/or chills, cough or barking cough (croup), shortness of breath, decrease or loss of smell or taste fatigue and/or muscle aches/joint pain (for adults), nausea/vomiting, and/or diarrhea (for <18 years of age) ('Yes' or 'No')",
+          type: "text",
+        },
+        {
+          required: true,
+          title:
+            "Has a doctor, health care provider, or public health unit told you that you should currently be isolating (staying at home)? ('Yes' or 'No')",
+          type: "text",
+        },
+        {
+          required: true,
+          title:
+            "Do you live with someone who has been told by a doctor, health care provider, or public health unit that they should currently be isolating? ('Yes' or 'No')",
+          type: "text",
+        },
+      ];
+
       document.addEventListener("DOMContentLoaded", function () {
         const availability = document.querySelector("nylas-availability");
         const scheduler = document.querySelector("nylas-scheduler");
@@ -15,7 +42,10 @@
 
         availability.addEventListener("timeSlotChosen", (event) => {
           // determine if first timeslot is a 30m or 1h event
-          const minutesBetween = (event.detail.timeSlots[0].end_time - event.detail.timeSlots[0].start_time)/(60 * 1000);
+          const minutesBetween =
+            (event.detail.timeSlots[0].end_time -
+              event.detail.timeSlots[0].start_time) /
+            (60 * 1000);
           if (minutesBetween === 30) {
             scheduler.event_title = "Ninja Haircut";
             scheduler.event_description = "Quick 30m snip snip";
@@ -25,6 +55,8 @@
           }
           scheduler.slots_to_book = event.detail.timeSlots;
         });
+
+        scheduler.custom_fields = custom_fields;
 
         scheduler.addEventListener("bookedEvents", () => {
           availability.reload(true, true);

--- a/components/scheduler/src/barbershop.html
+++ b/components/scheduler/src/barbershop.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta content="width=device-width,initial-scale=1" name="viewport" />
+    <meta charset="UTF-8" />
+    <title>Scheduler Demo</title>
+    <script src="../index.js"></script>
+    <script src="../../availability/index.js"></script>
+    <script>
+      document.addEventListener("DOMContentLoaded", function () {
+        const availability = document.querySelector("nylas-availability");
+        const scheduler = document.querySelector("nylas-scheduler");
+
+        availability.email_ids = ["joanna.smith@nylas.com"];
+
+        availability.addEventListener("timeSlotChosen", (event) => {
+          scheduler.slots_to_book = event.detail.timeSlots;
+        });
+
+        scheduler.addEventListener("bookedEvents", () => {
+          availability.reload(true, true);
+        });
+      });
+    </script>
+    <style>
+      body {
+        padding: 0;
+        margin: 0;
+        background: white;
+        color: black;
+      }
+
+      main {
+        width: 80vw;
+        margin-left: 10vw;
+        height: 80vh;
+        margin-top: 10vh;
+        display: grid;
+        grid-template-columns: 2fr 1fr;
+        grid-template-rows: 100%;
+        gap: 1rem;
+      }
+    </style>
+  </head>
+
+  <body>
+    <main>
+      <nylas-availability
+        show_as_week="true"
+        allow_booking="true"
+        id="71bdd4b8-b0b7-4ede-a208-34e96d68e735"
+        slot_size="30"
+        start_hour="9"
+        end_hour="17"
+        show_hosts="hide"
+        max_bookable_slots="2"
+        closed_color="#999"
+      >
+      </nylas-availability>
+      <nylas-scheduler
+        id="fb16c1c5-1a84-4179-96bd-3becfeed8e69"
+        recurrence="none"
+      >
+      </nylas-scheduler>
+    </main>
+  </body>
+</html>

--- a/components/scheduler/src/barbershop.html
+++ b/components/scheduler/src/barbershop.html
@@ -9,6 +9,17 @@
     <script>
       const custom_fields = [
         {
+          title: "Your Name",
+          type: "text",
+          required: false,
+        },
+        {
+          title: "Email Address",
+          type: "text",
+          required: true,
+          placeholder: "you@example.com",
+        },
+        {
           required: true,
           title: "Location ('Downtown'/'West Toronto')",
           type: "text",
@@ -30,6 +41,47 @@
         },
       ];
 
+      function saveToDB() {
+        let url =
+          "https://api.sheety.co/1bd4ee1b211e35fa28d936baa287c1c6/schedulerDogfoodingBarbershopQ4/sheet1";
+        eventBookings.map((event) => {
+          return {
+            title: event.title,
+            start_time: event.when.start_time,
+            end_time: event.when.end_time,
+            duration:
+              (event.when.end_time - event.when.start_time) / (60 * 1000) + "m",
+            email: event.participants.find(
+              (p) => p.email !== "joanna.smith@nylas.com",
+            ).email,
+            name: event.participants.find(
+              (p) => p.email !== "joanna.smith@nylas.com",
+            ).name,
+          };
+        });
+        console.log(eventBookings);
+
+        eventBookings.forEach((event) => {
+          let body = {
+            sheet1: {
+              title: "hi",
+            },
+          };
+          fetch(url, {
+            method: "POST",
+            body: JSON.stringify({ sheet1: { hi: "hi" } }),
+            headers: {
+              "Content-Type": "application/json",
+            },
+          })
+            .then((response) => response.json())
+            .then((json) => {
+              // Do something with object
+              console.log(json.sheet1);
+            });
+        });
+      }
+
       document.addEventListener("DOMContentLoaded", function () {
         const availability = document.querySelector("nylas-availability");
         const scheduler = document.querySelector("nylas-scheduler");
@@ -39,6 +91,7 @@
 
         availability.addEventListener("timeSlotChosen", (event) => {
           // determine if first timeslot is a 30m or 1h event
+          // user can only choose 2 30m slots - if the 1st is 30m, 2nd will be too
           const minutesBetween =
             (event.detail.timeSlots[0].end_time -
               event.detail.timeSlots[0].start_time) /
@@ -51,14 +104,19 @@
             scheduler.event_description = "60m line up & face";
           }
           scheduler.slots_to_book = event.detail.timeSlots;
+          saveToDB();
         });
 
         scheduler.custom_fields = custom_fields;
 
-        scheduler.addEventListener("bookedEvents", () => {
+        scheduler.addEventListener("bookedEvents", (event) => {
+          let eventBookings = event.detail.eventBookings;
+
+          // save booked events to see a list of them
+          saveToDB(eventBookings);
+
           // this doesn't work!! it takes too long to update on the Nylas side.
           availability.reload(true, true);
-          window.location.reload();
         });
       });
     </script>

--- a/components/scheduler/src/barbershop.html
+++ b/components/scheduler/src/barbershop.html
@@ -82,6 +82,21 @@
         grid-template-rows: 100%;
         gap: 1rem;
       }
+
+      /* mobile */
+      @media (max-width: 600px) {
+        main {
+          display: flex;
+          flex-direction: column;
+          margin: 3rem 1rem;
+          gap: 3rem;
+          width: unset;
+          height: unset;
+        }
+        nylas-availability {
+          height: 50vh;
+        }
+      }
     </style>
   </head>
 
@@ -90,6 +105,7 @@
       <nylas-availability
         show_as_week="true"
         allow_booking="true"
+        booking_label="Schedule Ninja Barber"
         id="cf221443-2613-4191-8e28-0481bc258b66"
         slot_size="30"
         start_hour="9"
@@ -102,6 +118,7 @@
       <nylas-scheduler
         id="71bdd4b8-b0b7-4ede-a208-34e96d68e735"
         recurrence="none"
+        notification_mode="show_message"
       >
       </nylas-scheduler>
     </main>

--- a/components/scheduler/src/barbershop.html
+++ b/components/scheduler/src/barbershop.html
@@ -35,6 +35,7 @@
         const scheduler = document.querySelector("nylas-scheduler");
 
         availability.email_ids = ["joanna.smith@nylas.com"];
+        availability.overbooked_threshold = 18; // allows for 3 30m meetings.
 
         availability.addEventListener("timeSlotChosen", (event) => {
           // determine if first timeslot is a 30m or 1h event
@@ -55,7 +56,9 @@
         scheduler.custom_fields = custom_fields;
 
         scheduler.addEventListener("bookedEvents", () => {
+          // this doesn't work!! it takes too long to update on the Nylas side.
           availability.reload(true, true);
+          window.location.reload();
         });
       });
     </script>

--- a/components/scheduler/src/barbershop.html
+++ b/components/scheduler/src/barbershop.html
@@ -14,6 +14,15 @@
         availability.email_ids = ["joanna.smith@nylas.com"];
 
         availability.addEventListener("timeSlotChosen", (event) => {
+          // determine if first timeslot is a 30m or 1h event
+          const minutesBetween = (event.detail.timeSlots[0].end_time - event.detail.timeSlots[0].start_time)/(60 * 1000);
+          if (minutesBetween === 30) {
+            scheduler.event_title = "Ninja Haircut";
+            scheduler.event_description = "Quick 30m snip snip";
+          } else if (minutesBetween === 60) {
+            scheduler.event_title = "Ninja Haircut & Beard Trim";
+            scheduler.event_description = "60m line up & face";
+          }
           scheduler.slots_to_book = event.detail.timeSlots;
         });
 
@@ -22,6 +31,7 @@
         });
       });
     </script>
+
     <style>
       body {
         padding: 0;
@@ -48,7 +58,7 @@
       <nylas-availability
         show_as_week="true"
         allow_booking="true"
-        id="71bdd4b8-b0b7-4ede-a208-34e96d68e735"
+        id="cf221443-2613-4191-8e28-0481bc258b66"
         slot_size="30"
         start_hour="9"
         end_hour="17"
@@ -58,7 +68,7 @@
       >
       </nylas-availability>
       <nylas-scheduler
-        id="fb16c1c5-1a84-4179-96bd-3becfeed8e69"
+        id="71bdd4b8-b0b7-4ede-a208-34e96d68e735"
         recurrence="none"
       >
       </nylas-scheduler>

--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
   </style>
 
   <body>
+    <a href="components/scheduler/src/barbershop.html">Barbershop shhh</a>
     <h2>Released Components</h2>
     <ul>
       <li>


### PR DESCRIPTION
Dog-fooding Scheduler component to see where we can improve development experience 

If you have comments and suggestions, or want to try additional features, please comment below! 


# Background
I am an underground barber trying to hide from the government, but I want to schedule haircuts with people and also be safe.
-  I want to book haircuts no more than 3 times a day, so that it doesn’t look suspicious to my neighbours when I leave the house.
- I also want to include screening questions (standard Ontario government Covid-19 questionnaire) that the customer is required to fill in.
- I don’t want to send the customer a confirmation email of the event because I don't want the government to somehow find evidence via a paper trail.
- I have 2 locations, in case one of them gets raided: a Downtown Barbershop and a West Toronto Barbershop. Either way, I can only give 3 total haircuts a day.
- Operating hours are 9am to 5pm Mon-Thurs, and 10am-3pm Sat/Sun
- Haircuts can either be 30 minutes, or 60 minutes (if the customer wants a beard trim)
- For internal bookkeeping purposes, I want to be able to see a history of who booked with me recently (for how long, their email address, and their timeslot) organized by most recent
- Bookings should be able to work via mobile as well as desktop




# Todo
- [ ] better implementation for only 3 events/day 
- [ ] implement booked events view