### PR TITLE
[mailbox] Fixed show_thread_checkbox prop being set to false causing alignment issues

### DIFF
--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -875,7 +875,7 @@
           .attachment {
             gap: 1rem;
             display: flex;
-            overflow-x: scroll;
+            overflow-x: auto;
 
             button {
               height: fit-content;
@@ -1032,7 +1032,7 @@
             flex-direction: column;
             width: 100%;
             div.attachment {
-              overflow-x: scroll;
+              overflow-x: auto;
               button {
                 margin: $spacing-xs;
                 height: fit-content;
@@ -1253,15 +1253,9 @@
               overflow: hidden;
               white-space: nowrap;
               position: relative;
+              text-overflow: ellipsis;
               .from-sub-section.second {
                 display: inline-block;
-              }
-              &.condensed::after {
-                content: ".";
-                position: absolute;
-                bottom: 0;
-                right: 0;
-                background: var(--nylas-email-body-background, var(--white));
               }
             }
             .participants-count {
@@ -1384,7 +1378,7 @@
           .attachment {
             gap: 1rem;
             display: flex;
-            overflow-x: scroll;
+            overflow-x: auto;
 
             button {
               padding: 0.3rem 1rem;

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -533,6 +533,8 @@
 
     // Toggle select-all checkbox and thread checkbox from CSS Var
     .thread-checkbox {
+      margin-right: 1rem;
+
       input {
         @include checkbox;
         &:disabled {
@@ -681,6 +683,7 @@
           thread={currentlySelectedThread}
           {you}
           show_star={_this.show_star}
+          show_thread_actions={true}
           click_action="mailbox"
           on:messageClicked={messageClicked}
           on:threadStarred={threadStarred}
@@ -787,8 +790,8 @@
                 thread?.messages &&
                 thread?.messages?.length <= 0}
             >
-              {#if _this.show_thread_checkbox}
-                <div class="checkbox-container thread-checkbox">
+              <div class="checkbox-container thread-checkbox">
+                {#if _this.show_thread_checkbox}
                   <input
                     title={selectTitle}
                     aria-label={selectTitle}
@@ -799,8 +802,8 @@
                       thread?.messages?.length <= 0}
                     on:click={(e) => onSelectOne(e, thread)}
                   />
-                </div>
-              {/if}
+                {/if}
+              </div>
               <div class="email-container">
                 {#key thread.id}
                   <nylas-email


### PR DESCRIPTION
# Code changes

- Fixed `show_thread_checkbox="false"` causing alignment issues
- Fixed missing margin when `show_thread_checkbox="false"`
- Minor styling tweaks

## Before
<img width="1775" alt="Screen Shot 2021-12-14 at 11 33 56 AM" src="https://user-images.githubusercontent.com/8049234/146039864-0fb7145e-6ddc-4dc9-b783-dedc0ee9a452.png">


## After
<img width="1777" alt="Screen Shot 2021-12-14 at 11 34 18 AM" src="https://user-images.githubusercontent.com/8049234/146039872-f012da41-9545-412a-b052-2c296c48a4a0.png">


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
