### PR TITLE
Allow Schedule Editor to provide a null start_date (which would default to the current date)

### DIFF
--- a/commons/src/types/ScheduleEditor.ts
+++ b/commons/src/types/ScheduleEditor.ts
@@ -7,7 +7,7 @@ export interface Manifest extends NylasManifest {
   show_hosts: "show" | "hide";
   start_hour: number;
   end_hour: number;
-  start_date: Date;
+  start_date: Date | null;
   dates_to_show: number;
   show_ticks: boolean;
   allow_booking: boolean;

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -270,7 +270,7 @@
 
   // Properties requiring further manipulation:
   function transformPropertyValues() {
-    if (_this.start_date === null) {
+    if (!_this.start_date) {
       _this.start_date = defaultValueMap.start_date;
     }
   }

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -102,7 +102,7 @@
   export let show_ticks: boolean;
   export let show_weekends: boolean;
   export let slot_size: number; // in minutes
-  export let start_date: Date;
+  export let start_date: Date | null;
   export let start_hour: number;
   export let timezone: string;
   export let view_as: "schedule" | "list";
@@ -243,6 +243,7 @@
     manifest = (await $ManifestStore[storeKey]) || {};
 
     _this = buildInternalProps($$props, manifest, defaultValueMap) as Manifest;
+    transformPropertyValues();
 
     const calendarQuery: CalendarQuery = {
       access_token,
@@ -264,6 +265,13 @@
         defaultValueMap,
       ) as Manifest;
       previousProps = $$props;
+    }
+  }
+
+  // Properties requiring further manipulation:
+  function transformPropertyValues() {
+    if (_this.start_date === null) {
+      _this.start_date = defaultValueMap.start_date;
     }
   }
 

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -166,16 +166,22 @@
 
   // Properties requiring further manipulation:
   let startDate: string = new Date().toLocaleDateString("en-CA");
+  let startDateMethod: "date" | "current" = "current";
 
   function transformPropertyValues() {
-    startDate = _this.start_date?.toLocaleDateString("en-CA");
+    startDate = _this.start_date?.toLocaleDateString("en-CA") as string;
+    startDateMethod = _this.start_date ? "date" : "current";
   }
 
-  $: {
-    _this.start_date = new Date(
-      new Date(startDate).getTime() -
-        new Date(startDate).getTimezoneOffset() * -60000,
-    );
+  $: if (initialized) {
+    if (startDateMethod === "date") {
+      _this.start_date = new Date(
+        new Date(startDate).getTime() -
+          new Date(startDate).getTimezoneOffset() * -60000,
+      );
+    } else {
+      _this.start_date = null;
+    }
   }
   // #endregion mount and prop initialization
 
@@ -583,7 +589,15 @@
           </div>
           <label>
             <strong>Start Date</strong>
-            <input type="date" bind:value={startDate} />
+
+            <select bind:value={startDateMethod}>
+              <option value="current">Always the current date</option>
+              <option value="date">A specific date (pick)</option>
+            </select>
+
+            {#if startDateMethod === "date"}
+              <input type="date" bind:value={startDate} />
+            {/if}
           </label>
           <label>
             <strong>Time Zone</strong>

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -165,22 +165,24 @@
   }
 
   // Properties requiring further manipulation:
-  let startDate: string = new Date().toLocaleDateString("en-CA");
-  let startDateMethod: "date" | "current" = "current";
+  let startDate: string | null = new Date().toLocaleDateString("en-CA");
+  let customStartDate: boolean = false;
 
   function transformPropertyValues() {
     startDate = _this.start_date?.toLocaleDateString("en-CA") as string;
-    startDateMethod = _this.start_date ? "date" : "current";
+    customStartDate = _this.start_date ? true : false;
   }
 
-  $: if (initialized) {
-    if (startDateMethod === "date") {
-      _this.start_date = new Date(
-        new Date(startDate).getTime() -
-          new Date(startDate).getTimezoneOffset() * -60000,
-      );
-    } else {
-      _this.start_date = null;
+  $: {
+    if (initialized) {
+      if (startDate) {
+        _this.start_date = new Date(
+          new Date(startDate).getTime() -
+            new Date(startDate).getTimezoneOffset() * -60000,
+        );
+      } else {
+        _this.start_date = null;
+      }
     }
   }
   // #endregion mount and prop initialization
@@ -589,15 +591,27 @@
           </div>
           <label>
             <strong>Start Date</strong>
+            <strong>
+              <input
+                type="checkbox"
+                name="custom_start_date"
+                bind:checked={customStartDate}
+                on:change={async () => {
+                  if (!customStartDate) {
+                    startDate = new Date().toLocaleDateString("en-CA");
+                    await tick();
+                    startDate = null;
+                  }
+                }}
+              />
+              Show a specific date
+            </strong>
 
-            <select bind:value={startDateMethod}>
-              <option value="current">Always the current date</option>
-              <option value="date">A specific date (pick)</option>
-            </select>
-
-            {#if startDateMethod === "date"}
-              <input type="date" bind:value={startDate} />
-            {/if}
+            <input
+              type="date"
+              bind:value={startDate}
+              disabled={!customStartDate}
+            />
           </label>
           <label>
             <strong>Time Zone</strong>


### PR DESCRIPTION
Solves two bugs:
- Inability to set start_date to whatever the current date is via the schedule editor ([Shortcut](https://app.shortcut.com/nylas/story/76246/schedule-editor-bug-no-way-to-set-date-to-always-be-current-date-set-to-null))
- start_date-less availability components default to Jan 1 1970 ([Shortcut](https://app.shortcut.com/nylas/story/76732/availability-component-consecutive-mode-the-calendar-period-is-dec-1969-jan-1970-when-the-availability-component-is-created))

By adding a little piece of UI to select a null date or a specific date; making `start_date` null; and inferring that `null` start_dates should fall back to the current date in `<nylas-availability>`

![image](https://user-images.githubusercontent.com/713991/147705576-cac9b1e1-3645-44f4-922b-8b59e19e3f5a.png)


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
