### PR TITLE
[Mailbox][Bug-fix]: cannot delete thread for outlook account

### DIFF
--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -213,7 +213,7 @@
   let folders: Folder[] = [];
   $: trashFolderID =
     folders && folders.length
-      ? labels.find((folder) => folder.name === "trash")?.id
+      ? folders.find((folder) => folder.name === "trash")?.id
       : null;
   // #endregion initialize label and folder vars (for trash)
 

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -190,7 +190,7 @@
 
   let folders: Folder[] = [];
   $: trashFolderID = folders.length
-    ? labels.find((folder) => folder.name === "trash")?.id
+    ? folders.find((folder) => folder.name === "trash")?.id
     : null;
 
   let you: Partial<Account> = {};


### PR DESCRIPTION
# Code changes

- The filtering for trash folder id was jumbled up causing the issue with deleting in outlook accounts.

# Readiness checklist

- [] New property added? make sure to update `component/src/properties.json`
- [] Cypress tests passing?
- [] New cypress tests added?
- [] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
