### PR TITLE
[composer] bugfix HTMLEditor getSelection firefox and safari support

### DIFF
--- a/components/composer/CHANGELOG.md
+++ b/components/composer/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Pending Changes
+
+## Breaking Changes
+## New Features
+## Bug Fixes
+
+- [Composer] Fix support for Firefox and Safari browsers. [#279](https://github.com/nylas/components/pull/279)
+
 # v1.1.6 (2021-12-15)
 
 ## New Features

--- a/components/composer/src/components/HTMLEditor.svelte
+++ b/components/composer/src/components/HTMLEditor.svelte
@@ -2,7 +2,6 @@
 
 <script lang="ts">
   import { defaultActions } from "../lib/html-editor";
-  import { get_current_component } from "svelte/internal";
   import type { ReplaceFields, ToolbarItem } from "@commons/types/Composer";
 
   export let onchange = (_html: string) => Promise.resolve({});
@@ -14,7 +13,7 @@
   let toolbar: ToolbarItem[] = defaultActions;
 
   $: if (html) {
-    const selection = get_current_component()?.shadowRoot?.getSelection();
+    const selection = window.getSelection();
 
     if (typeof replace_fields === "string") {
       replace_fields = JSON.parse(replace_fields);


### PR DESCRIPTION
# Code changes

- [x] replace `shadowRoot.getSelection()` with `window.getSelection` in `HTMLEditor` to support firefox and safari.

# Readiness checklist

- [x] Added changes to component `CHANGELOG.md`

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
