### PR TITLE
Consolidating availability requests into a single request

### DIFF
--- a/commons/src/connections/availability.ts
+++ b/commons/src/connections/availability.ts
@@ -35,7 +35,6 @@ export const fetchFreeBusy = async (
 };
 
 export const fetchAvailability = async (
-  // TODO: rename
   query: AvailabilityQuery,
 ): Promise<AvailabilityResponse> => {
   return fetch(

--- a/commons/src/types/Availability.ts
+++ b/commons/src/types/Availability.ts
@@ -112,10 +112,12 @@ export interface PreDatedTimeSlot
   end_time: number;
   start?: number;
   end?: number;
+  emails: string[]; //present when round_robin property is set on request, which it always is in Availability
 }
 
 export interface AvailabilityResponse {
   object: "availability";
+  order: string[]; //present when round_robin property is set on request, which it always is in Availability
   time_slots: PreDatedTimeSlot[];
 }
 


### PR DESCRIPTION
To test, set component.email_ids to an array of several peoples' IDs.

This takes advantage of the `calendar/availability` endpoint's new `round_robin` property; when set to `max_availability`, it will return time slots for each passed user, and provide an `order` array indicating the most to least available users. We iterate over this in the return to create discreet calendar lists, and consolidate (blob) those timeslots same as we were doing before.

Caveat to be fixe later: in theory, booking_user might have a different access_token than the one passed into the component. We should wrap a couple fetch promises in the future.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
