### PR TITLE
Update Composer file size error 

### DIFF
--- a/commons/src/types/Composer.ts
+++ b/commons/src/types/Composer.ts
@@ -65,6 +65,7 @@ export interface Attachment {
   object?: string;
   loading?: boolean;
   error?: boolean;
+  errorMessage?: string;
 }
 
 export interface AttachmentUpdate {
@@ -76,6 +77,7 @@ export interface AttachmentUpdate {
   object?: string;
   loading?: boolean;
   error?: boolean;
+  errorMessage?: string;
 }
 
 export interface SendCallback {

--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -226,7 +226,7 @@
       fileSelector.value = "";
       if (beforeFileUpload) beforeFileUpload(file);
 
-      if (file.size >= 5000000) {
+      if (file.size >= 4000000) {
         throw "Error: File size is too large.";
       }
 

--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -209,8 +209,8 @@
     showDatepicker = false;
   };
 
-  async function handleFilesChange(fileChanged: any) {
-    const fileSelector = fileChanged.target;
+  async function handleFilesChange(fileChangedEvent: Event) {
+    const fileSelector = fileChangedEvent.target as HTMLInputElement;
     if (!fileSelector?.files) return;
 
     const file = fileSelector.files[0];

--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -513,6 +513,14 @@
       background: var(--composer-background-muted-color, #f0f2ff);
     }
   }
+  .composer-btn.file-upload {
+    margin-right: 10px;
+    width: 32px;
+    height: 32px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
 
   .cc-btn {
     position: absolute;
@@ -582,9 +590,6 @@
   }
   .MinimizeIcon {
     transform: translateY(4px);
-  }
-  .AttachmentIcon {
-    margin-right: 15px;
   }
 </style>
 
@@ -775,14 +780,10 @@
       </main>
       <footer>
         {#if _this.show_attachment_button && (id || uploadFile)}
-          <button
-            class="composer-btn file-upload"
-            style="margin-right: 10px; width: 32px; height: 32px;"
-            on:click={() => fileSelector.click()}
-          >
-            <span class="sr-only">Attach Files</span>
+          <label for="file-upload" class="composer-btn file-upload">
             <AttachmentIcon class="AttachmentIcon" />
-          </button>
+            <span class="sr-only">Attach Files</span>
+          </label>
         {/if}
         <div class="btn-group">
           <button class="send-btn" on:click={handleSend} disabled={!isSendable}>
@@ -796,7 +797,7 @@
             type="file"
             name=""
             bind:this={fileSelector}
-            id=""
+            id="file-upload"
             on:change={handleFilesChange}
           />
         </form>

--- a/components/composer/src/components/Attachment.svelte
+++ b/components/composer/src/components/Attachment.svelte
@@ -40,8 +40,6 @@
     cursor: pointer;
     margin-left: 10px;
     flex-shrink: 0;
-    max-height: 10px;
-    max-width: 10px;
   }
 
   .file-info {
@@ -104,9 +102,13 @@
           />
         {/if}
         {#if attachment.error}
-          <span class="file-info__error"
-            >Error: Please try attaching the file again.</span
-          >
+          {#if attachment.errorMessage}
+            <span class="file-info__error">{attachment.errorMessage}</span>
+          {:else}
+            <span class="file-info__error"
+              >Error: Please try attaching the file again.</span
+            >
+          {/if}
         {/if}
         {#if !attachment.loading}
           <button class="close-btn" on:click={() => remove(attachment)}>

--- a/components/composer/src/components/Attachment.svelte
+++ b/components/composer/src/components/Attachment.svelte
@@ -102,13 +102,10 @@
           />
         {/if}
         {#if attachment.error}
-          {#if attachment.errorMessage}
-            <span class="file-info__error">{attachment.errorMessage}</span>
-          {:else}
-            <span class="file-info__error"
-              >Error: Please try attaching the file again.</span
-            >
-          {/if}
+          <span class="file-info__error">
+            {attachment.errorMessage ??
+              "Error: Please try attaching the file again."}
+          </span>
         {/if}
         {#if !attachment.loading}
           <button class="close-btn" on:click={() => remove(attachment)}>

--- a/components/composer/src/index.html
+++ b/components/composer/src/index.html
@@ -62,15 +62,6 @@
   </head>
 
   <body>
-    <nylas-composer
-      id="demo-composer"
-      theme="dark"
-      template="Hey what up!<br/>
-      <br/>
-      <br/>
-      Thanks,
-      -Phil"
-    >
-    </nylas-composer>
+    <nylas-composer id="demo-composer" theme="dark"> </nylas-composer>
   </body>
 </html>


### PR DESCRIPTION
# Background 
Our lamba's cannot accept file size larger than 5MB, so this causes an unconventional error in Composer. Handled this inside the Component since it cannot be handled in lambdas

# Code changes
- [x] added error flow for large files
- [x] simplified attachment onclick + tweaked ui 
- [x] added attachmentError to surface attachment errors to users
- [x] removed template from html cause I think it wasn't working

# Readiness checklist
- [ ] Added changes to component `CHANGELOG.md`
- [ ] New property added? make sure to update `component/src/properties.json`
- [ ] Cypress tests passing?
- [ ] New cypress tests added?
- [ ] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
