### PR TITLE
[Mailbox]: Remove personal component id and add demo mailbox

### DIFF
--- a/components/mailbox/src/index.html
+++ b/components/mailbox/src/index.html
@@ -28,10 +28,6 @@
   </head>
 
   <body>
-    <nylas-mailbox
-      id="5ccaa739-daa1-4594-821f-34189d539968"
-      header="Mailbox"
-      show_star="true"
-    />
+    <nylas-mailbox id="demo-mailbox" header="Mailbox" show_star="true" />
   </body>
 </html>


### PR DESCRIPTION
# Code changes

- Accidentally pushed my personal component id, replacing it with the demo id

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
