### PR TITLE
[Email][Mailbox]: Fix for some attachments being treated as inline

### DIFF
--- a/commons/src/components/MessageBody.svelte
+++ b/commons/src/components/MessageBody.svelte
@@ -7,7 +7,10 @@
   import * as DOMPurify from "dompurify";
   import { getEventDispatcher } from "@commons/methods/component";
   import { get_current_component, onMount } from "svelte/internal";
-  import { DisallowedContentTypes } from "@commons/constants/attachment-content-types";
+  import {
+    DisallowedContentTypes,
+    InlineImageTypes,
+  } from "@commons/constants/attachment-content-types";
 
   export let message;
   export let body;
@@ -30,7 +33,7 @@
       for (const [fileIndex, file] of message.files.entries()) {
         if (
           file.content_disposition === "attachment" &&
-          !file.content_id && // treat all files with content_id as inline
+          !(file.content_id && InlineImageTypes.includes(file.content_type)) && // treat all files with content_id as inline
           !DisallowedContentTypes.includes(file.content_type)
         ) {
           attachedFiles.push(message.files[fileIndex]);

--- a/commons/src/constants/attachment-content-types.ts
+++ b/commons/src/constants/attachment-content-types.ts
@@ -3,3 +3,13 @@ export const DisallowedContentTypes = [
   "message/rfc822",
   "text/calendar",
 ];
+
+export const InlineImageTypes = [
+  "image/png",
+  "image/apng",
+  "image/avif",
+  "image/gif",
+  "image/jpeg",
+  "image/svg+xml",
+  "image/webp",
+];

--- a/commons/src/constants/attachment-content-types.ts
+++ b/commons/src/constants/attachment-content-types.ts
@@ -11,5 +11,4 @@ export const InlineImageTypes = [
   "image/gif",
   "image/jpeg",
   "image/svg+xml",
-  "image/webp",
 ];

--- a/commons/src/store/files.ts
+++ b/commons/src/store/files.ts
@@ -1,7 +1,7 @@
 import { writable } from "svelte/store";
 import type { File, Message } from "@commons/types/Nylas";
 import { downloadFile } from "@commons/connections/files";
-
+import { InlineImageTypes } from "@commons/constants/attachment-content-types";
 function initializeFilesForMessage() {
   const { subscribe, set, update } = writable<
     Record<string, Record<string, File>>
@@ -19,7 +19,9 @@ function initializeFilesForMessage() {
         for (const file of incomingMessage.files.values()) {
           // treat all files with content_id as inline
           if (
-            (file.content_disposition === "inline" || file.content_id) &&
+            (file.content_disposition === "inline" ||
+              (file.content_id &&
+                InlineImageTypes.includes(file.content_type))) &&
             !inlineFiles[file.id]
           ) {
             inlineFiles[file.id] = file;
@@ -40,7 +42,9 @@ function initializeFilesForMessage() {
     },
     hasInlineFiles: (incomingMessage: Message): boolean => {
       return incomingMessage?.files?.some(
-        (file) => file.content_disposition === "inline" || file.content_id,
+        (file) =>
+          file.content_disposition === "inline" ||
+          (file.content_id && InlineImageTypes.includes(file.content_type)),
       );
     },
     reset: () => set({}),

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -51,7 +51,10 @@
   import * as DOMPurify from "dompurify";
   import LoadingIcon from "./assets/loading.svg";
   import { downloadFile } from "@commons/connections/files";
-  import { DisallowedContentTypes } from "@commons/constants/attachment-content-types";
+  import {
+    DisallowedContentTypes,
+    InlineImageTypes,
+  } from "@commons/constants/attachment-content-types";
 
   const dispatchEvent = getEventDispatcher(get_current_component());
   $: dispatchEvent("manifestLoaded", manifest);
@@ -688,7 +691,9 @@
         for (const [fileIndex, file] of message.files.entries()) {
           if (
             file.content_disposition === "attachment" &&
-            !file.content_id && // treat all files with content_id as inline
+            !(
+              file.content_id && InlineImageTypes.includes(file.content_type)
+            ) && // treat all files with content_id as inline
             !DisallowedContentTypes.includes(file.content_type)
           ) {
             if (!files[message.id]) {


### PR DESCRIPTION
# Code changes

- Added a check to only treat files with following content types as inline:
```
  "image/png",
  "image/apng",
  "image/avif",
  "image/gif",
  "image/jpeg",
  "image/svg+xml",
```
Treating   "image/webp" as an attachment as per the way it is shown in gmail

This list is based on the support image type formats: https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types

# Readiness checklist

- [ ] Added changes to component `CHANGELOG.md`
- [ ] New property added? make sure to update `component/src/properties.json`
- [ ] Cypress tests passing?
- [ ] New cypress tests added?
- [ ] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
