### PR TITLE
[availability] Don't show timezone ticks if timezone prop is the same as client's timezone

### DIFF
--- a/commons/src/methods/convertDateTimeZone.ts
+++ b/commons/src/methods/convertDateTimeZone.ts
@@ -1,4 +1,8 @@
-import { DateTime } from "luxon";
+import { DateTime, IANAZone } from "luxon";
+
+export function isValidTimezone(zone: string) {
+  return IANAZone.isValidZone(zone);
+}
 
 /**
  *
@@ -30,14 +34,12 @@ export function formatTimeSlot(slot: Date, zone: string): string {
  * @param zone string
  * @returns string
  */
-export function setTimeZoneOffset(
-  slot: Date,
-  zone: string | undefined = undefined,
-): string {
+export function setTimeZoneOffset(slot: Date, zone?: string): string {
   const dateTimeSlot = DateTime.fromJSDate(slot, { zone });
   if (
-    !dateTimeSlot.isValid &&
-    (dateTimeSlot.invalidReason === "unsupported zone" || !zone)
+    (zone && !isValidTimezone(zone)) ||
+    (!dateTimeSlot.isValid &&
+      (dateTimeSlot.invalidReason === "unsupported zone" || !zone))
   ) {
     return "";
   }

--- a/commons/src/store/mailbox.ts
+++ b/commons/src/store/mailbox.ts
@@ -25,7 +25,7 @@ async function initializePaginatedThreads(totalPages: number) {
   for (let i = 0; i < totalPages; i++) {
     paginatedThreads.push({
       isLoaded: false,
-      threads: [],
+      threads: <Thread[]>[],
     });
   }
   return paginatedThreads;

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -3,6 +3,7 @@
 <script lang="ts">
   import {
     formatTimeSlot,
+    isValidTimezone,
     setTimeZoneOffset,
   } from "@commons/methods/convertDateTimeZone";
   import {
@@ -62,7 +63,7 @@
   import { createConsecutiveQueryKey } from "./method/consecutive";
   import type { EventDefinition } from "@commonstypes/ScheduleEditor";
   import type { ConsecutiveEvent } from "@commonstypes/Scheduler";
-  import { generateDaySlots, overlap } from "./method/availabilityUtils";
+  import { generateDaySlots } from "./method/availabilityUtils";
 
   //#region props
   export let id: string = "";
@@ -264,6 +265,17 @@
         defaultValueMap,
       ) as Manifest;
       previousProps = $$props;
+
+      if (_this.timezone) {
+        if (!isValidTimezone(_this.timezone)) {
+          console.warn(`Invalid IANA time zone: ${_this.timezone}`);
+          _this.timezone = undefined;
+        } else if (
+          _this.timezone === Intl.DateTimeFormat().resolvedOptions().timeZone
+        ) {
+          _this.timezone = undefined;
+        }
+      }
     }
   }
 

--- a/components/availability/src/method/consecutive.ts
+++ b/components/availability/src/method/consecutive.ts
@@ -35,7 +35,7 @@ export async function createConsecutiveQueryKey(
       1000,
     end_time:
       timeHour(new Date(new Date(endDay).setHours(endHour))).getTime() / 1000,
-    free_busy: [],
+    free_busy: <any[]>[],
     open_hours: openHours,
     emails: emailsList,
     events,

--- a/components/composer/src/lib/store.ts
+++ b/components/composer/src/lib/store.ts
@@ -2,14 +2,14 @@ import { writable } from "svelte/store";
 import type { Attachment, AttachmentUpdate } from "@commons/types/Composer";
 
 const messageInitialState = {
-  from: [],
-  to: [],
-  cc: [],
-  bcc: [],
+  from: <string[]>[],
+  to: <string[]>[],
+  cc: <string[]>[],
+  bcc: <string[]>[],
   body: "",
   subject: "New Message",
-  send_at: null,
-  file_ids: [],
+  send_at: <Date>null,
+  file_ids: <string[]>[],
 };
 export const message = writable(
   JSON.parse(JSON.stringify(messageInitialState)),

--- a/tests/agenda/agenda.spec.ts
+++ b/tests/agenda/agenda.spec.ts
@@ -9,7 +9,7 @@ import { mockEvents } from "../mocks/MockEvents";
 import { mockAgendaManifest } from "../mocks/MockManifests";
 
 jest.mock("../../commons/src/connections/manifest", () => ({
-  ...jest.requireActual("../../commons/src/connections/manifest"),
+  ...(jest.requireActual("../../commons/src/connections/manifest") as any),
   fetchManifest: jest.fn(),
 }));
 import { fetchManifest } from "../../commons/src/connections/manifest";

--- a/tests/agenda/methods/position.spec.ts
+++ b/tests/agenda/methods/position.spec.ts
@@ -10,17 +10,17 @@ describe("Event positioning", () => {
   it("should correctly populate a position map based on a list of events", () => {
     const expectedPositionMap = {
       abc123: {
-        leftNeighbour: null,
+        leftNeighbour: <any>null,
         offset: 0,
         overlaps: [mockEvents.find((event) => event.id === "ghi789")],
       },
       def456: {
-        leftNeighbour: null,
+        leftNeighbour: <any>null,
         offset: 0,
         overlaps: [mockEvents.find((event) => event.id === "ghi789")],
       },
       ghi789: {
-        leftNeighbour: null,
+        leftNeighbour: <any>null,
         offset: 0,
         overlaps: [
           mockEvents.find((event) => event.id === "abc123"),
@@ -39,9 +39,9 @@ describe("Event positioning", () => {
   it("should position and size events with no overlaps to take up the full width of the calendar", () => {
     const positionMap = {
       abc123: {
-        leftNeighbour: null,
+        leftNeighbour: <any>null,
         offset: 0,
-        overlaps: [],
+        overlaps: <any>[],
       },
     };
     const mockEvent = <any>{

--- a/tests/region/region.spec.ts
+++ b/tests/region/region.spec.ts
@@ -1,7 +1,7 @@
 import { getMiddlewareApiUrl } from "../../commons/src/methods/api";
 
 jest.mock("../../commons/src/connections/manifest", () => ({
-  ...jest.requireActual("../../commons/src/connections/manifest"),
+  ...(jest.requireActual("../../commons/src/connections/manifest") as any),
   fetchManifest: jest.fn(),
 }));
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
       "@commons": ["./commons/src/"]
     },
     "strict": true,
+    "strictNullChecks": false,
     "skipLibCheck": true,
     "resolveJsonModule": true
   },


### PR DESCRIPTION
# Code changes

- Don't show timezone ticks if timezone prop is the same as client's timezone
- Warn if passed timezone is not a valid IANA timezone
- Set `"strictNullChecks": false,` so we don't have to deal with not being able to set vars as `null` / `undefined`

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
