### PR TITLE
[contact-list] Fixed contacts_to_load prop manifest value being ignored

### DIFF
--- a/components/contact-list/src/ContactList.svelte
+++ b/components/contact-list/src/ContactList.svelte
@@ -116,7 +116,7 @@
   }
 
   // sanitization to conform with Nylas API maximums
-  $: {
+  $: if (hasComponentLoaded) {
     _this.contacts_to_load = Math.max(
       Math.min(_this.contacts_to_load, 1000),
       1,


### PR DESCRIPTION
# Code changes

Ensure `contacts_to_load` doesn't have a value assigned before manifest is loaded.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
