### PR TITLE
[Conversation][Bug-fix]: FIxed all accounts component id errors out when clicking send

### DIFF
--- a/components/conversation/src/Conversation.svelte
+++ b/components/conversation/src/Conversation.svelte
@@ -291,15 +291,19 @@
       if (!conversation) {
         return;
       }
-      sendMessage(id, {
-        from: reply.from,
-        to: reply.to,
-        body: `${replyBody} <br /><br /> --Sent with Nylas`,
-        subject: conversation.subject,
-        cc: reply.cc,
-        reply_to_message_id: lastMessage.id,
-        bcc: [],
-      }).then((res) => {
+      sendMessage(
+        id,
+        {
+          from: reply.from,
+          to: reply.to,
+          body: `${replyBody} <br /><br /> --Sent with Nylas`,
+          subject: conversation.subject,
+          cc: reply.cc,
+          reply_to_message_id: lastMessage.id,
+          bcc: [],
+        },
+        access_token,
+      ).then((res) => {
         const conversationQuery = { queryKey: queryKey, data: res };
         ConversationStore.addMessageToThread(conversationQuery);
         replyStatus = "";


### PR DESCRIPTION
- Added access_token argument to sendMessage request.

[Shortcut story](https://app.shortcut.com/nylas/story/75147/conversation-component-send-doesn-t-work-using-all-accounts)

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
