### PR TITLE
Show partial availability along a spectrum, rather than just "partial"

### DIFF
--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -21,7 +21,7 @@
   } from "@commons/methods/component";
   import type { TimeInterval } from "d3-time";
   import { timeWeek, timeDay, timeHour, timeMinute } from "d3-time";
-  import { scaleTime } from "d3-scale";
+  import { scaleTime, scaleLinear } from "d3-scale";
   import throttle from "just-throttle";
   import type { CalendarQuery } from "@commons/types/Events";
   import { lightenHexColour } from "@commons/methods/colour";
@@ -1456,6 +1456,13 @@
       },
     };
   }
+
+  //#region colours
+  // Show partial availability as a gradient, rather than as categorically "partial"
+  $: partialScale = scaleLinear()
+    .domain([0, allCalendars?.length / 2, allCalendars?.length])
+    .range([_this.busy_color, _this.partial_color, _this.free_color]);
+  //#endregion colours
 </script>
 
 <style lang="scss">
@@ -1575,7 +1582,12 @@
                   data-start-time={new Date(epoch.start_time).toLocaleString()}
                   data-end-time={new Date(epoch.end_time).toLocaleString()}
                 >
-                  <div class="inner">
+                  <div
+                    class="inner"
+                    style="background-color: {partialScale(
+                      epoch.available_calendars.length,
+                    )}"
+                  >
                     {#if _this.show_hosts === "show"}
                       <div class="available-calendars">
                         <span

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -791,12 +791,14 @@ describe("availability component", () => {
         .as("availability")
         .then((element) => {
           const component = element[0];
-          component.partial_color = "#000";
+          component.partial_color = "#222";
+          component.busy_color = "#000";
+          component.free_color = "#444";
           cy.get(".epoch.partial .inner").should(
             "have.css",
             "background-color",
-            "rgb(0, 0, 0)",
-          );
+            "rgb(45, 45, 45)",
+          ); // 45: 2/3 availability = 2/3 distance between 000 and 444 in base RGB.
         });
     });
   });


### PR DESCRIPTION
- changes partial availability from just showing the `partial_color` to a scale that ranges between `busy_color` to `partial_color` to `free_color`, letting users get an at-a-glance view of how busy parts of the day are.

https://user-images.githubusercontent.com/713991/142137143-374d854f-45aa-47c4-82c8-6b39438de442.mov

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
