### PR TITLE
[Composer]: Disable changing from field, added toottip to icons and enlarged attachment icon

### DIFF
--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -522,6 +522,20 @@
     position: relative;
     text-decoration: none;
     color: var(--composer-text-color, black);
+    .contact-item {
+      display: inline-flex;
+      background: var(--primary-light);
+      color: var(--primary);
+      align-items: center;
+      border-radius: calc(var(--border-radius) / 2);
+      padding: 0.2rem 0.8rem;
+      margin: 2px 0.25rem;
+    }
+    .contact-item__name {
+      color: var(--text-secondary);
+      font-size: 12px;
+      padding-right: 0.75rem;
+    }
   }
   .close-btn {
     background: none;
@@ -610,8 +624,8 @@
 
   [class$="Icon"] {
     fill: var(--composer-icons-color, #666774);
-    width: 10px;
-    height: 10px;
+    width: 16px;
+    height: 16px;
   }
   .ExpandIcon {
     transform: translateY(1px);
@@ -677,14 +691,14 @@
         <!-- Search -->
         <div class="contacts-wrapper">
           {#if _this.show_from}
-            <nylas-contacts-search
-              data-cy="from-field"
-              placeholder="From:"
-              single={true}
-              change={handleContactsChange("from")}
-              contacts={from}
-              value={$message.from}
-            />
+            <div class="contact-item">
+              <span class="contact-item__name">
+                {#if $message.from[0].name}
+                  <strong>{$message.from[0].name}</strong>
+                  {`<${$message.from[0].email}>`}
+                {:else}{$message.from[0].email}{/if}
+              </span>
+            </div>
           {/if}
           {#if _this.show_to}
             <nylas-contacts-search

--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -522,6 +522,19 @@
     position: relative;
     text-decoration: none;
     color: var(--composer-text-color, black);
+    .contacts-container {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      padding: 0.4rem var(--outer-padding);
+      border-bottom: 1px solid var(--border);
+    }
+    .contact-from {
+      display: flex;
+      align-items: center;
+      padding-bottom: 0.1rem;
+      padding-right: 0.1rem;
+    }
     .contact-item {
       display: inline-flex;
       background: var(--primary-light);
@@ -529,12 +542,21 @@
       align-items: center;
       border-radius: calc(var(--border-radius) / 2);
       padding: 0.2rem 0.8rem;
-      margin: 2px 0.25rem;
+      margin-right: 0.25rem;
+      margin-top: 2px;
+      margin-bottom: 2px;
     }
     .contact-item__name {
       color: var(--text-secondary);
       font-size: 12px;
       padding-right: 0.75rem;
+    }
+    .contacts-placeholder {
+      font-size: var(--font-size-small);
+      margin-right: 10px;
+      min-width: 30px;
+      display: flex;
+      color: var(--text-light);
     }
   }
   .close-btn {
@@ -624,6 +646,10 @@
 
   [class$="Icon"] {
     fill: var(--composer-icons-color, #666774);
+    width: 10px;
+    height: 10px;
+  }
+  [class$="AttachmentIcon"] {
     width: 16px;
     height: 16px;
   }
@@ -691,13 +717,20 @@
         <!-- Search -->
         <div class="contacts-wrapper">
           {#if _this.show_from}
-            <div class="contact-item">
-              <span class="contact-item__name">
-                {#if $message.from[0].name}
-                  <strong>{$message.from[0].name}</strong>
-                  {`<${$message.from[0].email}>`}
-                {:else}{$message.from[0].email}{/if}
-              </span>
+            <div class="contacts-container">
+              <div class="contact-from">
+                <div class="contacts-placeholder">From:</div>
+                <div class="contacts-results-inner">
+                  <div class="contact-item" data-cy="from-field">
+                    <span class="contact-item__name">
+                      {#if $message.from[0].name}
+                        <strong>{$message.from[0].name}</strong>
+                        {`<${$message.from[0].email}>`}
+                      {:else}{$message.from[0].email}{/if}
+                    </span>
+                  </div>
+                </div>
+              </div>
             </div>
           {/if}
           {#if _this.show_to}

--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -723,10 +723,14 @@
                 <div class="contacts-results-inner">
                   <div class="contact-item" data-cy="from-field">
                     <span class="contact-item__name">
-                      {#if $message.from[0].name}
-                        <strong>{$message.from[0].name}</strong>
-                        {`<${$message.from[0].email}>`}
-                      {:else}{$message.from[0].email}{/if}
+                      {#if $message.from.length > 0}
+                        {#if $message.from[0].name}
+                          <strong>{$message.from[0].name}</strong>
+                          {`<${$message.from[0].email}>`}
+                        {:else}
+                          {$message.from[0].email}
+                        {/if}
+                      {/if}
                     </span>
                   </div>
                 </div>

--- a/components/composer/src/components/HTMLEditor.svelte
+++ b/components/composer/src/components/HTMLEditor.svelte
@@ -155,6 +155,7 @@
       {#each toolbar as item}
         <button
           on:click={handleAction(item)}
+          title={item.title}
           class={item.state && item.state() ? "active" : ""}
         >
           {#if item.icon}

--- a/components/composer/src/init.spec.js
+++ b/components/composer/src/init.spec.js
@@ -274,7 +274,7 @@ describe("Composer customizations", () => {
     ).as("getMiddlewareManifest");
 
     cy.intercept("GET", "https://web-components.nylas.com/middleware/account", {
-      fixture: "composer/manifest.json", // We don't want account loaded so from field is empty
+      fixture: "composer/account.json",
     }).as("getMiddlewareAccount");
 
     cy.intercept("GET", "/users", [
@@ -322,6 +322,30 @@ describe("Composer customizations", () => {
     });
 
     cy.get("[data-cy=from-field]").should("exist");
+  });
+
+  it("from field cannot be changed", () => {
+    cy.get("@composer").then((el) => {
+      const component = el[0];
+      component.show_from = true;
+      component.value = {
+        from: [
+          {
+            name: "Luka Test",
+            email: "luka.b@nylas.com",
+          },
+        ],
+        to: [
+          {
+            name: "Dan Test",
+            email: "dan.r@nylas.com",
+          },
+        ],
+      };
+    });
+
+    cy.get("[data-cy=from-field]").contains("Luka Test").should("be.visible");
+    cy.get("[data-cy=from-field] .contact-item button").should("not.exist");
   });
 
   it("hide to field", () => {
@@ -471,7 +495,7 @@ describe("Composer customizations", () => {
     });
   });
 
-  it.only("Replaces merge fields as defined in replace_fields when passed a prop", () => {
+  it("Replaces merge fields as defined in replace_fields when passed a prop", () => {
     cy.get("@composer").then((el) => {
       const component = el[0];
       component.value = {
@@ -527,30 +551,6 @@ describe("Composer integration", () => {
 
     cy.get("input[name=subject]").should("have.value", "Sample subject");
     cy.get("header").contains("Sample subject").should("be.visible");
-  });
-
-  it("Removes contact from from-field", () => {
-    cy.get("@composer").then((element) => {
-      const component = element[0];
-      component.value = {
-        from: [
-          {
-            name: "Luka Test",
-            email: "luka.b@nylas.com",
-          },
-        ],
-        to: [
-          {
-            name: "Dan Test",
-            email: "dan.r@nylas.com",
-          },
-        ],
-      };
-    });
-
-    cy.get("[data-cy=from-field]").contains("Luka Test").should("be.visible");
-    cy.get(".contact-item button").first().click();
-    cy.get("[data-cy=from-field]").contains("Luka Test").should("not.exist");
   });
 
   it("Search input populates contact search dropdown", () => {

--- a/components/composer/src/init.spec.js
+++ b/components/composer/src/init.spec.js
@@ -454,7 +454,7 @@ describe("Composer customizations", () => {
     cy.get("@composer").then((el) => {
       const component = el[0];
       component.close();
-      // Check after applying options
+      // Check after applying options.
       cy.get(".nylas-composer").should("not.exist");
     });
   });

--- a/components/composer/src/init.spec.js
+++ b/components/composer/src/init.spec.js
@@ -274,7 +274,7 @@ describe("Composer customizations", () => {
     ).as("getMiddlewareManifest");
 
     cy.intercept("GET", "https://web-components.nylas.com/middleware/account", {
-      fixture: "composer/account.json",
+      fixture: "composer/manifest.json", // We don't want account loaded so from field is empty
     }).as("getMiddlewareAccount");
 
     cy.intercept("GET", "/users", [
@@ -344,7 +344,7 @@ describe("Composer customizations", () => {
       };
     });
 
-    cy.get("[data-cy=from-field]").contains("Luka Test").should("be.visible");
+    cy.get("[data-cy=from-field]").contains("Test").should("be.visible");
     cy.get("[data-cy=from-field] .contact-item button").should("not.exist");
   });
 
@@ -558,7 +558,7 @@ describe("Composer integration", () => {
       const component = element[0];
       component.to = [
         {
-          name: "Luka Test",
+          name: "Test User",
           email: "luka.b@nylas.com",
         },
       ];
@@ -566,9 +566,9 @@ describe("Composer integration", () => {
 
     cy.get("[data-cy=to-field]")
       .find("[data-cy=contacts-search-field]")
-      .type("Luk", { force: true });
+      .type("Test", { force: true });
 
-    cy.contains("Luka Test").should("be.visible");
+    cy.contains("Test User").should("be.visible");
   });
 
   it("Displays failed message after failing to send email", () => {

--- a/components/mailbox/src/index.html
+++ b/components/mailbox/src/index.html
@@ -49,7 +49,7 @@
         const composer = document.querySelector("nylas-composer");
         composer.show_header = true;
         composer.show_minimize_button = false;
-        composer.show_from = false;
+        composer.show_from = true;
         composer.show_bcc = false;
         composer.show_cc = false;
         composer.reset_after_send = true;

--- a/components/mailbox/src/index.html
+++ b/components/mailbox/src/index.html
@@ -49,7 +49,7 @@
         const composer = document.querySelector("nylas-composer");
         composer.show_header = true;
         composer.show_minimize_button = false;
-        composer.show_from = true;
+        composer.show_from = false;
         composer.show_bcc = false;
         composer.show_cc = false;
         composer.reset_after_send = true;


### PR DESCRIPTION
# Code changes

- Replaced `<nylas-contact-search>` in the from field with html
- Enlarged attachment icon [sc-77498](https://app.shortcut.com/nylas/story/77498/composer-attachment-icon-too-small)
- Added `title` attribute to the icons (Bold, Italic etc) [sc-77496](https://app.shortcut.com/nylas/story/77496/composer-no-tooltip-labels-are-shown-when-hovered-over-the-cta-button-icons-present-in-the-composer)
- Added a test to verify that from field cannot be changed / removed
- Removed the test which checked to see that from field can be removed

# Screenhot
![image](https://user-images.githubusercontent.com/16315004/148412815-515057ff-9f8a-4a15-a857-70f5aefd133e.png)


# Readiness checklist

- [X] Added changes to component `CHANGELOG.md`
- [X] Cypress tests passing?
- [x] New cypress tests added?
- [X] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
