### PR TITLE
[Mailbox]: When the E-mail List is being refreshed, the screen is blurred but we are still able to click and open (view) the email.

### DIFF
--- a/components/composer/CHANGELOG.md
+++ b/components/composer/CHANGELOG.md
@@ -1,35 +1,33 @@
-# Pending Changes
+# v1.1.6 (Unreleased)
+
+## New Features
+
+- Added `onError` custom event when an error occurs [#262](https://github.com/nylas/components/pull/262)
+- Allow sending with CMD/CTRL + Enter
+- Added tooltip labels to the WYSIWYG editor icons & attachment icons for improved accessibility
+- Added a prop `reset_after_close` which resets composer fields after closing
+
+## Bug Fixes
+
+- Fix support for Firefox and Safari browsers. [#279](https://github.com/nylas/components/pull/279)
+- Reset sendSuccess when composer is opened and closed [#300](https://github.com/nylas/components/pull/300)
+- Added a prop 'reset_after_close' which resets after closing[#301](https://github.com/nylas/components/pull/301)
+- Attachment icon size was too small making it inaccessible
 
 ## Breaking
 
-## New Features
-
-## Bug Fixes
-
-- [Composer]: Reset sendSuccess when composer is opened and closed [#300](https://github.com/nylas/components/pull/300)
-- [Composer]: Added a prop 'reset_after_close' which resets after closing[#301](https://github.com/nylas/components/pull/301)
-
-# v1.1.6 (2021-12-22)
-
-## New Features
-
-- [Composer] Added `onError` custom event when an error occurs [#262](https://github.com/nylas/components/pull/262)
-- [Composer] Allow sending with CMD/CTRL + Enter
-
-## Bug Fixes
-
-- [Composer] Fix support for Firefox and Safari browsers. [#279](https://github.com/nylas/components/pull/279)
+- Removed the ability for users to change the "From" field value via the UI
 
 # v1.1.5 (2021-12-10)
 
 ## Bug Fixes
 
-- [Composer] Added better error handling when file size exceeds 5MB [248](https://github.com/nylas/components/pull/248)
+- Added better error handling when file size exceeds 5MB [248](https://github.com/nylas/components/pull/248)
 
 # v1.1.4 (2021-12-09)
 
 ## Bug Fixes
 
-- [Composer] Don't hide `from` field when account is loaded and add collapsible height to whole composer [#247](https://github.com/nylas/components/pull/247)
-- [Composer] Add background color to contact search dropdown items and increase search input width [#251](https://github.com/nylas/components/pull/251)
-- [Composer] Fix `show_cc` and `show_bcc` buttons and sets defaults to `true` [#250](https://github.com/nylas/components/pull/250)
+- Don't hide `from` field when account is loaded and add collapsible height to whole composer [#247](https://github.com/nylas/components/pull/247)
+- Add background color to contact search dropdown items and increase search input width [#251](https://github.com/nylas/components/pull/251)
+- Fix `show_cc` and `show_bcc` buttons and sets defaults to `true` [#250](https://github.com/nylas/components/pull/250)

--- a/components/mailbox/CHANGELOG.md
+++ b/components/mailbox/CHANGELOG.md
@@ -1,26 +1,8 @@
-<<<<<<< HEAD
-# Pending Changes
-=======
-# Unreleased (2021-12-17)
-
-## Bug Fixes
-
-- [Mailbox] Updated border style + variables [#270](https://github.com/nylas/components/pull/270)
-
-# v1.1.5 (2021-12-15)
->>>>>>> 4dbc871 (changelog)
-
-## Breaking
+# v1.1.6 (Unreleased)
 
 ## New Features
 
-## Bug Fixes
-
-# v1.1.6 (2021-12-22)
-
-## New Features
-
-- [Mailbox] Added ability to reply to email/thread [#228](https://github.com/nylas/components/issues/228)
+- Added ability to reply to email/thread [#228](https://github.com/nylas/components/issues/228)
 - Added dispatched event `replyAllClicked` with properties
   - event
   - message
@@ -40,13 +22,15 @@
 
 ## Bug Fixes
 
-- [Mailbox] Fixed some attached files being treated as inline [283](https://github.com/nylas/components/pull/283)
+- Updated border style + variables [#270](https://github.com/nylas/components/pull/270)
+- Message content of emails failed to load if they were accessed while pagination was in progress
+- Fixed some attached files being treated as inline [283](https://github.com/nylas/components/pull/283)
 
 # v1.1.5 (2021-12-15)
 
 ## New Features
 
-- [Mailbox] Added `onError` custom event when an error occurs [#262](https://github.com/nylas/components/pull/262)
+- Added `onError` custom event when an error occurs [#262](https://github.com/nylas/components/pull/262)
 
 # v1.1.4 (2021-12-10)
 

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -247,11 +247,13 @@
         );
       }
       if (currentlySelectedThread) {
-        currentlySelectedThread.messages =
-          currentlySelectedThread.messages?.map((currentMessage) =>
-            currentMessage.id === message.id ? message : currentMessage,
-          );
-        currentlySelectedThread = currentlySelectedThread;
+        currentlySelectedThread = {
+          ...currentlySelectedThread,
+          messages:
+            currentlySelectedThread.messages?.map((currentMessage) =>
+              currentMessage.id === message.id ? message : currentMessage,
+            ) ?? [],
+        };
       }
     }
   }
@@ -299,11 +301,13 @@
         );
       }
       if (currentlySelectedThread) {
-        currentlySelectedThread.messages =
-          currentlySelectedThread.messages?.map((currentMessage) =>
-            currentMessage.id === message.id ? message : currentMessage,
-          );
-        currentlySelectedThread = currentlySelectedThread;
+        currentlySelectedThread = {
+          ...currentlySelectedThread,
+          messages:
+            currentlySelectedThread.messages?.map((currentMessage) =>
+              currentMessage.id === message.id ? message : currentMessage,
+            ) ?? [],
+        };
       }
     }
   }

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -246,6 +246,13 @@
           currentPage,
         );
       }
+      if (currentlySelectedThread) {
+        currentlySelectedThread.messages =
+          currentlySelectedThread.messages?.map((currentMessage) =>
+            currentMessage.id === message.id ? message : currentMessage,
+          );
+        currentlySelectedThread = currentlySelectedThread;
+      }
     }
   }
 
@@ -290,6 +297,13 @@
           query,
           currentPage,
         );
+      }
+      if (currentlySelectedThread) {
+        currentlySelectedThread.messages =
+          currentlySelectedThread.messages?.map((currentMessage) =>
+            currentMessage.id === message.id ? message : currentMessage,
+          );
+        currentlySelectedThread = currentlySelectedThread;
       }
     }
   }


### PR DESCRIPTION
# Background
If a user was using the pagination functionality and while the threads were being loaded (or refreshed via the refresh button) the user clicked a message, the body of that message would never have completed loading. 

# What did you do?
- [x] Updated the `threadClicked` and `messageClick` methods to update the `thread.messages` with the updated Message object after it's been fetched via a network request.

Story details: https://app.shortcut.com/nylas/story/77490