### PR TITLE
[Mailbox][Email]: Fixed inline files being displayed as attachments

### DIFF
--- a/commons/src/components/MessageBody.svelte
+++ b/commons/src/components/MessageBody.svelte
@@ -30,6 +30,7 @@
       for (const [fileIndex, file] of message.files.entries()) {
         if (
           file.content_disposition === "attachment" &&
+          !file.content_id && // treat all files with content_id as inline
           !DisallowedContentTypes.includes(file.content_type)
         ) {
           attachedFiles.push(message.files[fileIndex]);

--- a/commons/src/store/files.ts
+++ b/commons/src/store/files.ts
@@ -17,7 +17,11 @@ function initializeFilesForMessage() {
       if (!filesMap[incomingMessage.id]) {
         const inlineFiles: Record<string, File> = {};
         for (const file of incomingMessage.files.values()) {
-          if (file.content_disposition === "inline" && !inlineFiles[file.id]) {
+          // treat all files with content_id as inline
+          if (
+            (file.content_disposition === "inline" || file.content_id) &&
+            !inlineFiles[file.id]
+          ) {
             inlineFiles[file.id] = file;
             inlineFiles[file.id].data = await downloadFile({
               file_id: file.id,
@@ -36,7 +40,7 @@ function initializeFilesForMessage() {
     },
     hasInlineFiles: (incomingMessage: Message): boolean => {
       return incomingMessage?.files?.some(
-        (file) => file.content_disposition === "inline",
+        (file) => file.content_disposition === "inline" || file.content_id,
       );
     },
     reset: () => set({}),

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -688,6 +688,7 @@
         for (const [fileIndex, file] of message.files.entries()) {
           if (
             file.content_disposition === "attachment" &&
+            !file.content_id && // treat all files with content_id as inline
             !DisallowedContentTypes.includes(file.content_type)
           ) {
             if (!files[message.id]) {


### PR DESCRIPTION
# Code changes

- Added a check to exclude files with `content_id` as attached files
- Added a check to include files with `content_id` as inline files

# Screenshot
## Before:
![image](https://user-images.githubusercontent.com/16315004/146256753-92af96f5-fe86-4642-ac39-efdb63279a26.png)

## After:
![image](https://user-images.githubusercontent.com/16315004/146256688-1a9340ad-de70-44aa-b995-60d3ca1842e9.png)


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
