### PR TITLE
Schedule Editor: Consecutive Events

### DIFF
--- a/commons/src/types/ScheduleEditor.ts
+++ b/commons/src/types/ScheduleEditor.ts
@@ -4,18 +4,12 @@ import type { AvailabilityRule } from "@commons/types/Availability";
 import type { CustomField } from "./Scheduler";
 
 export interface Manifest extends NylasManifest {
-  event_title: string;
-  event_description: string;
   show_hosts: "show" | "hide";
-  event_location: string;
-  event_conferencing: string;
   start_hour: number;
   end_hour: number;
-  slot_size: 15 | 30 | 60;
   start_date: Date;
   dates_to_show: number;
   show_ticks: boolean;
-  email_ids: string[];
   allow_booking: boolean;
   max_bookable_slots: number;
   partial_bookable_ratio: number;
@@ -48,4 +42,19 @@ export interface Manifest extends NylasManifest {
   min_book_ahead_days: number;
   custom_fields: CustomField[];
   events: any[]; // TODO
+}
+
+export interface EventDefinition {
+  event_title: string;
+  event_description: string;
+  event_location: string;
+  event_conferencing: string;
+  slot_size: 15 | 30 | 60;
+  email_ids: string[];
+  host_rules: HostRules;
+}
+
+interface HostRules {
+  method: "all" | "user_determined" | "random";
+  host_count?: number;
 }

--- a/commons/src/types/ScheduleEditor.ts
+++ b/commons/src/types/ScheduleEditor.ts
@@ -47,4 +47,5 @@ export interface Manifest extends NylasManifest {
   max_book_ahead_days: number;
   min_book_ahead_days: number;
   custom_fields: CustomField[];
+  events: any[]; // TODO
 }

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -8,7 +8,10 @@
   } from "@commons/methods/component";
   import { weekdays } from "@commons/methods/datetime";
   import type { AvailabilityRule, TimeSlot } from "@commons/types/Availability";
-  import type { Manifest } from "@commons/types/ScheduleEditor";
+  import type {
+    Manifest,
+    EventDefinition,
+  } from "@commons/types/ScheduleEditor";
   import type { CustomField } from "@commons/types/Scheduler";
   import { onMount, tick } from "svelte";
   import timezones from "timezones-list";
@@ -25,12 +28,7 @@
   export let capacity: number | null;
   export let custom_fields: CustomField[];
   export let dates_to_show: number;
-  export let email_ids: string[];
   export let end_hour: number;
-  export let event_conferencing: string;
-  export let event_description: string;
-  export let event_location: string;
-  export let event_title: string;
   export let mandate_top_of_hour: boolean;
   export let max_bookable_slots: number;
   export let max_book_ahead_days: number;
@@ -53,21 +51,23 @@
   export let show_preview: boolean;
   export let show_ticks: boolean;
   export let show_weekends: boolean;
-  export let slot_size: number; // in minutes
   export let start_date: Date;
   export let start_hour: number;
   export let view_as: "schedule" | "list";
   export let screen_bookings: boolean;
   export let timezone: string;
+  export let events: EventDefinition[];
 
