### PR TITLE
Agenda: Set default color_by to event to match our dashboard-created defaults

### DIFF
--- a/components/agenda/src/Agenda.svelte
+++ b/components/agenda/src/Agenda.svelte
@@ -78,7 +78,7 @@
     auto_time_box: false,
     calendar_id: "",
     calendar_ids: "",
-    color_by: "calendar",
+    color_by: "event",
     condensed_view: false,
     eagerly_fetch_events: true,
     end_minute: 1440,

--- a/components/agenda/src/properties.json
+++ b/components/agenda/src/properties.json
@@ -51,7 +51,7 @@
     "title": "Color items by",
     "type": "string",
     "options": ["calendar", "event"],
-    "value": "calendar"
+    "value": "event"
   },
   {
     "label": "hide_all_day_events",


### PR DESCRIPTION
Sets the default `color_by` property for `<nylas-agenda>` to `event`, rather than `calendar`.

(Calendar is used as a color differentiator in situations where you're passing multiple peoples' calendars to the agenda component, which is a minority of use-cases)

Update to our documentation forthcoming.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
