### PR TITLE
Poojaguggari/sc 76677/email add test for draft and empty emails

### DIFF
--- a/components/availability/package.json
+++ b/components/availability/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nylas/components-availability",
-  "version": "1.1.4",
+  "version": "1.1.5-canary.0",
   "repository": {
     "type": "git",
     "url": "github:nylas/components.git",

--- a/components/composer/package.json
+++ b/components/composer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nylas/components-composer",
-  "version": "1.1.6-canary.0",
+  "version": "1.1.6-canary.1",
   "repository": {
     "type": "git",
     "url": "github:nylas/components.git",

--- a/components/email/package.json
+++ b/components/email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nylas/components-email",
-  "version": "1.1.6",
+  "version": "1.1.7-canary.0",
   "repository": {
     "type": "git",
     "url": "github:nylas/components.git",

--- a/components/email/src/init.spec.js
+++ b/components/email/src/init.spec.js
@@ -189,6 +189,71 @@ const SAMPLE_THREAD = {
   version: 63,
 };
 
+const EMPTY_THREAD = {
+  account_id: "cou6r5tjgubx9rswikzvz9afb",
+  drafts: [],
+  first_message_timestamp: 1613494375,
+  has_attachments: true,
+  id: "c7ksnn0zyweivc3bcjnd9miwb",
+  labels: [
+    {
+      display_name: "Important",
+      id: "qu2u9kjbafk1xgfd1qr3auv4",
+      name: "important",
+    },
+    {
+      display_name: "All Mail",
+      id: "2j0dp79lsxxw8fa4y57yszmw9",
+      name: "all",
+    },
+    {
+      display_name: "Sent Mail",
+      id: "4t2d14mxzlushnbgtlknxf7e0",
+      name: "sent",
+    },
+  ],
+  last_message_received_timestamp: 1613703916,
+  last_message_sent_timestamp: 1613748385,
+  last_message_timestamp: 1613748385,
+  messages: [],
+  object: "thread",
+  participants: [
+    {
+      email: "jimmy@nylas.com",
+      name: "Jimmy Hooker",
+    },
+    {
+      email: "chantal.l@nylas.com",
+      name: "Chantal Lam",
+    },
+    {
+      email: "hazik.a@nylas.com",
+      name: "Hazik Afzal",
+    },
+    {
+      email: "phil.r@nylas.com",
+      name: "Phil Renaud",
+    },
+  ],
+  snippet: "Testing with updated commons! --Sent with Nylas",
+  starred: false,
+  subject: "This is a Super great test email.",
+  unread: true,
+  version: 63,
+};
+
+const DRAFT_THREAD = {
+  ...EMPTY_THREAD,
+  labels: [
+    ...EMPTY_THREAD.labels,
+    {
+      display_name: "Draft",
+      id: "qu2u9kjbafk1xgfd1qr3auv4",
+      name: "drafts",
+    },
+  ],
+};
+
 describe("Email component", () => {
   beforeEach(() => {
     cy.visit("/components/email/src/index.html");
@@ -571,6 +636,40 @@ describe("Email component", () => {
               .should("eq", "show email");
           });
       });
+    });
+
+    it("Shows empty message", () => {
+      cy.get("nylas-email")
+        .as("email")
+        .then((element) => {
+          const component = element[2];
+          component.show_expanded_email_view_onload = false;
+          component.thread = EMPTY_THREAD;
+          cy.get(component)
+            .find(".no-messages-warning-container")
+            .should("exist")
+            .and(($div) => {
+              expect($div).to.contain(
+                "Sorry, looks like this thread is currently unavailable",
+              );
+            });
+        });
+    });
+
+    it("Shows draft message", () => {
+      cy.get("nylas-email")
+        .as("email")
+        .then((element) => {
+          const component = element[2];
+          component.show_expanded_email_view_onload = false;
+          component.thread = DRAFT_THREAD;
+          cy.get(component)
+            .find(".no-messages-warning-container")
+            .should("exist")
+            .and(($div) => {
+              expect($div).to.contain("This is a draft email");
+            });
+        });
     });
   });
 });