-  const eventTemplate = {
+  const eventTemplate: EventDefinition = {
     event_title: "",
     event_description: "",
     slot_size: 15,
     event_location: "",
     event_conferencing: "",
-    emailIDs: "",
-    email_ids: "",
+    email_ids: [],
+    host_rules: {
+      method: "all",
+    },
   };
 
   const defaultValueMap: Partial<Manifest> = {
@@ -76,12 +76,7 @@
     capacity: null,
     custom_fields: DefaultCustomFields,
     dates_to_show: 1,
-    email_ids: [],
     end_hour: 17,
-    event_conferencing: "",
-    event_description: "",
-    event_location: "",
-    event_title: "Meeting",
     mandate_top_of_hour: false,
     max_bookable_slots: 1,
     max_book_ahead_days: 30,
@@ -96,7 +91,6 @@
     show_as_week: false,
     show_ticks: true,
     show_weekends: true,
-    slot_size: 15,
     start_date: new Date(),
     start_hour: 9,
     view_as: "schedule",
@@ -232,7 +226,7 @@
     const emailString = e.target.value;
     clearTimeout(debouncedInputTimer);
     debouncedInputTimer = setTimeout(() => {
-      event.email_ids = emailString;
+      event.email_ids = parseStringToArray(emailString);
       _this.events = [..._this.events];
     }, 1000);
   }

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -255,14 +255,15 @@
   //#endregion custom fields
 
   //#region consecutive events
-  // Object.freeze(eventTemplate);
-
-  // let consecutiveEvents: any[] = [{ ...eventTemplate }]; // TODO: type
 
   function addConsecutiveEvent() {
-    console.log("adding a consecutive event");
     _this.events = [..._this.events, { ...eventTemplate }];
   }
+
+  function removeConsecutiveEvent(event: EventDefinition) {
+    _this.events = _this.events.filter((e) => e !== event);
+  }
+
   //#endregion consecutive events
 </script>
 
@@ -289,6 +290,14 @@
         <div class="contents">
           {#each _this.events as event, iter}
             <fieldset>
+              {#if _this.events.length > 1}
+                <button
+                  class="remove-event"
+                  on:click={() => removeConsecutiveEvent(event)}
+                >
+                  Remove this event
+                </button>
+              {/if}
               <label>
                 <strong>Event Title</strong>
                 <input type="text" bind:value={event.event_title} />

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -255,6 +255,22 @@
     newFieldTitleElement.focus();
   }
   //#endregion custom fields
+
+  //#region consecutive events
+  const eventTemplate = {
+    event_title: "",
+    event_description: "",
+  };
+  Object.freeze(eventTemplate);
+
+  let consecutiveEvents: any[] = [{ ...eventTemplate }]; // TODO: type
+
+  $: _this.events = consecutiveEvents;
+  $: console.log({ evnts: _this.events });
+  function addConsecutiveEvent() {
+    console.log("adding a consecutive event");
+  }
+  //#endregion consecutive events
 </script>
 
 <style lang="scss">
@@ -273,58 +289,77 @@
     <div class="settings">
       <section class="basic-details">
         <h1>Event Details</h1>
+        <p>
+          Edit the details for your meeting. You can add consecutive meetings to
+          allow users to book back-to-back events.
+        </p>
         <div class="contents">
-          <label>
-            <strong>Event Title</strong>
-            <input type="text" bind:value={_this.event_title} />
-          </label>
-          <label>
-            <strong>Event Description</strong>
-            <input type="text" bind:value={_this.event_description} />
-          </label>
-          <label>
-            <strong>Event Location</strong>
-            <input type="text" bind:value={_this.event_location} />
-          </label>
-          <label>
-            <strong>Event Conferencing</strong>
-            <input type="url" bind:value={_this.event_conferencing} />
-          </label>
-          <div role="radiogroup" aria-labelledby="show_hosts">
-            <strong id="show_hosts">Show meeting hosts to the end-user?</strong>
+          {#each consecutiveEvents as event}
             <label>
-              <input
-                type="radio"
-                name="show_hosts"
-                value={"show"}
-                bind:group={_this.show_hosts}
-              />
-              <span>Show Hosts</span>
+              <strong>Event Title</strong>
+              <input type="text" bind:value={event.event_title} />
             </label>
             <label>
-              <input
-                type="radio"
-                name="show_hosts"
-                value={"hide"}
-                bind:group={_this.show_hosts}
-              />
-              <span>Hide Hosts</span>
+              <strong>Event Description</strong>
+              <input type="text" bind:value={event.event_description} />
             </label>
-          </div>
-          <div>
-            <div>
-              <strong id="email_ids">Email Ids to include for scheduling</strong
-              >
+            <label>
+              <strong>Event Location</strong>
+              <input type="text" bind:value={_this.event_location} />
+            </label>
+            <label>
+              <strong>Conferencing Link (Zoom, Teams, or Meet URL)</strong>
+              <input type="url" bind:value={_this.event_conferencing} />
+            </label>
+            <div role="radiogroup" aria-labelledby="slot_size">
+              <strong id="slot_size">Meeting Length</strong>
+              <label>
+                <input
+                  type="radio"
+                  name="slot_size"
+                  value={15}
+                  bind:group={_this.slot_size}
+                />
+                <span>15 minutes</span>
+              </label>
+              <label>
+                <input
+                  type="radio"
+                  name="slot_size"
+                  value={30}
+                  bind:group={_this.slot_size}
+                />
+                <span>30 minutes</span>
+              </label>
+              <label>
+                <input
+                  type="radio"
+                  name="slot_size"
+                  value={60}
+                  bind:group={_this.slot_size}
+                />
+                <span>60 minutes</span>
+              </label>
             </div>
-            <label>
-              <textarea
-                name="email_ids"
-                on:input={debounceEmailInput}
-                value={emailIDs}
-              />
-            </label>
-          </div>
+            <div>
+              <div>
+                <strong id="email_ids"
+                  >Email Ids to include for scheduling</strong
+                >
+              </div>
+              <label>
+                <textarea
+                  name="email_ids"
+                  on:input={debounceEmailInput}
+                  value={emailIDs}
+                />
+              </label>
+            </div>
+          {/each}
         </div>
+        <button class="add-event" on:click={addConsecutiveEvent}
+          >Add a follow-up event</button
+        >
         <button on:click={saveProperties}>Save Editor Options</button>
       </section>
       <section class="time-date-details">
@@ -355,36 +390,6 @@
               />
             </label>
             {_this.end_hour}:00
-          </div>
-          <div role="radiogroup" aria-labelledby="slot_size">
-            <strong id="slot_size">Timeslot size</strong>
-            <label>
-              <input
-                type="radio"
-                name="slot_size"
-                value={15}
-                bind:group={_this.slot_size}
-              />
-              <span>15 minutes</span>
-            </label>
-            <label>
-              <input
-                type="radio"
-                name="slot_size"
-                value={30}
-                bind:group={_this.slot_size}
-              />
-              <span>30 minutes</span>
-            </label>
-            <label>
-              <input
-                type="radio"
-                name="slot_size"
-                value={60}
-                bind:group={_this.slot_size}
-              />
-              <span>60 minutes</span>
-            </label>
           </div>
           <label>
             <strong>Start Date</strong>

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -271,7 +271,6 @@
 
   // let consecutiveEvents: any[] = [{ ...eventTemplate }]; // TODO: type
 
-  $: console.log({ evnts: _this.events });
   function addConsecutiveEvent() {
     console.log("adding a consecutive event");
     _this.events = [..._this.events, { ...eventTemplate }];
@@ -332,6 +331,15 @@
                   <input type="radio" value={60} bind:group={event.slot_size} />
                   <span>60 minutes</span>
                 </label>
+                {#if iter !== 0 && event.slot_size !== _this.events[0].slot_size}
+                  <!-- Temporary! Nylas' Consecutive Availabiilty API does not support variant time lengths between meetings -->
+                  <!-- https://app.shortcut.com/nylas/story/74514/consecutive-availability-allow-to-specify-duration-minutes-per-meeting -->
+                  <p class="warning">
+                    Note: different meeting lengths in a conecutive chain are
+                    not currently supported; all meetings in this chain will
+                    fall back to {_this.events[0].slot_size} minutes.
+                  </p>
+                {/if}
               </div>
               <div>
                 <div>

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -127,16 +127,10 @@
   }
 
   // Properties requiring further manipulation:
-  let emailIDs: string = "";
   let startDate: string = new Date().toLocaleDateString("en-CA");
 
   function transformPropertyValues() {
-    emailIDs = _this.email_ids?.join(", ") ?? "";
     startDate = _this.start_date?.toLocaleDateString("en-CA");
-  }
-
-  $: {
-    _this.email_ids = parseStringToArray(emailIDs);
   }
 
   $: {
@@ -814,11 +808,12 @@
         <h1>Preview</h1>
         <nylas-availability
           {..._this}
+          {..._this.events[0]}
           capacity={null}
           on:timeSlotChosen={(event) => {
             slots_to_book = event.detail.timeSlots;
           }}
-          calendars={!_this.email_ids
+          calendars={!_this.events[0]?.email_ids
             ? [
                 {
                   availability: "busy",
@@ -832,7 +827,7 @@
           {slots_to_book}
           {..._this}
           capacity={null}
-          calendars={!_this.email_ids
+          calendars={!_this.events[0]?.email_ids
             ? [
                 {
                   availability: "busy",

--- a/components/schedule-editor/src/init.spec.js
+++ b/components/schedule-editor/src/init.spec.js
@@ -3,4 +3,14 @@ describe("schedule-editor component", () => {
     cy.visit("/components/schedule-editor/src/index.html");
     cy.get("nylas-schedule-editor").should("exist");
   });
+
+  describe("Allows for multiple meetings", () => {
+    it("Allows the user to add consecutive meetings", () => {
+      cy.get(".basic-details fieldset").should("have.length", 1);
+      cy.get(".basic-details button.add-event").click();
+      cy.get(".basic-details fieldset").should("have.length", 2);
+      cy.get(".basic-details button.add-event").click();
+      cy.get(".basic-details fieldset").should("have.length", 3);
+    });
+  });
 });

--- a/components/schedule-editor/src/init.spec.js
+++ b/components/schedule-editor/src/init.spec.js
@@ -11,6 +11,9 @@ describe("schedule-editor component", () => {
       cy.get(".basic-details fieldset").should("have.length", 2);
       cy.get(".basic-details button.add-event").click();
       cy.get(".basic-details fieldset").should("have.length", 3);
+      cy.get(".basic-details button.remove-event").eq(0).click();
+      cy.get(".basic-details button.remove-event").eq(0).click();
+      cy.get(".basic-details fieldset").should("have.length", 1);
     });
   });
 });

--- a/components/schedule-editor/src/styles/schedule-editor.scss
+++ b/components/schedule-editor/src/styles/schedule-editor.scss
@@ -129,6 +129,17 @@ section {
     border: none;
     font-weight: 600;
   }
+
+  &.basic-details .contents {
+    grid-template-columns: 1fr;
+    & > fieldset {
+      border: none;
+      padding: 0;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: 24px;
+    }
+  }
 }
 .availability-container {
   overflow: auto;

--- a/components/schedule-editor/src/styles/schedule-editor.scss
+++ b/components/schedule-editor/src/styles/schedule-editor.scss
@@ -134,13 +134,24 @@ section {
     grid-template-columns: 1fr;
     & > fieldset {
       border: none;
+      border-bottom: 1px solid var(--grey);
       padding: 0;
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-      gap: 24px;
+      padding-bottom: 2rem;
+      gap: 2rem;
     }
   }
 }
+
+.warning {
+  background-color: var(--red-lighter);
+  border: 1px solid var(--red);
+  color: var(--black);
+  padding: 0.5rem;
+  font-size: 0.9rem;
+}
+
 .availability-container {
   overflow: auto;
   height: 300px;

--- a/components/schedule-editor/src/styles/schedule-editor.scss
+++ b/components/schedule-editor/src/styles/schedule-editor.scss
@@ -134,12 +134,17 @@ section {
     grid-template-columns: 1fr;
     & > fieldset {
       border: none;
-      border-bottom: 1px solid var(--grey);
       padding: 0;
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-      padding-bottom: 2rem;
-      gap: 2rem;
+      padding: 1rem;
+      gap: 1rem;
+      background-color: var(--grey-background);
+
+      .remove-event {
+        grid-column: -1 / 1;
+        justify-self: end;
+      }
     }
   }
 }


### PR DESCRIPTION
- Adds the ability to set multiple events in a "Consecutive Booking" -- something like a panel interview, allowing for back-to-back meetings with different details.

- Removes the following properties from the top level of the schedule editor manifest and adds them to a new `events` array:
```
  event_title: string;
  event_description: string;
  event_location: string;
  event_conferencing: string;
  slot_size: 15 | 30 | 60;
  email_ids: string[];
```

- Introduces the concept of `host_rules` to dictate how multiple `email_ids` in a given event should be treated

![image](https://user-images.githubusercontent.com/713991/143295433-427a6ade-2415-4022-8def-4b4df95b991a.png)


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
