### PR TITLE
[agenda] zoom in with cmd/ctrl + scroll, scroll down enabled, reduce …

### DIFF
--- a/components/agenda/CHANGELOG.md
+++ b/components/agenda/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## New Features
 
+- [Agenda] Zoom in with `cmd`/`ctrl` + `scroll`, allow scroll up and down, reduce max zoom out so 15 min meetings remain visible [#]()
+
 ## Bug Fixes
 
 - [Agenda] Ensure that the `auto_time_box` property updates when events update [#243](https://github.com/nylas/components/pull/243)

--- a/components/agenda/src/Agenda.svelte
+++ b/components/agenda/src/Agenda.svelte
@@ -81,7 +81,7 @@
     color_by: "event",
     condensed_view: false,
     eagerly_fetch_events: true,
-    end_minute: 1440,
+    end_minute: 1000,
     event_snap_interval: 15,
     header_type: "full",
     hide_all_day_events: false,
@@ -568,14 +568,19 @@
     setTimeout(() => {
       scrolling = false;
     }, 500);
+
+    // Only allow zooming in when meta or ctrl key is pressed while scrolling
+    if (!event.metaKey && !event.ctrlKey) {
+      return;
+    }
+
     event.preventDefault();
     const canvas = agendaElement.getBoundingClientRect();
     const mouseYPosition = event.clientY - canvas.top;
     let velocity = Math.abs(event.deltaY) / 10;
 
-    // ctrlKey = Pinch-to-zoom
-    if (event.ctrlKey) {
-      event.preventDefault();
+    // Pinch-to-zoom
+    if (event.ctrlKey || event.metaKey) {
       velocity *= 20;
     }
 
@@ -589,11 +594,12 @@
       (canvas.height - mouseYPosition) / canvas.height,
     ];
 
+    const max = 1000;
     if (direction === "out") {
-      if (endMinute <= 1440 && endMinute + velocity <= 1440) {
+      if (endMinute <= max && endMinute + velocity <= max) {
         endMinute += velocity;
       } else {
-        endMinute = 1440;
+        endMinute = max;
       }
       if (startMinute >= 0 && startMinute - velocity >= 0) {
         startMinute -= velocity;
@@ -1065,7 +1071,7 @@
     display: grid;
     grid-column: 1/3;
     grid-template-columns: 40px 1fr;
-    overflow: hidden;
+    overflow-x: hidden;
     line-height: 100%;
 
     &.hide-ticks {
@@ -1223,7 +1229,7 @@
     color: var(--mainTextAndDeclinedEvents);
     font-size: 12px;
     position: relative;
-    overflow: hidden;
+    overflow-y: visible;
     .tick {
       position: absolute;
       width: 100%;

--- a/components/composer/src/init.spec.js
+++ b/components/composer/src/init.spec.js
@@ -96,7 +96,7 @@ describe("Composer dispatches events", () => {
   });
 });
 
-describe.only("Composer `to` prop", () => {
+describe("Composer `to` prop", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",

--- a/tests/agenda/agenda.spec.ts
+++ b/tests/agenda/agenda.spec.ts
@@ -144,11 +144,12 @@ describe("Agenda Props", () => {
       const initialZoomLevel = zoomableEvent.getAttribute("style");
 
       // Zooming in shouldn't work, because we are at max zoom by default
-      await fireEvent.wheel(zoomableEvent, { deltaY: 5 });
-      expect(initialZoomLevel).toBe(zoomableEvent.getAttribute("style"));
+      await fireEvent.wheel(zoomableEvent, { deltaY: 5, metaKey: true });
+      const afterZoomLevel = zoomableEvent.getAttribute("style");
+      expect(initialZoomLevel).toBe(afterZoomLevel);
 
       // Zooming out should still work
-      await fireEvent.wheel(zoomableEvent, { deltaY: -5 });
+      await fireEvent.wheel(zoomableEvent, { deltaY: -5, metaKey: true });
       expect(initialZoomLevel).not.toBe(zoomableEvent.getAttribute("style"));
       done();
     });
@@ -164,12 +165,12 @@ describe("Agenda Props", () => {
       const zoomableEvent = agenda.querySelector(".event") as Element;
       const initialZoomLevel = zoomableEvent.getAttribute("style");
 
-      await fireEvent.wheel(zoomableEvent, { deltaY: -5 });
+      await fireEvent.wheel(zoomableEvent, { deltaY: -5, metaKey: true });
       expect(initialZoomLevel).toBe(zoomableEvent.getAttribute("style"));
 
       component.prevent_zoom = false;
 
-      await fireEvent.wheel(zoomableEvent, { deltaY: -5 });
+      await fireEvent.wheel(zoomableEvent, { deltaY: -5, metaKey: true });
       expect(initialZoomLevel).not.toBe(zoomableEvent.getAttribute("style"));
       done();
     });
@@ -185,12 +186,12 @@ describe("Agenda Props", () => {
       const zoomableEvent = agenda.querySelector(".event") as Element;
       const initialZoomLevel = zoomableEvent.getAttribute("style");
 
-      await fireEvent.wheel(zoomableEvent, { deltaY: -5 });
+      await fireEvent.wheel(zoomableEvent, { deltaY: -5, metaKey: true });
       expect(initialZoomLevel).toBe(zoomableEvent.getAttribute("style"));
 
       component.condensed_view = false;
 
-      await fireEvent.wheel(zoomableEvent, { deltaY: -5 });
+      await fireEvent.wheel(zoomableEvent, { deltaY: -5, metaKey: true });
       expect(initialZoomLevel).not.toBe(zoomableEvent.getAttribute("style"));
       done();
     });


### PR DESCRIPTION
…max zoom out for 15 min meeting visibility

# Code changes

- [x] changes zoom in/out from `scroll` only to `cmd`/`ctrl` + `scroll` so that `scroll` can navigate up and down the page
- [x] change max zoom out so that 15 minute meeting text is always visible 

# Screenshots

https://user-images.githubusercontent.com/34139730/145624618-2f2bf1a7-4f71-4e14-a42c-f8f9195ba7f2.mov

# Readiness checklist

- [x] Added changes to component `CHANGELOG.md`
- [x] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
