### PR TITLE
[Composer]: Reset sendSuccess when composer is opened and closed

### DIFF
--- a/components/composer/CHANGELOG.md
+++ b/components/composer/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Bug Fixes
 
+- [Composer]: Reset sendSuccess when composer is opened and closed [#300](https://github.com/nylas/components/pull/300)
+
 # v1.1.6 (2021-12-22)
 
 ## New Features

--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -126,11 +126,17 @@
   // Callbacks
   export const open = (): void => {
     visible = true;
+    if (_this.reset_after_send) {
+      sendSuccess = false;
+    }
     dispatchEvent("composerOpened", {});
   };
 
   export const close = (): void => {
     visible = false;
+    if (_this.reset_after_send) {
+      sendSuccess = false;
+    }
     dispatchEvent("composerClosed", {});
   };
 

--- a/components/mailbox/src/index.html
+++ b/components/mailbox/src/index.html
@@ -52,6 +52,7 @@
         composer.show_from = false;
         composer.show_bcc = false;
         composer.show_cc = false;
+        composer.reset_after_send = true;
 
         composer.close();
 
@@ -101,6 +102,7 @@
       class="composer"
       show_header="true"
       show_subject="true"
-    ></nylas-composer>
+    >
+    </nylas-composer>
   </body>
 </html>


### PR DESCRIPTION
# Code changes

- If `reset_after_send` prop is set to true, reset `sendSuccess` by setting to false

# Readiness checklist

- [X] Added changes to component `CHANGELOG.md`
- [X] Cypress tests passing?

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
