### PR TITLE
[availability] loading bar visual regression fix

### DIFF
--- a/components/availability/src/styles/availability.scss
+++ b/components/availability/src/styles/availability.scss
@@ -113,9 +113,9 @@ main {
     &.loading {
       @include progress-bar(
         top,
-        118px,
+        36px,
         left,
-        95px,
+        0,
         var(--blue),
         var(--blue-lighter)
       );
@@ -127,7 +127,7 @@ main {
       }
     }
     &.loading.error {
-      @include progress-bar(top, 118px, left, 95px, var(--red), var(--red));
+      @include progress-bar(top, 36px, left, 0, var(--red), var(--red));
       animation: none;
     }
 


### PR DESCRIPTION
# Code changes

- Fixed visual regression where loading bar was overlapping with the availability component

# Screenshots
## Before
<img width="644" alt="Screen Shot 2021-12-02 at 6 16 46 PM" src="https://user-images.githubusercontent.com/55773810/144518151-717bee8b-f37e-441a-9ff5-632069cef7e7.png">

## After
<img width="636" alt="Screen Shot 2021-12-02 at 6 16 00 PM" src="https://user-images.githubusercontent.com/55773810/144518154-46e33abe-2daa-4993-b83c-c374be557f65.png">
# Readiness checklist

- [] New property added? make sure to update `component/src/properties.json`
- [] Cypress tests passing?
- [] New cypress tests added?
- [] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
