### PR TITLE
[chore] add changelogs for each component

### DIFF
--- a/components/agenda/CHANGELOG.md
+++ b/components/agenda/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Pending Changes
+
+## Breaking
+
+## New Features
+
+## Bug Fixes

--- a/components/availability/CHANGELOG.md
+++ b/components/availability/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Pending Changes
+
+## Breaking
+
+## New Features
+
+## Bug Fixes

--- a/components/composer/CHANGELOG.md
+++ b/components/composer/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Pending Changes
+
+## Breaking
+
+## New Features
+
+## Bug Fixes

--- a/components/contact-list/CHANGELOG.md
+++ b/components/contact-list/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Pending Changes
+
+## Breaking
+
+## New Features
+
+## Bug Fixes

--- a/components/conversation/CHANGELOG.md
+++ b/components/conversation/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Pending Changes
+
+## Breaking
+
+## New Features
+
+## Bug Fixes

--- a/components/email/CHANGELOG.md
+++ b/components/email/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Pending Changes
+
+## Breaking
+
+## New Features
+
+## Bug Fixes

--- a/components/mailbox/CHANGELOG.md
+++ b/components/mailbox/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Pending Changes
+
+## Breaking
+
+## New Features
+
+## Bug Fixes

--- a/components/schedule-editor/CHANGELOG.md
+++ b/components/schedule-editor/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Pending Changes
+
+## Breaking
+
+## New Features
+
+## Bug Fixes

--- a/components/scheduler/CHANGELOG.md
+++ b/components/scheduler/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Pending Changes
+
+## Breaking
+
+## New Features
+
+## Bug Fixes

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -4,6 +4,7 @@
 
 # Readiness checklist
 
+- [] Added changes to component `CHANGELOG.md`
 - [] New property added? make sure to update `component/src/properties.json`
 - [] Cypress tests passing?
 - [] New cypress tests added?


### PR DESCRIPTION
When any changes are made to a component, describe the change with PR reference under the appropriate category (Breaking changes indicates major version upgrade, new features indicates minor version upgrade, and bugfixes indicates patch version upgrade).

When a release is made, it should be paired with moving the changes from `# Pending Changes` to the version it will be upgraded to. Example below:

**Before release:**
```
# Pending Changes

## Breaking

## New Features
- new feature #123

## Bug Fixes

```

**After release:**
```
# Pending Changes

## Breaking

## New Features

## Bug Fixes

# v1.1.0

## Breaking

## New Features
- new feature #123

## Bug Fixes

```

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
