### PR TITLE
[mailbox] add `returnToMailbox`  event listener to demo page

### DIFF
--- a/components/mailbox/src/index.html
+++ b/components/mailbox/src/index.html
@@ -11,6 +11,9 @@
       document.addEventListener("DOMContentLoaded", function () {
         const mailbox = document.querySelector("nylas-mailbox");
 
+        mailbox.addEventListener("returnToMailbox", (event) => {
+          console.log("returnToMailbox", event.detail);
+        });
         // enable `header="string"` and click refresh button
         // mailbox.addEventListener("refreshClicked", function (event) {
         //   mailbox.all_threads = [...mailbox.all_threads, thread2];


### PR DESCRIPTION
# Code changes

- adds `returnToMailbox` event listener to demo page

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
