### PR TITLE
[Mailbox]: Update thread request was not passing in access token header

### DIFF
--- a/commons/src/connections/threads.ts
+++ b/commons/src/connections/threads.ts
@@ -79,6 +79,7 @@ export const updateThread = async (
     getFetchConfig({
       method: "PUT",
       component_id: query.component_id,
+      access_token: query.access_token,
       body: {
         unread: updatedThread.unread,
         starred: updatedThread.starred,


### PR DESCRIPTION
# Code changes

- Added access_token property to the object being passed to `getFetchConfig` in update thread request.

# Readiness checklist

- [] New property added? make sure to update `component/src/properties.json`
- [] Cypress tests passing?
- [] New cypress tests added?
- [] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
