### PR TITLE
[mailbox] add workaround for pagination when using keyword_to_search

### DIFF
--- a/commons/src/connections/threads.ts
+++ b/commons/src/connections/threads.ts
@@ -55,7 +55,9 @@ export const fetchSearchResultThreads = (
 ): Promise<Thread[]> => {
   const queryString = `${getMiddlewareApiUrl(
     query.component_id,
-  )}/threads/search?q=${query.keywordToSearch}&view=expanded`;
+  )}/threads/search?q=${query.keywordToSearch}&view=expanded&limit=${
+    query.query.limit
+  }&offset=${query.query.offset}`;
 
   return fetch(queryString, getFetchConfig(query))
     .then(async (response) =>

--- a/components/mailbox/CHANGELOG.md
+++ b/components/mailbox/CHANGELOG.md
@@ -1,8 +1,10 @@
-# v1.1.6 (Unreleased)
+# Unreleased
 
+## Breaking
 ## New Features
 
-- Added ability to reply to email/thread [#228](https://github.com/nylas/components/issues/228)
+- [Mailbox] Add pagination when `keyword_to_search` is used [#313](https://github.com/nylas/components/pull/313)
+- [Mailbox] Added ability to reply to email/thread [#311](https://github.com/nylas/components/pull/311)
 - Added dispatched event `replyAllClicked` with properties
   - event
   - message

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -77,9 +77,13 @@
   let displayedThreadsPromise: Promise<Thread[]>;
 
   // paginations vars
+  const DEFAULT_NUM_PAGES = 1;
   let currentPage: number = 0;
-  let numPages: number = 1;
+  let numPages: number = DEFAULT_NUM_PAGES;
   let numThreads: number = 0;
+
+  // pagination when searching threads is limited to limit and offset, this cursor keeps track of the offset
+  let searchCursor: number = 0;
 
   onMount(async () => {
     await tick();
@@ -156,8 +160,11 @@
         new URLSearchParams(_this.query_string?.replaceAll(" ", "&")),
       ),
     };
+
     if (_this.keyword_to_search) {
       query.keywordToSearch = _this.keyword_to_search;
+      query.query.limit = _this.items_per_page + 1; // add one to check if there is another page of threads
+      query.query.offset = searchCursor;
     }
   }
 
@@ -197,7 +204,21 @@
           query,
           forceRefresh,
         );
+
         threads = (await displayedThreadsPromise) ?? [];
+
+        // We only display the number of messages in _this.items_per_page
+        if (_this.items_per_page + 1 === threads.length) {
+          if (searchCursor === 0) {
+            numPages = DEFAULT_NUM_PAGES + 1; // there is 1 more item in _this.items_per_page, meaning there's another page
+          } else {
+            numPages =
+              DEFAULT_NUM_PAGES +
+              Math.ceil(searchCursor / _this.items_per_page) +
+              1;
+          }
+          threads.pop(); // there is one additional item in threads to check for next page, we remove it to only display _this.items_per_page
+        }
       } else {
         displayedThreadsPromise = MailboxStore.getThreads(
           query,
@@ -494,8 +515,13 @@
   //#region pagination
   async function changePage(event: CustomEvent) {
     loading = true;
+
     currentPage = event.detail.newPage;
+
+    searchCursor = _this.items_per_page * currentPage;
+
     await updateDisplayedThreads();
+
     loading = false;
   }
   //#endregion pagination
@@ -914,13 +940,14 @@
             {/if} is empty!
           </div>
         {/each}
-        {#if !_this.keyword_to_search && threads && threads.length > 0}
+        {#if threads && threads.length > 0}
           <pagination-nav
             current_page={currentPage}
             items_per_page={_this.items_per_page}
             num_pages={numPages}
             num_items={numThreads}
             visible={true}
+            num_pages_visible={!_this.keyword_to_search}
             on:changePage={changePage}
           />
         {/if}

--- a/components/mailbox/src/components/PaginationNav.svelte
+++ b/components/mailbox/src/components/PaginationNav.svelte
@@ -5,6 +5,7 @@
   export let items_per_page: number;
   export let num_pages: number = 1;
   export let num_items: number;
+  export let num_pages_visible: boolean = true;
 
   import { getEventDispatcher } from "@commons/methods/component";
   import { get_current_component } from "svelte/internal";
@@ -64,17 +65,19 @@
 </style>
 
 <nav class="pagination-nav">
-  <span class="page-indicator">
-    <span class="page-start">
-      {current_page * items_per_page + 1}
+  {#if num_pages_visible}
+    <span class="page-indicator">
+      <span class="page-start">
+        {current_page * items_per_page + 1}
+      </span>
+      -
+      <span class="page-end">
+        {Math.min((current_page + 1) * items_per_page, num_items)}
+      </span>
+      of
+      <span class="total">{num_items}</span>
     </span>
-    -
-    <span class="page-end">
-      {Math.min((current_page + 1) * items_per_page, num_items)}
-    </span>
-    of
-    <span class="total">{num_items}</span>
-  </span>
+  {/if}
   {#if num_pages > 1}
     <button
       class="paginate-btn first-btn"
@@ -90,8 +93,6 @@
     >
       <BackIcon style="width: 24px; height: 24px;" />
     </button>
-  {/if}
-  {#if num_pages > 1}
     <button
       class="paginate-btn next-btn"
       on:click={() => changePage(current_page + 1)}


### PR DESCRIPTION
# Code changes

- [x] `offset` and `limit` query params added to `fetchSearchResultThreads`
- [x] [num_page_visible](https://github.com/nylas/components/compare/kg/sc-77531/mailbox-fetch-search-threads-workaround?expand=1#diff-189566464b8c2b488ae80c9c80d2423a92052098ab19a21d4d17bd858088a314R8) prop  added to `PaginationNav.svelte`

# Screenshot
Notice that requests are fetched only when new threads are requested. The example below has a `items_per_page` of `3`.
https://user-images.githubusercontent.com/34139730/148395656-ac5d0880-f52e-4d43-82b4-96c97749fdd4.mov





# Readiness checklist

- [x] Added changes to component `CHANGELOG.md`

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