--- a/components/mailbox/package.json
+++ b/components/mailbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nylas/components-mailbox",
-  "version": "1.1.5",
+  "version": "1.1.6-canary.0",
   "repository": {
     "type": "git",
     "url": "github:nylas/components.git",

--- a/components/mailbox/src/init.spec.js
+++ b/components/mailbox/src/init.spec.js
@@ -1,5 +1,69 @@
 import { thread1, thread2 } from "./test-data.js";
 const threads = [thread1, thread2];
+const EMPTY_THREAD = {
+  account_id: "cou6r5tjgubx9rswikzvz9afb",
+  drafts: [],
+  first_message_timestamp: 1613494375,
+  has_attachments: true,
+  id: "c7ksnn0zyweivc3bcjnd9miwb",
+  labels: [
+    {
+      display_name: "Important",
+      id: "qu2u9kjbafk1xgfd1qr3auv4",
+      name: "important",
+    },
+    {
+      display_name: "All Mail",
+      id: "2j0dp79lsxxw8fa4y57yszmw9",
+      name: "all",
+    },
+    {
+      display_name: "Sent Mail",
+      id: "4t2d14mxzlushnbgtlknxf7e0",
+      name: "sent",
+    },
+  ],
+  last_message_received_timestamp: 1613703916,
+  last_message_sent_timestamp: 1613748385,
+  last_message_timestamp: 1613748385,
+  messages: [],
+  object: "thread",
+  participants: [
+    {
+      email: "jimmy@nylas.com",
+      name: "Jimmy Hooker",
+    },
+    {
+      email: "chantal.l@nylas.com",
+      name: "Chantal Lam",
+    },
+    {
+      email: "hazik.a@nylas.com",
+      name: "Hazik Afzal",
+    },
+    {
+      email: "phil.r@nylas.com",
+      name: "Phil Renaud",
+    },
+  ],
+  snippet: "Testing with updated commons! --Sent with Nylas",
+  starred: false,
+  subject: "This is a Super great test email.",
+  unread: true,
+  version: 63,
+};
+
+const DRAFT_THREAD = {
+  ...EMPTY_THREAD,
+  labels: [
+    ...EMPTY_THREAD.labels,
+    {
+      display_name: "Draft",
+      id: "qu2u9kjbafk1xgfd1qr3auv4",
+      name: "drafts",
+    },
+  ],
+};
 
 // TODO: We need to intercept network requests in order to ensure we have less flaky tests
 // and they become more deterministic.
@@ -35,8 +99,7 @@ describe("MailBox  component", () => {
         });
     });
 
-    // TODO: Disabled until we get a merged
-    xit("Shows attached file", () => {
+    it("Shows attached file", () => {
       cy.get("nylas-mailbox")
         .as("mailbox")
         .then((element) => {
@@ -52,6 +115,48 @@ describe("MailBox  component", () => {
               cy.get(email)
                 .find(".email-row.condensed .attachment.desktop button")
                 .should("have.text", "invoice_2062.pdf ");
+            });
+        });
+    });
+
+    it("Shows empty message", () => {
+      cy.get("nylas-mailbox")
+        .as("mailbox")
+        .then((element) => {
+          const component = element[0];
+          component.all_threads = [EMPTY_THREAD];
+          cy.get(component)
+            .find("nylas-email")
+            .then((element) => {
+              const email = element[0];
+              cy.get(email)
+                .find(".no-messages-warning-container")
+                .should("exist")
+                .and(($div) => {
+                  expect($div).to.contain(
+                    "Sorry, looks like this thread is currently unavailable",
+                  );
+                });
+            });
+        });
+    });
+
+    it("Shows draft message", () => {
+      cy.get("nylas-mailbox")
+        .as("mailbox")
+        .then((element) => {
+          const component = element[0];
+          component.all_threads = [DRAFT_THREAD];
+          cy.get(component)
+            .find("nylas-email")
+            .then((element) => {
+              const email = element[0];
+              cy.get(email)
+                .find(".no-messages-warning-container")
+                .should("exist")
+                .and(($div) => {
+                  expect($div).to.contain("This is a draft email");
+                });
             });
         });
     });


### PR DESCRIPTION
# Code changes

- Added a test to Email & Mailbox for when there is a thread with no messages
- Added a test to Email & Mailbox for when there is a thread in draft

# Readiness checklist

- [X ] Cypress tests passing?
- [ X] New cypress tests added?

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
