### PR TITLE
Allow yarn install to work with node 16+

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "live-server": "1.2.1",
     "luxon": "^2.0.2",
     "mockdate": "^3.0.4",
-    "node-sass": "5.0.0",
+    "node-sass": "6.0.1",
     "prettier": "^2.0.5",
     "prettier-plugin-svelte": "^2.1.6",
     "pretty-quick": "3.0.0",


### PR DESCRIPTION
Node-sass at v5 was preventing node at v16+ from completing `yarn install`.


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
