### PR TITLE
[composer] subject prop

### DIFF
--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -74,6 +74,7 @@
   export let cc: ContactSearchCallback = [];
   export let bcc: ContactSearchCallback = [];
   export let send: SendCallback;
+  export let subject: string;
   export let change: FetchContactsCallback | null = null;
   export let beforeSend: (msg: Message) => Message | void;
   export let afterSendSuccess: Function | null = null;
@@ -122,6 +123,7 @@
     show_attachment_button: true,
     show_editor_toolbar: true,
     theme: "theme-1",
+    subject: $message.subject,
   };
 
   // Callbacks
@@ -682,7 +684,7 @@
   <div class="nylas-composer" class:minimized={_this.minimized}>
     {#if _this.show_header}
       <header class={_this.minimized ? "minimized" : undefined}>
-        {$message.subject}
+        {subject}
         <div>
           {#if _this.show_minimize_button}
             {#if _this.minimized}
@@ -827,7 +829,7 @@
               type="text"
               placeholder="Subject"
               class="subject"
-              value={$message.subject}
+              value={subject}
               name="subject"
               on:input={handleInputChange}
             />

--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -74,7 +74,6 @@
   export let cc: ContactSearchCallback = [];
   export let bcc: ContactSearchCallback = [];
   export let send: SendCallback;
-  export let subject: string;
   export let change: FetchContactsCallback | null = null;
   export let beforeSend: (msg: Message) => Message | void;
   export let afterSendSuccess: Function | null = null;
@@ -123,7 +122,6 @@
     show_attachment_button: true,
     show_editor_toolbar: true,
     theme: "theme-1",
-    subject: $message.subject,
   };
 
   // Callbacks
@@ -152,6 +150,7 @@
   let showDatepicker = false;
   let themeLoaded = false;
   let visible = true;
+  $: subject = value?.subject ?? $message.subject;
 
   onMount(async () => {
     isLoading = true;
@@ -684,7 +683,7 @@
   <div class="nylas-composer" class:minimized={_this.minimized}>
     {#if _this.show_header}
       <header class={_this.minimized ? "minimized" : undefined}>
-        {subject}
+        <span>{subject}</span>
         <div>
           {#if _this.show_minimize_button}
             {#if _this.minimized}

--- a/components/composer/src/init.spec.js
+++ b/components/composer/src/init.spec.js
@@ -541,16 +541,28 @@ describe("Composer integration", () => {
     cy.get("nylas-composer").should("exist").as("composer");
   });
 
-  it("Sets subject", () => {
+  it("Removes contact from from-field", () => {
     cy.get("@composer").then((element) => {
       const component = element[0];
       component.value = {
-        subject: "Sample subject",
+        from: [
+          {
+            name: "Luka Test",
+            email: "luka.b@nylas.com",
+          },
+        ],
+        to: [
+          {
+            name: "Dan Test",
+            email: "dan.r@nylas.com",
+          },
+        ],
       };
     });
 
-    cy.get("input[name=subject]").should("have.value", "Sample subject");
-    cy.get("header").contains("Sample subject").should("be.visible");
+    cy.get("[data-cy=from-field]").contains("Luka Test").should("be.visible");
+    cy.get(".contact-item button").first().click();
+    cy.get("[data-cy=from-field]").contains("Luka Test").should("not.exist");
   });
 
   it("Search input populates contact search dropdown", () => {
@@ -813,5 +825,29 @@ describe("Composer file upload", () => {
       "contain",
       "Failed to send the message",
     );
+  });
+});
+
+describe("Composer subject", () => {
+  beforeEach(() => {
+    cy.visitComponentPage(
+      "/components/composer/src/index.html",
+      "nylas-composer",
+      "demo-composer",
+    );
+    cy.get("@testComponent")
+      .should("have.prop", "id")
+      .and("equal", "test-composer");
+  });
+
+  it("Shows subject prop if passed by user", () => {
+    cy.get("@testComponent").invoke("attr", "subject", "my test subject");
+    cy.get("header").contains("my test subject");
+    cy.get("input.subject").invoke("val").should("eq", "my test subject");
+  });
+
+  it("Shows default subject if subject prop is not passed", () => {
+    cy.get("header").contains("New Message");
+    cy.get("input.subject").invoke("val").should("eq", "New Message");
   });
 });

--- a/components/composer/src/init.spec.js
+++ b/components/composer/src/init.spec.js
@@ -541,30 +541,6 @@ describe("Composer integration", () => {
     cy.get("nylas-composer").should("exist").as("composer");
   });
 
-  it("Removes contact from from-field", () => {
-    cy.get("@composer").then((element) => {
-      const component = element[0];
-      component.value = {
-        from: [
-          {
-            name: "Luka Test",
-            email: "luka.b@nylas.com",
-          },
-        ],
-        to: [
-          {
-            name: "Dan Test",
-            email: "dan.r@nylas.com",
-          },
-        ],
-      };
-    });
-
-    cy.get("[data-cy=from-field]").contains("Luka Test").should("be.visible");
-    cy.get(".contact-item button").first().click();
-    cy.get("[data-cy=from-field]").contains("Luka Test").should("not.exist");
-  });
-
   it("Search input populates contact search dropdown", () => {
     cy.get("@composer").then((element) => {
       const component = element[0];
@@ -840,14 +816,17 @@ describe("Composer subject", () => {
       .and("equal", "test-composer");
   });
 
-  it("Shows subject prop if passed by user", () => {
-    cy.get("@testComponent").invoke("attr", "subject", "my test subject");
-    cy.get("header").contains("my test subject");
-    cy.get("input.subject").invoke("val").should("eq", "my test subject");
+  it("Sets subject", () => {
+    cy.get("@testComponent").then((element) => {
+      element[0].value = { subject: "Test subject" };
+    });
+
+    cy.get("input[name=subject]").should("have.value", "Test subject");
+    cy.get("header span:eq(0)").contains("Test subject").should("be.visible");
   });
 
-  it("Shows default subject if subject prop is not passed", () => {
-    cy.get("header").contains("New Message");
+  it("Sets default subject if no subject is set", () => {
+    cy.get("header span:eq(0)").contains("New Message");
     cy.get("input.subject").invoke("val").should("eq", "New Message");
   });
 });

--- a/components/composer/src/init.spec.js
+++ b/components/composer/src/init.spec.js
@@ -468,31 +468,26 @@ describe("Composer customizations", () => {
   });
 
   it("Replaces merge fields as defined in replace_fields when passed as a strinigfied version", () => {
-    cy.get("@composer").then((el) => {
-      const component = el[0];
-      component.value = {
-        body: `[hi] what up!<br />
+    const value = {
+      body: `[hi] what up!<br />
       <br />
       <br />
       Thanks,
       -Phil`,
-      };
-    });
+    };
 
-    cy.get("@composer").then((el) => {
-      const component = el[0];
-      component.setAttribute(
-        "replace_fields",
-        '[{"from": "[hi]", "to": "hello"}]',
-      );
-      cy.get(".html-editor[contenteditable=true]")
-        .invoke("prop", "innerHTML")
-        .then((html) => {
-          expect(html).to.equal(
-            "hello what up!<br>\n      <br>\n      <br>\n      Thanks,\n      -Phil",
-          );
-        });
-    });
+    cy.get("@composer").invoke("prop", "value", value);
+    cy.get("@composer").invoke("prop", "replace_fields", [
+      { from: "[hi]", to: "hello" },
+    ]);
+    cy.get(".html-editor[contenteditable=true]").should("exist");
+    cy.get(".html-editor[contenteditable=true]")
+      .invoke("prop", "innerHTML")
+      .then((html) => {
+        expect(html).to.equal(
+          "hello what up!<br>\n      <br>\n      <br>\n      Thanks,\n      -Phil",
+        );
+      });
   });
 
   it("Replaces merge fields as defined in replace_fields when passed a prop", () => {

--- a/components/composer/src/properties.json
+++ b/components/composer/src/properties.json
@@ -130,5 +130,12 @@
     "type": "boolean",
     "options": [true, false],
     "value": true
+  },
+  {
+    "label": "subject",
+    "title": "Message subject",
+    "type": "string",
+    "value": "",
+    "noPreview": true
   }
 ]

--- a/components/composer/src/properties.json
+++ b/components/composer/src/properties.json
@@ -20,10 +20,9 @@
   },
   {
     "label": "value",
-    "title": "Message value",
-    "type": "string",
-    "value": "",
-    "noPreview": true
+    "title": "Message object that you can pass in",
+    "type": "Message",
+    "value": { "subject": "string" }
   },
   {
     "label": "minimized",
@@ -130,12 +129,5 @@
     "type": "boolean",
     "options": [true, false],
     "value": true
-  },
-  {
-    "label": "subject",
-    "title": "Message subject",
-    "type": "string",
-    "value": "",
-    "noPreview": true
   }
 ]

--- a/components/contact-list/src/init.spec.js
+++ b/components/contact-list/src/init.spec.js
@@ -247,7 +247,7 @@ describe("Optional Prop Handling", () => {
     cy.get("label.entry.filter").contains("Filter by email: ");
     cy.get("input#show-filter-input").should("exist");
     cy.get("input#show-filter-input").type("nylascypresstest");
-    cy.get("nylas-contact-list").find(".contact").should("have.length", 2);
+    cy.get("nylas-contact-list").find(".contact").should("have.length", 3);
   });
 
   it("Component loads and works for sort_by=last_emailed when account has email & contact scopes", () => {


### PR DESCRIPTION
# Code changes

- Added reactive `subject` var that uses either `value.subject` or `$message.subject` (store value)

- Added tests for manually passed, and default subject prop scenarios

# Readiness checklist

- [ ] Added changes to component `CHANGELOG.md`
- [x] New property added? make sure to update `component/src/properties.json`
- [ ] Cypress tests passing?
- [x] New cypress tests added?
- [ ] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
