### PR TITLE
Schedule Editor: Save to manifest functionality 

### DIFF
--- a/commons/src/connections/manifest.ts
+++ b/commons/src/connections/manifest.ts
@@ -21,3 +21,30 @@ export const fetchManifest = async (
     .then((response) => response.component.theming)
     .catch((error) => handleError(id, error));
 };
+
+// Allows <nylas-schedule-editor> to modify its own properties
+
+interface saveManifestParams {
+  id: string;
+  access_token?: string;
+  manifest: Manifest;
+}
+
+export const saveManifest = async (
+  params: saveManifestParams
+): Promise<Manifest> => {
+  const { id, access_token, manifest } = params;
+  return fetch(
+    `${getMiddlewareApiUrl(id)}/component`,
+    getFetchConfig({
+      method: "PUT",
+      component_id: id,
+      access_token,
+      body: manifest,
+    }),
+  )
+    .then((response) => handleResponse<MiddlewareResponse<Manifest>>(response))
+    .then((json) => {
+      return json.response;
+    });
+}

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -64,7 +64,7 @@
   const defaultValueMap: Partial<Manifest> = {
     allow_booking: false,
     attendees_to_show: 5,
-    capacity: 1,
+    capacity: null,
     custom_fields: DefaultCustomFields,
     dates_to_show: 1,
     email_ids: [],

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -13,6 +13,7 @@
   import { onMount, tick } from "svelte";
   import timezones from "timezones-list";
   import { ManifestStore } from "../../../commons/src";
+  import { saveManifest } from "@commons/connections/manifest";
   import "../../availability/src/Availability.svelte";
   import "../../scheduler/src/Scheduler.svelte";
 
@@ -143,11 +144,19 @@
   }
   // #endregion mount and prop initialization
 
+  console.log({ _this });
+
   function saveProperties() {
     console.log("Saving the following properties:");
     Object.entries(_this).forEach(([k, v]) => {
       console.log(k, v);
     });
+    let savedManifest = saveManifest({
+      id,
+      access_token,
+      manifest: { settings: JSON.parse(_this) },
+    });
+    console.log({ savedManifest });
   }
 
   // #region unpersisted variables

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -144,19 +144,12 @@
   }
   // #endregion mount and prop initialization
 
-  console.log({ _this });
-
   function saveProperties() {
-    console.log("Saving the following properties:");
-    Object.entries(_this).forEach(([k, v]) => {
-      console.log(k, v);
-    });
-    let savedManifest = saveManifest({
+    saveManifest({
       id,
       access_token,
       manifest: { settings: JSON.parse(_this) },
     });
-    console.log({ savedManifest });
   }
 
   // #region unpersisted variables

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -148,7 +148,7 @@
     saveManifest({
       id,
       access_token,
-      manifest: { settings: JSON.parse(_this) },
+      manifest: { settings: { ..._this } },
     });
   }
 

--- a/components/schedule-editor/src/index.html
+++ b/components/schedule-editor/src/index.html
@@ -1,29 +1,31 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta content="width=device-width,initial-scale=1" name="viewport" />
-    <meta charset="UTF-8" />
-    <title>Schedule Editor Demo</title>
-    <script src="../index.js"></script>
-    <style>
-      html,
-      body {
-        margin: 0;
-        padding: 0;
-      }
-    </style>
 
-    <script>
-      document.addEventListener("DOMContentLoaded", function () {
-        const component = document.querySelector("nylas-schedule-editor");
-        component.email_ids = ["nylascypresstest@gmail.com"];
-      });
-    </script>
-  </head>
+<head>
+  <meta content="width=device-width,initial-scale=1" name="viewport" />
+  <meta charset="UTF-8" />
+  <title>Schedule Editor Demo</title>
+  <script src="../index.js"></script>
+  <style>
+    html,
+    body {
+      margin: 0;
+      padding: 0;
+    }
+  </style>
 
-  <body>
-    <main>
-      <nylas-schedule-editor id="demo-schedule-editor"></nylas-schedule-editor>
-    </main>
-  </body>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      const component = document.querySelector("nylas-schedule-editor");
+      // component.email_ids = ["nylascypresstest@gmail.com"];
+    });
+  </script>
+</head>
+
+<body>
+  <main>
+    <nylas-schedule-editor id="messaround-schedule-editor"></nylas-schedule-editor>
+  </main>
+</body>
+
 </html>

--- a/components/schedule-editor/src/index.html
+++ b/components/schedule-editor/src/index.html
@@ -1,31 +1,29 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta content="width=device-width,initial-scale=1" name="viewport" />
+    <meta charset="UTF-8" />
+    <title>Schedule Editor Demo</title>
+    <script src="../index.js"></script>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
 
-<head>
-  <meta content="width=device-width,initial-scale=1" name="viewport" />
-  <meta charset="UTF-8" />
-  <title>Schedule Editor Demo</title>
-  <script src="../index.js"></script>
-  <style>
-    html,
-    body {
-      margin: 0;
-      padding: 0;
-    }
-  </style>
+    <script>
+      document.addEventListener("DOMContentLoaded", function () {
+        const component = document.querySelector("nylas-schedule-editor");
+        component.email_ids = ["nylascypresstest@gmail.com"];
+      });
+    </script>
+  </head>
 
-  <script>
-    document.addEventListener("DOMContentLoaded", function () {
-      const component = document.querySelector("nylas-schedule-editor");
-      // component.email_ids = ["nylascypresstest@gmail.com"];
-    });
-  </script>
-</head>
-
-<body>
-  <main>
-    <nylas-schedule-editor id="messaround-schedule-editor"></nylas-schedule-editor>
-  </main>
-</body>
-
+  <body>
+    <main>
+      <nylas-schedule-editor id="demo-schedule-editor"></nylas-schedule-editor>
+    </main>
+  </body>
 </html>


### PR DESCRIPTION
- Allows the Schedule Editor component to save to its own manifest
- Will save every property in `_this` -- which is, if defaults haven't been overwritten, those defaults will be saved upwards, too.

### Defaults will be saved upwards

^---- *this is a point worth discussing!* This makes sense if we want to say that the defaults at the time of component creation should be locked-in, regardless of future default changes to those properties. But that's not a foregone conclusion and it's neither the most efficient in terms of storage space. I'm on the fence about this, but let's say, 60% in favour of saving defaults up the way this is doing it.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
