### PR TITLE
[Mailbox/Email][Bug-fix]: Return to mailbox arrow too small

### DIFF
--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -886,7 +886,7 @@
           &:before {
             content: "\2605";
             display: inline-block;
-            font-size: 1em;
+            font-size: 1.1em;
             color: var(--nylas-email-unstarred-star-button-color, #ccc);
             -webkit-user-select: none;
             -moz-user-select: none;
@@ -936,15 +936,16 @@
               background: none;
               display: flex;
               cursor: pointer;
-
-              * {
-                width: 0.7em;
-                height: 0.7em;
-              }
             }
           }
           [role="toolbar"] {
             outline: none;
+            button {
+              * {
+                width: 1em;
+                height: 1em;
+              }
+            }
           }
         }
 


### PR DESCRIPTION
# Code changes

- Fixed the style issue with return to mailbox arrow

# Screenshot

Before:
![image](https://user-images.githubusercontent.com/16315004/146086378-86be798f-fd2d-4c1b-9800-3539d8c95afb.png)

After:
![image](https://user-images.githubusercontent.com/16315004/146086100-42c9a743-0560-4fcc-8b9e-47bf28851c0e.png)

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
