### PR TITLE
[Mailbox] Implemented server-side pagination

### DIFF
--- a/commons/src/enums/Nylas.ts
+++ b/commons/src/enums/Nylas.ts
@@ -9,12 +9,6 @@ export enum AccountSyncState {
   STOPPED = "stopped",
 }
 
-export enum EmailUnreadStatus {
-  READ = "read",
-  UNREAD = "unread",
-  DEFAULT = "default",
-}
-
 export enum MailboxActions {
   SELECTALL = "selectall",
   DELETE = "delete",

--- a/commons/src/index.ts
+++ b/commons/src/index.ts
@@ -5,7 +5,12 @@ export {
   fetchContactImage,
   fetchContactThreads,
 } from "./connections/contacts";
-export { fetchThreads, fetchThread, updateThread } from "./connections/threads";
+export {
+  fetchThreads,
+  fetchThreadCount,
+  fetchThread,
+  updateThread,
+} from "./connections/threads";
 export { fetchManifest } from "./connections/manifest";
 export {
   sendMessage,
@@ -26,7 +31,7 @@ export { ContactStore } from "./store/contacts";
 export { ContactAvatarStore } from "./store/contact-avatar";
 export { ConversationStore } from "./store/conversations";
 export { EventStore } from "./store/events";
-export { MailboxStore } from "./store/mailbox";
+export { MailboxStore, EmailStore } from "./store/mailbox";
 export { MessageStore } from "./store/messages";
 export { ManifestStore } from "./store/manifest";
 export {

--- a/commons/src/store/mailbox.ts
+++ b/commons/src/store/mailbox.ts
@@ -1,9 +1,9 @@
-import { writable } from "svelte/store";
+import { derived, Readable, writable } from "svelte/store";
 import {
-  fetchThread,
   fetchThreads,
   fetchSearchResultThreads,
   updateThread,
+  fetchThreadCount,
 } from "../connections/threads";
 import type {
   Thread,
@@ -11,72 +11,158 @@ import type {
   ConversationQuery,
   Message,
   Conversation,
-  SearchResultThreadsQuery,
 } from "@commons/types/Nylas";
 
+interface PaginatedThreads {
+  isLoaded: boolean;
+  threads: Thread[];
+}
+
+async function initializePaginatedThreads(totalPages: number) {
+  const paginatedThreads = [];
+
+  for (let i = 0; i < totalPages; i++) {
+    paginatedThreads.push({
+      isLoaded: false,
+      threads: [],
+    });
+  }
+  return paginatedThreads;
+}
+
 function initializeThreads() {
-  const { subscribe, set, update } = writable<Record<string, Thread[]>>({});
-  let threadsMap: Record<string, Thread[]> = {};
+  const { subscribe, set, update } = writable<
+    Record<string, PaginatedThreads[]>
+  >({});
+  let threadsMap: Record<string, PaginatedThreads[]> = {};
+  let totalItems: number;
 
   return {
     subscribe,
     set,
-    getThreads: async (query: MailboxQuery, forceRefresh = false) => {
+    getThreads: async (
+      query: MailboxQuery,
+      currentPage: number,
+      pageSize: number,
+      forceRefresh = false,
+    ) => {
       const queryKey = JSON.stringify(query);
-      if (
-        (!threadsMap[queryKey] || forceRefresh) &&
-        (query.component_id || query.access_token)
-      ) {
-        threadsMap[queryKey] = await fetchThreads(query);
+      if (!query.component_id && !query.access_token) {
+        return [];
       }
-      update((threads) => {
-        threads[queryKey] = threadsMap[queryKey];
-        return { ...threads };
-      });
-      return threadsMap[queryKey];
-    },
-    getThreadsWithSearchKeyword: async (query: SearchResultThreadsQuery) => {
-      const queryKey = JSON.stringify(query);
-      if (!threadsMap[queryKey] && (query.component_id || query.access_token)) {
-        threadsMap[queryKey] = (await fetchSearchResultThreads(query)).map(
-          (thread) => thread,
+
+      if (totalItems === undefined || forceRefresh) {
+        totalItems = await fetchThreadCount(query);
+      }
+
+      if (!Array.isArray(threadsMap[queryKey]) || forceRefresh) {
+        const totalPages = Math.ceil(totalItems / pageSize);
+        threadsMap[queryKey] = await initializePaginatedThreads(totalPages);
+      }
+
+      if (!threadsMap[queryKey][currentPage].isLoaded) {
+        threadsMap[queryKey][currentPage].threads = await fetchThreads(
+          query,
+          pageSize,
+          currentPage * pageSize,
         );
+        threadsMap[queryKey][currentPage].isLoaded = true;
+      }
+
+      update((threads) => {
+        threads[queryKey] = threadsMap[queryKey];
+        return { ...threads };
+      });
+      return threadsMap[queryKey][currentPage].threads;
+    },
+    getNumberOfItems: async (query: MailboxQuery) => {
+      if (!query.component_id && !query.access_token) {
+        return 0;
+      }
+
+      if (totalItems === undefined) {
+        totalItems = await fetchThreadCount(query);
+      }
+      return totalItems;
+    },
+    // TODO - Use real pagination when search endpoint supports it
+    getThreadsWithSearchKeyword: async (
+      query: MailboxQuery,
+      forceRefresh = false,
+    ) => {
+      if (!query.component_id && !query.access_token) {
+        return [];
+      }
+      const queryKey = JSON.stringify(query);
+
+      if (!Array.isArray(threadsMap[queryKey]) || forceRefresh) {
+        threadsMap[queryKey] = await initializePaginatedThreads(1);
+      }
+
+      if (!threadsMap[queryKey][0].isLoaded || forceRefresh) {
+        threadsMap[queryKey][0].threads = await fetchSearchResultThreads(query);
+        threadsMap[queryKey][0].isLoaded = true;
       }
       update((threads) => {
         threads[queryKey] = threadsMap[queryKey];
         return { ...threads };
       });
-      return threadsMap[queryKey];
+      return threadsMap[queryKey][0].threads;
     },
     updateThread: async (
       threadQuery: ConversationQuery,
       queryKey: string,
       updatedThread: Conversation,
+      currentPage: number,
+      pageSize: number,
     ) => {
       const thread = await updateThread(threadQuery, updatedThread);
-      if (!threadsMap[queryKey]) {
-        threadsMap[queryKey] = await fetchThreads(JSON.parse(queryKey));
+      if (!threadsMap[queryKey][currentPage].isLoaded) {
+        threadsMap[queryKey][currentPage].threads = await fetchThreads(
+          JSON.parse(queryKey),
+          pageSize,
+          currentPage * pageSize,
+        );
+        threadsMap[queryKey][currentPage].isLoaded = true;
       }
-      threadsMap[queryKey] = threadsMap[queryKey].map((initialThread) => {
+
+      threadsMap[queryKey][currentPage].threads = threadsMap[queryKey][
+        currentPage
+      ].threads.map((initialThread) => {
         if (initialThread.id === thread.id) {
           initialThread = Object.assign(initialThread, thread);
         }
         return initialThread;
       });
+      update((threads) => {
+        threads[queryKey] = threadsMap[queryKey];
+        return { ...threads };
+      });
+      return threadsMap[queryKey][currentPage].threads;
     },
-    getThread: async (query: ConversationQuery) => {
-      const queryKey = JSON.stringify(query);
-      if (!threadsMap[queryKey] && (query.component_id || query.access_token)) {
-        threadsMap[queryKey] = [await fetchThread(query)];
+    updateThreadSelection: (
+      queryKey: string,
+      currentPage: number,
+      threadId?: string,
+    ) => {
+      const threads = threadsMap[queryKey][currentPage].threads;
+
+      if (!threadId) {
+        const selectionState = threads.some((thread) => thread.selected);
+        for (const thread of threads) {
+          thread.selected = !selectionState;
+        }
+      } else {
+        const thread = threads.find((thread) => thread.id === threadId);
+        if (thread) {
+          thread.selected = !thread.selected;
+        }
       }
       update((threads) => {
         threads[queryKey] = threadsMap[queryKey];
         return { ...threads };
       });
-      return threadsMap[queryKey][0];
-    },
-    getFlatThreads: () => {
-      return Object.values(threadsMap).flat();
+      return threadsMap[queryKey][currentPage].threads;
     },
 
     reset: () => {
@@ -84,30 +170,53 @@ function initializeThreads() {
       set({});
     },
 
-    hydrateMessageInThread: (incomingMessage: Message, query: MailboxQuery) => {
+    hydrateMessageInThread: (
+      incomingMessage: Message,
+      query: MailboxQuery,
+      currentPage: number,
+    ) => {
       const queryKey = JSON.stringify(query);
-      const foundThread = threadsMap[queryKey].find(
+
+      const foundThread = threadsMap[queryKey][currentPage]?.threads.find(
         (thread) => thread.id === incomingMessage.thread_id,
       );
       if (foundThread) {
-        const foundMessage = foundThread?.messages?.find(
+        const foundMessage = foundThread.messages?.find(
           (message) => message.id === incomingMessage.id,
         );
         if (foundMessage) {
           foundMessage.body = incomingMessage.body;
+          update((threads) => {
+            if (incomingMessage.thread_id) {
+              let threadToUpdate = threads[queryKey][currentPage].threads.find(
+                (thread) => thread.id === foundThread.id,
+              );
+
+              if (threadToUpdate) {
+                threadToUpdate = JSON.parse(JSON.stringify(foundThread));
+              }
+            }
+            return { ...threads };
+          });
         }
       }
-      update((threads) => {
-        if (incomingMessage.thread_id) {
-          threads[incomingMessage.thread_id] = JSON.parse(
-            JSON.stringify(foundThread),
-          );
-        }
-        return { ...threads };
-      });
-      return threadsMap[JSON.stringify(query)];
+      return threadsMap[queryKey][currentPage].threads;
     },
   };
 }
 
 export const MailboxStore = initializeThreads();
+
+export const EmailStore: Readable<Record<string, Thread[]>> = derived(
+  MailboxStore,
+  ($MailboxStore) => {
+    const emailStore: Record<string, Thread[]> = {};
+    Object.entries($MailboxStore).forEach(
+      ([key, paginatedThreads]) =>
+        (emailStore[key] = paginatedThreads
+          .map((paginatedThread) => paginatedThread.threads)
+          .flat()),
+    );
+    return emailStore;
+  },
+);

--- a/commons/src/types/Nylas.ts
+++ b/commons/src/types/Nylas.ts
@@ -1,7 +1,6 @@
 import type {
   AccountOrganizationUnit,
   AccountSyncState,
-  EmailUnreadStatus,
   MailboxActions,
 } from "@commons/enums/Nylas";
 import type { Contact, HydratedContact } from "@commons/types/Contacts";
@@ -19,6 +18,7 @@ export interface ConversationQuery extends CommonQuery {
 
 export interface MailboxQuery extends CommonQuery {
   query: ThreadsQuery;
+  keywordToSearch?: string;
 }
 
 export type AccountQuery = CommonQuery;
@@ -184,7 +184,6 @@ export interface EmailProperties extends Manifest {
   theme: "theme-1" | "theme-2" | "theme-3" | "theme-4" | "theme-5";
   thread_id: string;
   thread: Thread;
-  unread: boolean;
   you: Partial<Account>;
 }
 
@@ -198,7 +197,6 @@ export interface MailboxProperties extends Manifest {
   show_star: boolean;
   show_thread_checkbox: boolean;
   theme: "theme-1" | "theme-2" | "theme-3" | "theme-4" | "theme-5";
-  unread_status: EmailUnreadStatus;
 }
 
 export interface ComposerProperties extends Manifest {
@@ -271,6 +269,7 @@ export interface Thread {
   folders?: Folder[]; //to be changed to Folder[];
   folder_id?: string;
   label_ids?: string[];
+  selected?: boolean;
 }
 export interface Conversation extends Thread {
   messages: Message[];

--- a/components/email/src/init.spec.js
+++ b/components/email/src/init.spec.js
@@ -344,8 +344,9 @@ describe("Email component", () => {
         .as("email")
         .then((element) => {
           const component = element[0];
+          component.thread = { ...SAMPLE_THREAD, unread: false };
           cy.get(component).find(".unread").should("not.exist");
-          component.unread = "true";
+          component.thread = { ...component.thread, unread: true };
           cy.get(component).find(".unread").should("exist");
         });
     });

--- a/components/email/src/properties.json
+++ b/components/email/src/properties.json
@@ -79,13 +79,6 @@
     "value": false
   },
   {
-    "label": "unread",
-    "title": "Show a thread as unread by overriding the thread's default value",
-    "type": "boolean",
-    "options": [true, false],
-    "value": false
-  },
-  {
     "label": "click_action",
     "title": "This option allows to specify the type of click action",
     "type": "string",

--- a/components/mailbox/src/components/PaginationNav.svelte
+++ b/components/mailbox/src/components/PaginationNav.svelte
@@ -1,8 +1,10 @@
 <svelte:options tag="pagination-nav" />
 
 <script lang="ts">
-  export let current_page: number = 1;
-  export let last_page: number = 1;
+  export let current_page: number = 0;
+  export let items_per_page: number;
+  export let num_pages: number = 1;
+  export let num_items: number;
 
   import { getEventDispatcher } from "@commons/methods/component";
   import { get_current_component } from "svelte/internal";
@@ -16,7 +18,7 @@
 
   function changePage(newPage: number) {
     dispatchEvent("changePage", {
-      newPage: newPage,
+      newPage,
     });
   }
 </script>
@@ -27,13 +29,19 @@
     --font: -apple-system, BlinkMacSystemFont, sans-serif;
     display: flex;
     align-items: center;
+
+    .page-indicator {
+      color: #454954;
+      height: 38px;
+      margin: 2em 1em 0 1em;
+    }
   }
 
   button {
+    margin-top: 1em;
     text-align: center;
     min-width: 38px;
     min-height: 38px;
-    margin-top: 25px;
     border: #e3e8ee solid 1px;
     margin-right: -1px;
     font-family: var(--font);
@@ -41,14 +49,12 @@
     color: #454954;
     cursor: pointer;
 
-    /*&:disabled {
-      background-color: var(--disabled);
-      color: var(--disabled-text);
-    }*/
-
     &.current {
       background-color: white;
       color: #2c2e2e;
+    }
+    &:disabled {
+      cursor: default;
     }
   }
 
@@ -58,43 +64,45 @@
 </style>
 
 <nav class="pagination-nav">
-  {#if last_page > 1}
+  <span class="page-indicator">
+    <span class="page-start">
+      {current_page * items_per_page + 1}
+    </span>
+    -
+    <span class="page-end">
+      {Math.min((current_page + 1) * items_per_page, num_items)}
+    </span>
+    of
+    <span class="total">{num_items}</span>
+  </span>
+  {#if num_pages > 1}
     <button
       class="paginate-btn first-btn"
-      on:click={() => changePage(1)}
-      disabled={current_page === 1}
+      on:click={() => changePage(0)}
+      disabled={current_page === 0}
     >
       <FirstIcon style="width: 24px; height: 24px;" />
     </button>
     <button
       class="paginate-btn back-btn"
       on:click={() => changePage(current_page - 1)}
-      disabled={current_page === 1}
+      disabled={current_page === 0}
     >
       <BackIcon style="width: 24px; height: 24px;" />
     </button>
   {/if}
-  <div class="page-numbers">
-    {#each { length: last_page } as _, i}
-      <button
-        class="paginate-btn {current_page === i + 1 ? 'current' : ''}"
-        on:click={() => changePage(i + 1)}
-        disabled={current_page === i + 1}>{i + 1}</button
-      >
-    {/each}
-  </div>
-  {#if last_page > 1}
+  {#if num_pages > 1}
     <button
       class="paginate-btn next-btn"
       on:click={() => changePage(current_page + 1)}
-      disabled={current_page === last_page}
+      disabled={current_page === num_pages - 1}
     >
       <NextIcon style="height:24px;width:24px;" />
     </button>
     <button
       class="paginate-btn last-btn"
-      on:click={() => changePage(last_page)}
-      disabled={current_page === last_page}
+      on:click={() => changePage(num_pages - 1)}
+      disabled={current_page === num_pages - 1}
     >
       <LastIcon style="height:24px;width:24px;" />
     </button>

--- a/components/mailbox/src/index.html
+++ b/components/mailbox/src/index.html
@@ -21,6 +21,8 @@
         mailbox.show_star = true;
         // mailbox.keyword_to_search = "Hi";
         // mailbox.query_string = "in=inbox from=tips@nylas.com";
+
+        // setTimeout(() => mailbox.items_per_page = 10, 5000)
       });
     </script>
   </head>

--- a/components/mailbox/src/properties.json
+++ b/components/mailbox/src/properties.json
@@ -26,13 +26,6 @@
     "value": false
   },
   {
-    "label": "unread_status",
-    "title": "Show read/unread status of emails",
-    "options": ["read", "unread", "default"],
-    "type": "string",
-    "value": "default"
-  },
-  {
     "label": "header",
     "title": "Shows the header passed in the Mailbox",
     "type": "string",
@@ -55,7 +48,7 @@
     "label": "query_string",
     "title": "Filter your threads",
     "type": "string",
-    "value": null
+    "value": "in=inbox"
   },
   {
     "label": "actions_bar",


### PR DESCRIPTION
# Code changes

- Implemented server-side pagination for mailbox component
- To keep pages the same size, I had to remove the filter that excluded threads without messages (most of these were from spam emails so we now exclude the spam folder as well
- Removed `unread_status` prop from Mailbox
- Removed `unread` prop from Email

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
