### PR TITLE
prevent duplicate requests for contacts at load

### DIFF
--- a/components/contact-list/src/ContactList.svelte
+++ b/components/contact-list/src/ContactList.svelte
@@ -60,6 +60,7 @@
   let lastNumContactsLoaded = 0;
   let hydratedContacts: HydratedContact[] = [];
   let status: "loading" | "loaded" | "error" = "loading";
+  let hasComponentLoaded = false;
 
   onMount(async () => {
     await tick();
@@ -87,6 +88,8 @@
         setContacts();
       }
     }
+
+    hasComponentLoaded = true;
   });
 
   $: dispatchEvent("manifestLoaded", manifest);
@@ -131,7 +134,12 @@
   $: queryKey = JSON.stringify(query);
 
   $: setHydratedContacts(), contacts, queryKey;
+
   async function setHydratedContacts() {
+    if (!hasComponentLoaded) {
+      return;
+    }
+
     status = "loading";
     if (contacts && Array.isArray(contacts)) {
       hydratedContacts = contacts as HydratedContact[];


### PR DESCRIPTION
# Code changes
- Remove duplicate calls/logic to setContacts by adding hasComponentLoaded and checking before running setHydratedContacts.


Fixes #sc-75122 https://app.shortcut.com/nylas/story/75122/contact-list-property-inconsistencies
Before: https://www.loom.com/share/5c40515734194e4bb3036119bafc55b6
~~After: https://www.loom.com/i/0924e0c9339147789a3e467fb15be54e~~
After: https://www.loom.com/share/7304c8742c064e20a9fe7b5d429fb5aa


**Note**
1. Tests for switching between passed data, and Nylas data has to be refactored. 
Proof that the ContactList component does actually respond correctly to that case is in the loom video posted above.
2. Found a bug when changing the contacts_to_load value, the component does not respond to those changes
      - Fix for this is not included in the PR 


# Readiness checklist
- [] New property added? make sure to update `component/src/properties.json`
- [] Cypress tests passing?
- [] New cypress tests added?
- [] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
