### PR TITLE
[Email|Mailbox]: Restrcit certain content types that should not be shown as attachments

### DIFF
--- a/commons/src/components/MessageBody.svelte
+++ b/commons/src/components/MessageBody.svelte
@@ -7,6 +7,7 @@
   import * as DOMPurify from "dompurify";
   import { getEventDispatcher } from "@commons/methods/component";
   import { get_current_component, onMount } from "svelte/internal";
+  import { DisallowedContentTypes } from "@commons/constants/attachment-content-types";
 
   export let message;
   export let body;
@@ -27,7 +28,10 @@
   onMount(() => {
     if (message && message.files.length > 0) {
       for (const [fileIndex, file] of message.files.entries()) {
-        if (file.content_disposition === "attachment") {
+        if (
+          file.content_disposition === "attachment" &&
+          !DisallowedContentTypes.includes(file.content_type)
+        ) {
           attachedFiles.push(message.files[fileIndex]);
         }
       }

--- a/commons/src/constants/attachment-content-types.ts
+++ b/commons/src/constants/attachment-content-types.ts
@@ -1,0 +1,5 @@
+export const DisallowedContentTypes = [
+  "message/delivery-status",
+  "message/rfc822",
+  "text/calendar",
+];

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -48,6 +48,7 @@
   import * as DOMPurify from "dompurify";
   import LoadingIcon from "./assets/loading.svg";
   import { downloadFile } from "@commons/connections/files";
+  import { DisallowedContentTypes } from "@commons/constants/attachment-content-types";
 
   const dispatchEvent = getEventDispatcher(get_current_component());
   $: dispatchEvent("manifestLoaded", manifest);
@@ -670,7 +671,10 @@
     attachedFiles = activeThread.messages.reduce(
       (files: Record<string, File[]>, message) => {
         for (const [fileIndex, file] of message.files.entries()) {
-          if (file.content_disposition === "attachment") {
+          if (
+            file.content_disposition === "attachment" &&
+            !DisallowedContentTypes.includes(file.content_type)
+          ) {
             if (!files[message.id]) {
               files[message.id] = [];
             }


### PR DESCRIPTION
# Code changes

- Added an additional check to exclude attachments that have content-type as `message/delivery-status , message/rfc822 or text/calendar`

# Screenshot:
## Before
![image](https://user-images.githubusercontent.com/16315004/145480662-afcd0d69-a1ca-4680-b279-575b3665d329.png)


## After
![image](https://user-images.githubusercontent.com/16315004/145480538-064cbc8d-6165-4532-a627-7254d60776af.png)


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
