### PR TITLE
Bug: Availability component loading bar is out of place

### DIFF
--- a/components/availability/src/styles/availability.scss
+++ b/components/availability/src/styles/availability.scss
@@ -104,6 +104,7 @@ main {
   }
 
   .days {
+    position: relative;
     display: grid;
     gap: 0rem;
     grid-auto-flow: column;


### PR DESCRIPTION
# Code changes

- [x] Set days container to position relative default


# Screenshots
## Before
![Screen Shot 2021-12-22 at 5 57 45 PM](https://user-images.githubusercontent.com/14408339/147164350-c469b1bd-95f0-44f2-be0c-5494951a8425.png)

## After
![Screen Shot 2021-12-22 at 5 57 25 PM](https://user-images.githubusercontent.com/14408339/147164367-8fe4cebc-75e5-4124-88c6-64450ff061b7.png)

# Readiness checklist

- [x] Included before/after screenshots, if the change is visual


# Explanations

###  TLDR: 
**Make sure to manually set the `position` CSS property other than `initial` on the element with `bind:clientWidth`, `clientHeight`, `offsetWidth` and `offsetHeight`. Otherwise it might get added with an inline `position: relative` during compile, which could break the layout unexpectedly.**


This is more complicated than I expected. This progress bar's visual went out of place for several times in our PR history.
- First time: [222](https://github.com/nylas/components/pull/222)
- It was fixed here: [241](https://github.com/nylas/components/pull/241)
- And it went wrong again here:  [Removal of the `{:else if}` at line 1492 of components/availability/src/Availability.svelte](https://github.com/nylas/components/commit/8dc6d1426fbfe7fd1c224248b9f44119483cabbd#diff-add10154d6084e3fbc593653cf59d008501325240ddd9047c734089bee9da62f)

By comparing the different versions above you can see on [#222](https://components-7sam04y4n-nylas.vercel.app/components/availability/src/index.html) and [#242](https://components-bbbtoohx7-nylas.vercel.app/components/availability/src/index.html), the `<div class="days schedule">` has an inline style `position: relative` added.

This is caused by the `bind:clientWidth` binding we have on this element, which adds this inline `position: relative` during compile and breaks the layout.
It seems like an unsolved issue of Svelte in Firefox, but it somehow happens in Chrome as well in my testing (which will be triggered by accessing props of the `_this.calendars` before mount).

### References
- [Svelte Twitter](https://twitter.com/sveltejs/status/992052656125435904)
- [Dimension bindings intermittently add inline style="position:relative;" in Firefox](https://github.com/sveltejs/svelte/issues/4776)


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
