### PR TITLE
Bugfix: Race condition on date fetch for Availability component

### DIFF
--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -865,7 +865,7 @@
 
     // If the booking user and access token are passed in, fetch their calendars as well.
     // TODO: dont include them in the main list, as they shouldn't contribute to partial slot availability.
-    // TODO: user booking_user_token instead of access_token for booking_user_email in calendarsToFetch
+    // TODO: use booking_user_token instead of access_token for booking_user_email in calendarsToFetch
     if (_this.booking_user_email && _this.booking_user_token) {
       calendarsToFetch.push({
         email: _this.booking_user_email,
@@ -884,8 +884,53 @@
         })
       ];
 
-      loading = false;
+      console.log(
+        "-------",
+        new Date(
+          getAvailabilityQuery(
+            calendarsToFetch.map((x) => x.email),
+            access_token,
+          )?.body.start_time * 1000,
+        ),
+      );
+      await $AvailabilityStore[
+        JSON.stringify({
+          ...getAvailabilityQuery(
+            calendarsToFetch.map((x) => x.email),
+            access_token,
+          ),
+          forceReload,
+        })
+      ].then((ful) => {
+        console.log(
+          "fetchedCals",
+          new Date(fetchedCalendars.time_slots[0]?.start_time * 1000),
+          new Date(ful.time_slots[0]?.start_time * 1000),
+        );
+      });
 
+      // Object.keys($AvailabilityStore).map(async (x) => {
+      //   await $AvailabilityStore[x].then((y) => {
+      //     console.log({
+      //       keyDate: new Date(JSON.parse(x).body.start_time * 1000),
+      //       dataDate: new Date(y.time_slots[0]?.start_time * 1000),
+      //     });
+      //   });
+      // });
+
+      loading = false;
+      console.log(
+        "just stop at this point",
+        fetchedCalendars,
+        timeDay(new Date(getAvailabilityQuery().body.start_time * 1000)),
+        timeDay(new Date(fetchedCalendars.time_slots[0]?.start_time * 1000)),
+        timeDay(
+          new Date(getAvailabilityQuery().body.start_time * 1000),
+        ).getTime() ===
+          timeDay(
+            new Date(fetchedCalendars.time_slots[0]?.start_time * 1000),
+          ).getTime(),
+      );
       const timeSlotMap: Record<string, PreDatedTimeSlot[]> = {};
 
       for (const user of fetchedCalendars?.order) {

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -884,53 +884,22 @@
         })
       ];
 
-      console.log(
-        "-------",
-        new Date(
-          getAvailabilityQuery(
-            calendarsToFetch.map((x) => x.email),
-            access_token,
-          )?.body.start_time * 1000,
-        ),
-      );
-      await $AvailabilityStore[
-        JSON.stringify({
-          ...getAvailabilityQuery(
-            calendarsToFetch.map((x) => x.email),
-            access_token,
-          ),
-          forceReload,
-        })
-      ].then((ful) => {
-        console.log(
-          "fetchedCals",
-          new Date(fetchedCalendars.time_slots[0]?.start_time * 1000),
-          new Date(ful.time_slots[0]?.start_time * 1000),
-        );
-      });
-
-      // Object.keys($AvailabilityStore).map(async (x) => {
-      //   await $AvailabilityStore[x].then((y) => {
-      //     console.log({
-      //       keyDate: new Date(JSON.parse(x).body.start_time * 1000),
-      //       dataDate: new Date(y.time_slots[0]?.start_time * 1000),
-      //     });
-      //   });
-      // });
-
       loading = false;
-      console.log(
-        "just stop at this point",
-        fetchedCalendars,
-        timeDay(new Date(getAvailabilityQuery().body.start_time * 1000)),
-        timeDay(new Date(fetchedCalendars.time_slots[0]?.start_time * 1000)),
+
+      // A user can load several queries in quick succession, and their variable latency can lead to race conditions.
+      // This condition checks to see if the returned schedule's date and the component active date are the same.
+      // If not, circuit break.
+      if (
         timeDay(
           new Date(getAvailabilityQuery().body.start_time * 1000),
-        ).getTime() ===
-          timeDay(
-            new Date(fetchedCalendars.time_slots[0]?.start_time * 1000),
-          ).getTime(),
-      );
+        ).getTime() !==
+        timeDay(
+          new Date(fetchedCalendars.time_slots[0]?.start_time * 1000),
+        ).getTime()
+      ) {
+        return;
+      }
+
       const timeSlotMap: Record<string, PreDatedTimeSlot[]> = {};
 
       for (const user of fetchedCalendars?.order) {

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -69,9 +69,7 @@
           },
         ];
 
-        // component.calendars = calendars;
-        component.email_ids = ["phil.r@nylas.com"];
-        component.start_date = new Date();
+        component.calendars = calendars;
 
         component.addEventListener("timeSlotChosen", (event) => {
           console.log(event.detail.timeSlots);
@@ -675,7 +673,7 @@
         <nylas-availability
           allow_booking="true"
           max_bookable_slots="8"
-          id="phils-availability"
+          id="demo-availability"
         >
         </nylas-availability>
       </div>

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -69,7 +69,9 @@
           },
         ];
 
-        component.calendars = calendars;
+        // component.calendars = calendars;
+        component.email_ids = ["phil.r@nylas.com"];
+        component.start_date = new Date();
 
         component.addEventListener("timeSlotChosen", (event) => {
           console.log(event.detail.timeSlots);
@@ -673,7 +675,7 @@
         <nylas-availability
           allow_booking="true"
           max_bookable_slots="8"
-          id="demo-availability"
+          id="phils-availability"
         >
         </nylas-availability>
       </div>


### PR DESCRIPTION
Because time to fetch schedule data varies from date to date, it's possible to end up in a situation where you click a bunch of next-dates in succession, for one of the slower, middle ones to finish last and overwrite your timeslots.

Or, an easier way to test would be to go from a loaded date, to an unloaded one, then quickly back again before the new date's schedule has loaded.

Because this is a little tricky to test, here's a video demonstrating the fix:

https://user-images.githubusercontent.com/713991/143381779-f77e06a8-fd03-4d65-9ec0-56de661d1723.mov

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
