### PR TITLE
[Availability, Bugfix]: Only adjust columns for timezone if in Schedule view

### DIFF
--- a/components/availability/src/styles/availability.scss
+++ b/components/availability/src/styles/availability.scss
@@ -16,9 +16,9 @@ main {
 
   &.ticked {
     grid-template-columns: 70px 1fr;
-  }
-  &.timezone {
-    grid-template-columns: 70px 70px 1fr;
+    &.timezone {
+      grid-template-columns: 70px 70px 1fr;
+    }
   }
 
   &.hide-header {


### PR DESCRIPTION
- The availability component has two views: `schedule` and `list`
- Only the `schedule` view shows ticks (y axis of time)
- Adding an explicit timezone (say, `timezone="America/Juneau"`) when instantiating the component adds another column to the ticks, **but only when in schedule view**
- This PR makes it so that .timezone class that assigns space for that new tick column only comes into play as a child of the `ticked` class, which depends on `view="schedule"`

## Before: 
![image](https://user-images.githubusercontent.com/713991/147699562-db75b89e-8e58-45bb-881a-805f9def86c5.png)

## After:
![image](https://user-images.githubusercontent.com/713991/147699585-9dd5ce4f-6de3-4a61-9248-c3b6a2b91b3e.png)


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
