### PR TITLE
Bugfix: Agenda auto_time_box not updating when events update

### DIFF
--- a/.github/workflows/build-test-publish.yaml
+++ b/.github/workflows/build-test-publish.yaml
@@ -10,6 +10,7 @@ on:
 env:
   API_GATEWAY: "web-components.nylas.com/middleware"
   CYPRESS_RECORD_KEY: ${{secrets.CYPRESS_RECORD_KEY}}
+  TZ: "America/Toronto"
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/components/agenda/CHANGELOG.md
+++ b/components/agenda/CHANGELOG.md
@@ -5,3 +5,5 @@
 ## New Features
 
 ## Bug Fixes
+
+- [Agenda] Ensure that the `auto_time_box` property updates when events update [#243](https://github.com/nylas/components/pull/243)

--- a/components/agenda/src/Agenda.svelte
+++ b/components/agenda/src/Agenda.svelte
@@ -356,19 +356,6 @@
     })
     .sort((a, b) => a.when.start_time - b.when.start_time);
 
-  // Adjust start/end minute (zoom) events are loaded
-  $: {
-    startMinute =
-      _this.auto_time_box && timespanEvents?.length
-        ? getDynamicStartTime(timespanEvents[0])
-        : _this.start_minute;
-
-    endMinute =
-      _this.auto_time_box && timespanEvents?.length
-        ? getDynamicEndTime(timespanEvents[timespanEvents.length - 1])
-        : _this.end_minute;
-  }
-
   // Only fired if no events prop was passed in
   $: if (!_this.events) {
     dispatchEvent("eventsLoaded", calendarEvents);
@@ -624,6 +611,19 @@
       }
     }
   };
+
+  // Adjust start/end minute (zoom) events are loaded
+  $: {
+    startMinute =
+      _this.auto_time_box && timespanEvents?.length
+        ? getDynamicStartTime(timespanEvents[0])
+        : _this.start_minute;
+
+    endMinute =
+      _this.auto_time_box && timespanEvents?.length
+        ? getDynamicEndTime(timespanEvents[timespanEvents.length - 1])
+        : _this.end_minute;
+  }
 
   // #endregion position and zoom
 

--- a/components/agenda/src/Agenda.svelte
+++ b/components/agenda/src/Agenda.svelte
@@ -174,17 +174,6 @@
       new Date().toLocaleDateString() != selectedDate.toLocaleDateString();
 
     allowedDates = getAllowedDates();
-
-    startMinute =
-      _this.auto_time_box && timespanEvents?.length
-        ? getDynamicStartTime(timespanEvents[0])
-        : _this.start_minute;
-
-    endMinute =
-      _this.auto_time_box && timespanEvents?.length
-        ? getDynamicEndTime(timespanEvents[timespanEvents.length - 1])
-        : _this.end_minute;
-
     calendarIDs = setCalendarIDs();
   }
 
@@ -366,6 +355,19 @@
       return event;
     })
     .sort((a, b) => a.when.start_time - b.when.start_time);
+
+  // Adjust start/end minute (zoom) events are loaded
+  $: {
+    startMinute =
+      _this.auto_time_box && timespanEvents?.length
+        ? getDynamicStartTime(timespanEvents[0])
+        : _this.start_minute;
+
+    endMinute =
+      _this.auto_time_box && timespanEvents?.length
+        ? getDynamicEndTime(timespanEvents[timespanEvents.length - 1])
+        : _this.end_minute;
+  }
 
   // Only fired if no events prop was passed in
   $: if (!_this.events) {

--- a/components/agenda/src/init.spec.js
+++ b/components/agenda/src/init.spec.js
@@ -170,6 +170,7 @@ describe("Timeboxing", () => {
       // 10/4 = 2.5.
       // We thus expect the "concealed before" viewport to be 250% of our active view,
       // in otherwords, a top of -250% (or, against our viewport, -1760px)
+      // (viewport height: 800px; .ticks container: 704px. 704 x 2.5 = 1760)
       cy.get(".ticks").get(".tick:eq(0)").should("have.css", "top", "-1760px");
     });
   });

--- a/components/agenda/src/init.spec.js
+++ b/components/agenda/src/init.spec.js
@@ -143,7 +143,7 @@ describe("Custom data", () => {
   });
 });
 
-describe.only("Timeboxing", () => {
+describe("Timeboxing", () => {
   it("scales midnight to midnight by default", () => {
     cy.visit("/components/agenda/src/index.html");
     cy.get("nylas-agenda").should("exist");
@@ -171,6 +171,31 @@ describe.only("Timeboxing", () => {
       // We thus expect the "concealed before" viewport to be 250% of our active view,
       // in otherwords, a top of -250% (or, against our viewport, -1760px)
       cy.get(".ticks").get(".tick:eq(0)").should("have.css", "top", "-1760px");
+    });
+  });
+  it("updates auto_time_box view when events are updated externally", () => {
+    cy.visit("/components/agenda/src/index.html");
+    cy.get("nylas-agenda").then((element) => {
+      const agenda = element[0];
+      agenda.events = AGENDA_EVENTS;
+      agenda.auto_time_box = true;
+      cy.get(".ticks")
+        .get(".tick:eq(0)")
+        .should("have.css", "top", "-1760px")
+        .then(() => {
+          agenda.events = [
+            ...AGENDA_EVENTS.map((slot, i) => {
+              if (i === 0) {
+                slot.when.start_time = 1600444800; // 12:00
+                slot.when.end_time = 1600446600; // 12:30
+              }
+              return slot;
+            }),
+          ];
+          cy.get(".ticks")
+            .get(".tick:eq(0)")
+            .should("have.css", "top", "-4224px");
+        });
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "release:stable": "lerna version --no-private",
     "postrelease:stable": "DATE=`date '+release/%Y%m%d%H%M%S'` && git tag $DATE && git push origin $DATE",
     "start": "concurrently \"live-server . --host=0.0.0.0 --port=8000\" \"yarn dev\"",
-    "start:ci": "sirv . --port 8000 public",
+    "start:ci": "TZ=America/Toronto sirv . --port 8000 public",
     "test": "jest --no-cache --verbose --run-in-band",
     "test-coverage": "yarn test --coverage",
     "tscheck": "lerna run --parallel tscheck",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "scripts": {
     "build": "lerna run --parallel build",
-    "cy:open": "cypress open",
-    "cy:run": "cypress run",
+    "cy:open": "TZ=America/Toronto cypress open",
+    "cy:run": "TZ=America/Toronto cypress run",
     "dev": "lerna run --parallel dev --concurrency 8",
     "dev:scoped": "concurrently \"live-server . --host=localhost --port=8000\" \"lerna run --parallel dev --scope=@nylas/components-{mailbox}\"",
     "lerna": "lerna",


### PR DESCRIPTION
the `auto_time_box` property, that sets the view of a day to be bound to the first and last event of that day, was working only if it was set when `timespanEvents` were established.

If they took longer than the manifest to load, and `auto_time_box` was set, say via external property, before that, the `startMinute` / `endMinute` properties wouldn't update to control the viewbox.

This PR adds a reactive binding to ensure it updates whenever auto_time_box, start_minute, end_minute, or timeSpanEvents are updated.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
