### PR TITLE
[Mailbox][bug-fix]: FIxed pagination offsetting by 1 email instead of page size

### DIFF
--- a/commons/src/connections/threads.ts
+++ b/commons/src/connections/threads.ts
@@ -14,8 +14,8 @@ import type {
 
 export const fetchThreads = (
   query: MailboxQuery,
-  offset: number,
   limit: number,
+  offset: number,
 ): Promise<Thread[]> => {
   let queryString = `${getMiddlewareApiUrl(
     query.component_id,

--- a/commons/src/store/mailbox.ts
+++ b/commons/src/store/mailbox.ts
@@ -69,9 +69,11 @@ function initializeThreads() {
       if (typeof threadsMap[queryKey][currentPage] === "undefined") {
         return [];
       } else if (!threadsMap[queryKey][currentPage].isLoaded) {
-        const threads = await fetchThreads(query, currentPage, pageSize).catch(
-          silence,
-        );
+        const threads = await fetchThreads(
+          query,
+          pageSize,
+          currentPage * pageSize,
+        ).catch(silence);
 
         if (threads) {
           threadsMap[queryKey][currentPage].threads = threads;


### PR DESCRIPTION
# Code changes

- There is currently a regression which is causing breaking pagination. Clicking on next page offsets by 1 email instead of the page size. This PR fixes that

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
