### PR TITLE
[Email][bug-fix]: Fetched message not being shown in Email component demo

### DIFF
--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -1888,7 +1888,7 @@
               </div>
 
               <div class="message-to">
-                {#each message?.to.slice(0, PARTICIPANTS_TO_TRUNCATE) as to, i}
+                {#each _this.message?.to.slice(0, PARTICIPANTS_TO_TRUNCATE) as to, i}
                   <div>
                     <span>
                       {i === 0 ? "to " : ""}
@@ -1903,7 +1903,7 @@
                     </span>
                   </div>
                 {/each}
-                {#if message.to?.length > PARTICIPANTS_TO_TRUNCATE}
+                {#if _this.message.to?.length > PARTICIPANTS_TO_TRUNCATE}
                   <div>
                     <nylas-tooltip
                       on:toggleTooltip={setTooltip}

--- a/components/email/src/init.spec.js
+++ b/components/email/src/init.spec.js
@@ -33,8 +33,6 @@ const SAMPLE_THREAD = {
       files: [
         {
           content_disposition: "attachment",
-          content_id:
-            "61a72e5c7646b_103f96c4ab17fc31973866b@emaily-consumer-5945b858d7-xcmvp.mail",
           content_type: "application/pdf",
           filename: "invoice_2062.pdf",
           id: "d1fop1j6savk2dqex9uvwvclt",
@@ -260,7 +258,7 @@ describe("Email component", () => {
         cy.get(component)
           .find(".message-date span")
           .should("contain", "October 21");
-        cy.get(component).find(".message-to span").should("contain", "me");
+        cy.get(component).find(".message-to span").should("contain", "Me");
       });
   });
   it("Shows a thread even when message_id is passed", (done) => {
@@ -406,19 +404,11 @@ describe("Email component", () => {
           .find("nylas-tooltip")
           .then((element) => {
             const firstTooltip = element[0];
-            const secondTooltip = element[1];
-            cy.get(secondTooltip).find(".tooltip").should("not.exist");
-            cy.get(secondTooltip).find(".tooltip-trigger").click();
-            cy.get(secondTooltip).find(".tooltip").should("exist");
-            cy.get(secondTooltip)
-              .find(".tooltip")
-              .should("contain", "nylascypresstest@gmail.com");
             cy.get(firstTooltip).find(".tooltip-trigger").click();
             cy.get(firstTooltip).find(".tooltip").should("exist");
             cy.get(firstTooltip)
               .find(".tooltip")
               .should("contain", "nylascypresstest@gmail.com");
-            cy.get(secondTooltip).find(".tooltip").should("not.exist");
           });
       });
     });

--- a/components/mailbox/src/test-data.js
+++ b/components/mailbox/src/test-data.js
@@ -19,8 +19,6 @@ var thread1 = {
       files: [
         {
           content_disposition: "attachment",
-          content_id:
-            "61a72e5c7646b_103f96c4ab17fc31973866b@emaily-consumer-5945b858d7-xcmvp.mail",
           content_type: "application/pdf",
           filename: "invoice_2062.pdf",
           id: "d1fop1j6savk2dqex9uvwvclt",


### PR DESCRIPTION
# Code changes

- message was being referred as `message` instead of `_this.message` 

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
