### PR TITLE
Re-implement existsWithinConsecutiveBlock checks

### DIFF
--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -574,6 +574,8 @@
         allCalendars,
         calendarID,
         requiredParticipants,
+        consecutiveOptions,
+        consecutiveParticipants,
         _this,
       ),
     ); // TODO: include other potential post-all-slots-established checks, like overbooked, in a single secondary run here.


### PR DESCRIPTION
Looks like #264 (move generateDaySlots into its own file) caused a regression for Consecutive availability: all slots for Consecutive Availability showed up as busy. https://github.com/nylas/components/pull/264/files#diff-add10154d6084e3fbc593653cf59d008501325240ddd9047c734089bee9da62fL556-L574

Likely porting this code was just missed at the time.

This PR re-implements it; this requires adding a couple new params to `generateDaySlots()`.

Left: demo file with fix in place. Right: current state of https://components.nylas.io/components/scheduler/src/index.html with consecutive selected.
![image](https://user-images.githubusercontent.com/713991/148112769-86e65b4f-ed45-4ce3-a666-c720708e2091.png)


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
