### PR TITLE
[devops] remove duplicate publish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "new-component": "node ./scripts/new.js",
     "postinstall": "husky install",
     "prepublishOnly": "yarn run build",
-    "publish": "lerna publish",
     "release:canary": "lerna version prerelease --no-private -m 'pre-release' --yes",
     "postrelease:canary": "DATE=`date '+prerelease/%Y%m%d%H%M%S'` && git tag $DATE && git push origin $DATE",
     "release:stable": "lerna version --no-private",


### PR DESCRIPTION
# Code changes

- `lerna publish` seems to run any `npm script` under the same name, removing this will hopefully remove the errors in Github Actions after packages are successfully released - [Reference](https://github.com/lerna/lerna/issues/2249#issuecomment-539256185)

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
