### PR TITLE
[Agenda] Set a default height if wrapper element does not set a height

### DIFF
--- a/components/agenda/src/Agenda.svelte
+++ b/components/agenda/src/Agenda.svelte
@@ -101,6 +101,10 @@
   onMount(async () => {
     await tick();
     clientHeight = agendaElement?.getBoundingClientRect().height;
+    if (clientHeight === 0) {
+      agendaElement.style.height = "300px";
+    }
+
     manifest = ((await $ManifestStore[
       JSON.stringify({ component_id: id, access_token })
     ]) || {}) as AgendaProperties;
@@ -559,7 +563,7 @@
     return (minutesInDayBeforeNow / minutesInVisibleDay) * 100;
   };
 
-  let agendaElement: Element;
+  let agendaElement: HTMLElement;
   let clientHeight: number;
 
   $: condensed = _this.condensed_view || (clientHeight && clientHeight < 500);


### PR DESCRIPTION
# Code changes

- Set a default height if wrapper element does not set a height. I set the default as `30vh`, but open to suggestions

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
