### PR TITLE
[Mailbox][Email]: border style regressions

### DIFF
--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -715,11 +715,7 @@
         }
         &.unread {
           background: var(--nylas-email-unread-background, white);
-          border: var(
-            --nylas-email-border-style,
-            1px solid var(--grey-lighter)
-          );
-          border-left-width: var(--nylas-email-border-left-width, 1px);
+
           .from-message-count,
           .date,
           .subject {

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -644,10 +644,7 @@
       background: var(--nylas-email-background, var(--grey-lightest));
       border: var(--nylas-email-border-style, 1px solid var(--grey-lighter));
       border-left-width: var(--nylas-email-border-left-width, 1px);
-      &:hover {
-        $hover-outline-width: 1px;
-        outline: $hover-outline-width solid var(--grey-warm);
-      }
+
       nylas-tooltip {
         position: relative;
       }

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -643,7 +643,7 @@
     .email-row {
       background: var(--nylas-email-background, var(--grey-lightest));
       border: var(--nylas-email-border-style, 1px solid var(--grey-lighter));
-      border-left: var(--nylas-email-border-left-style, 1px solid);
+      border-left-width: var(--nylas-email-border-left-width, 1px);
       &:hover {
         $hover-outline-width: 1px;
         outline: $hover-outline-width solid var(--grey-warm);
@@ -722,8 +722,7 @@
             --nylas-email-border-style,
             1px solid var(--grey-lighter)
           );
-          border-left: var(--nylas-email-border-left-style, 1px solid);
-
+          border-left-width: var(--nylas-email-border-left-width, 1px);
           .from-message-count,
           .date,
           .subject {

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -625,7 +625,6 @@
   @import "../../theming/animation.scss";
   @import "../../theming/variables.scss";
 
-  $border-style: 1px solid #ebebeb;
   $hover-outline-width: 2px;
   $collapsed-height: 56px;
   $mobile-collapsed-height: fit-content;
@@ -643,8 +642,12 @@
     font-family: -apple-system, BlinkMacSystemFont, sans-serif;
     .email-row {
       background: var(--nylas-email-background, var(--grey-lightest));
-      border: var(--nylas-email-border, #{$border-style});
-
+      border: var(--nylas-email-border-style, 1px solid var(--grey-lighter));
+      border-left: var(--nylas-email-border-left-style, 1px solid);
+      &:hover {
+        $hover-outline-width: 1px;
+        outline: $hover-outline-width solid var(--grey-warm);
+      }
       nylas-tooltip {
         position: relative;
       }
@@ -715,6 +718,11 @@
         }
         &.unread {
           background: var(--nylas-email-unread-background, white);
+          border: var(
+            --nylas-email-border-style,
+            1px solid var(--grey-lighter)
+          );
+          border-left: var(--nylas-email-border-left-style, 1px solid);
 
           .from-message-count,
           .date,

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -535,6 +535,7 @@
       // #region define background styles
       --nylas-email-background: transparent;
       --nylas-email-border-left-width: 0px;
+      --nylas-email-unread-background: transparent;
 
       &:not(.unread) {
         background: var(--grey-lightest);

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -534,7 +534,7 @@
 
       // #region define background styles
       --nylas-email-background: transparent;
-      --nylas-email-border-left-style: none;
+      --nylas-email-border-left-width: 0px;
 
       &:not(.unread) {
         background: var(--grey-lightest);

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -39,7 +39,7 @@
 
   export let actions_bar: MailboxActions[];
   export let all_threads: Thread[];
-  export let header: string;
+  export let header: string = "Mailbox";
   export let items_per_page: number;
   export let keyword_to_search: string;
   export let onSelectThread: (event: MouseEvent, t: Thread) => void =
@@ -534,6 +534,8 @@
 
       // #region define background styles
       --nylas-email-background: transparent;
+      --nylas-email-border-left-style: none;
+
       &:not(.unread) {
         background: var(--grey-lightest);
       }

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -540,7 +540,7 @@
         background: var(--grey-lightest);
       }
       &.unread {
-        background: white;
+        background: var(--nylas-email-background);
       }
       // #endregion define background styles
 


### PR DESCRIPTION
# Code changes

- Style fixes for email border
- Fixed Mailbox header being shown as undefined when no header passed in

# Screenshots:

### Before:
![image](https://user-images.githubusercontent.com/16315004/143947568-51a28442-3488-4019-8173-9031cb4013b9.png)
![image](https://user-images.githubusercontent.com/16315004/143947682-03e89722-ba7d-407a-927f-8e7e8a8b604a.png)


### After:
![image](https://user-images.githubusercontent.com/16315004/143942051-b3b51682-8656-4dc8-b8a7-f59bf4fd8692.png)



# Readiness checklist

- [X] Cypress tests passing?
- [X] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
