### PR TITLE
[email] Fixed email prop inconsistencies

### DIFF
--- a/components/conversation/src/test-data.js
+++ b/components/conversation/src/test-data.js
@@ -17,7 +17,7 @@ export const mockedMessages = [
     object: "message",
     reply_to: [],
     snippet:
-      "Hey there, Welcome to Nylas! Glad to have you onboard Aaron D'Mello Sr. Software Engineer, Nylas aaron.d@nylas.com +1(647)220-5567",
+      "Hey there, Welcome to Nylas! Glad to have you onboard Aaron D'Mello Sr. Software Engineer, Nylas",
     starred: false,
     subject: "Welcome to Nylas",
     thread_id: "dclpsfd1i46mukv77b8y0qe4s",
@@ -82,7 +82,7 @@ export const mockedMessages = [
     object: "message",
     reply_to: [],
     snippet:
-      "That is awesome! Let’s chat soon regarding your first project. Aaron D'Mello Sr. Software Engineer, Nylas aaron.d@nylas.com +1(647)220-5567 On Aug 16, 2021, at 9:23 PM, Jack Smith",
+      "That is awesome! Let’s chat soon regarding your first project. Aaron D'Mello Sr. Software Engineer, Nylas aaron.d@nylas.com On Aug 16, 2021, at 9:23 PM, Jack Smith",
     starred: false,
     subject: "Re: Welcome to Nylas",
     thread_id: "dclpsfd1i46mukv77b8y0qe4s",
@@ -112,7 +112,7 @@ export const mockedMessages = [
     object: "message",
     reply_to: [],
     snippet:
-      "Sounds great! Looking forward to it. Aaron D'Mello Sr. Software Engineer, Nylas aaron.d@nylas.com +1(647)220-5567 On Aug 16, 2021, at 9:23 PM, Aaron D'Mello <aaron.d@nylas.com> wrote: That is",
+      "Sounds great! Looking forward to it. Aaron D'Mello Sr. Software Engineer, Nylas aaron.d@nylas.com On Aug 16, 2021, at 9:23 PM, Aaron D'Mello <aaron.d@nylas.com> wrote: That is",
     starred: false,
     subject: "Re: Welcome to Nylas",
     thread_id: "dclpsfd1i46mukv77b8y0qe4s",

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -172,7 +172,6 @@
 
   //#region methods
   function fetchIndividualMessage(message: Message) {
-    // messageLoadStatus[msgIndex] = "loading";
     return fetchMessage(query, message.id).then((json) => {
       message.body = json.body;
       return message;


### PR DESCRIPTION
# Code changes

- Fixed `show_received_timestamp` not affecting displayed timestamp in certain cases
- Fixed expanding/collapsing a thread before it is loaded causing the thread to collapse/expand back
- Fixed `show_number_of_messages` not being visible because the element's default colour was the same as the background
- Increased size of action button icons to be easier to click
- Fixed infinite loop caused by setting `clean_conversation="true"`
- Fixed `show_thread_actions` not affecting displayed actions in certain cases


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
