### PR TITLE
[Mailbox][Bug-fix]: Fix for read status persisting after reading a thread and clicking refresh

### DIFF
--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -191,13 +191,13 @@ describe("availability component", () => {
           const component = element[0];
           component.calendars = calendars;
           cy.get(
-            `.slot[data-start-time='${new Date().toLocaleDateString()}, 6:30:00 a.m.']`,
+            `.slot[data-start-time='${new Date().toLocaleDateString()}, 6:30:00 AM']`,
           )
             .should("have.class", "partial")
             .then(() => {
               component.required_participants = [calendars[1].emailAddress];
               cy.get(
-                `.slot[data-start-time='${new Date().toLocaleDateString()}, 6:30:00 a.m.']`,
+                `.slot[data-start-time='${new Date().toLocaleDateString()}, 6:30:00 AM']`,
               ).should("have.class", "busy");
             });
         });

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -250,10 +250,9 @@
 
     dispatchEvent("threadClicked", { event, thread });
     currentlySelectedThread = thread;
-    thread.unread = false;
-
     if (!_this.all_threads && thread?.expanded) {
       if (thread.unread) {
+        thread.unread = false;
         await updateThreadStatus(thread);
       }
       let message = await fetchIndividualMessage(

--- a/components/mailbox/src/init.spec.js
+++ b/components/mailbox/src/init.spec.js
@@ -314,10 +314,13 @@ describe("MailBox  component", () => {
                 .then((totalElem) => {
                   const total = totalElem.text();
                   expect(total).to.equal(pageEnd);
-
+                  const lastPageitems = Number(total) % itemsPerPage;
                   cy.get(component)
                     .find("nylas-email", { timeout: 10000 })
-                    .should("have.length", Number(total) % itemsPerPage);
+                    .should(
+                      "have.length",
+                      lastPageitems === 0 ? itemsPerPage : lastPageitems,
+                    );
                 });
             });
         });


### PR DESCRIPTION
# Code changes

- `thread.unread` was being set to false before checking if `thread.unread=true`

# Readiness checklist

- [X] Cypress tests passing?

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
