### PR TITLE
Consistent noreply color

### DIFF
--- a/components/agenda/src/Agenda.svelte
+++ b/components/agenda/src/Agenda.svelte
@@ -1152,8 +1152,9 @@
       }
 
       &.status-noreply {
-        background-color: var(--emptyEventBackground) !important;
-        color: var(--secondaryCalendar) !important;
+        background-color: #ccc !important;
+        color: #444 !important;
+
         a {
           color: var(--secondaryCalendar) !important;
         }

--- a/components/agenda/src/Agenda.svelte
+++ b/components/agenda/src/Agenda.svelte
@@ -1132,7 +1132,7 @@
       }
 
       &.status-maybe {
-        background-color: var(--emptyEventBackground) !important;
+        background-color: var(--emptyEventBackground, #ddd) !important;
         border-left-width: 7px;
         color: var(--secondaryCalendar) !important;
 
@@ -1152,8 +1152,8 @@
       }
 
       &.status-noreply {
-        background-color: #ccc !important;
-        color: #444 !important;
+        background-color: var(--emptyEventBackground, #ddd) !important;
+        color: var(--secondaryCalendar, #444) !important;
 
         a {
           color: var(--secondaryCalendar) !important;
@@ -1165,9 +1165,9 @@
           text-decoration: line-through;
         }
 
-        border-color: var(--alertWarningDeclined);
-        color: var(--alertWarningDeclined);
-        background-color: var(--emptyEventBackground) !important;
+        border-color: var(--alertWarningDeclined, #eb8f24);
+        color: var(--alertWarningDeclined, #eb8f24);
+        background-color: var(--emptyEventBackground, #ddd) !important;
 
         a {
           color: var(--secondaryCalendar) !important;


### PR DESCRIPTION
Adding a consistent bg/text color for no-reply events (events that are still waiting on the participant's attendance answer).

Previously this was showing up with no background, so the outline of the event / time wasn't clear.
![image](https://user-images.githubusercontent.com/713991/146040394-1f72fb37-eb1f-483c-8b35-dceb54c9c37c.png)

I played with using mix-blend-mode but shadow DOM doesnt allow blends to traverse pass the shadow barrier. Tried using filter: invert(n); but couldn't find a pairing that worked consistently with both a light and dark background, either.

Ultimately opted for a hardcoded colour pair here to solve the issue: 
![image](https://user-images.githubusercontent.com/713991/146040725-e680c3d0-5cbb-4933-bebb-d13149766a4e.png)


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
