### PR TITLE
Infra bug: "Rerun all jobs" doesn't appear to kick off new Cypress runs

### DIFF
--- a/.github/workflows/build-test-publish.yaml
+++ b/.github/workflows/build-test-publish.yaml
@@ -27,6 +27,7 @@ jobs:
 
       - name: Print unique ID 🖨`
         run: echo "generated id ${{ steps.uuid.outputs.value }}"
+
   build:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/build-test-publish.yaml
+++ b/.github/workflows/build-test-publish.yaml
@@ -2,7 +2,7 @@ name: Build & Test
 on:
   push:
     branches: [main]
-    tags: 
+    tags:
       - release/*
       - prerelease/*
   pull_request:
@@ -12,6 +12,21 @@ env:
   CYPRESS_RECORD_KEY: ${{secrets.CYPRESS_RECORD_KEY}}
   TZ: "America/Toronto"
 jobs:
+  # single job that generates and outputs a common id
+  prepare:
+    runs-on: ubuntu-20.04
+    outputs:
+      uuid: ${{ steps.uuid.outputs.value }}
+    steps:
+      - name: Generate unique ID 💎
+        id: uuid
+        # take the current commit + timestamp together
+        # the typical value would be something like
+        # "sha-5d3fe...35d3-time-1620841214"
+        run: echo "::set-output name=value::sha-$GITHUB_SHA-time-$(date +"%s")"
+
+      - name: Print unique ID 🖨`
+        run: echo "generated id ${{ steps.uuid.outputs.value }}"
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -105,7 +120,7 @@ jobs:
       fail-fast: false
       matrix:
         containers: [1, 2, 3, 4, 5, 6, 7]
-    needs: build
+    needs: ["build", "prepare"]
     steps:
       - uses: actions/cache@v2
         id: restore-build
@@ -127,6 +142,7 @@ jobs:
           start: npm run start:ci
           wait-on: http://localhost:8000
           wait-on-timeout: 30
+          ci-build-id: ${{ needs.prepare.outputs.uuid }}
 
   publish:
     needs: [build, lint, test-unit, type-check, test-cypress]


### PR DESCRIPTION
# Background
Hitting the "re-run" button for tests would not actually run cypress tests

# What did you do?
- [x] Generated a new UUID in a separate build step that is used to identify our cypress runs

Story details: https://app.shortcut.com/nylas/story/76293