### PR TITLE
[mailbox] scroll into latest message when thread is opened

### DIFF
--- a/components/mailbox/CHANGELOG.md
+++ b/components/mailbox/CHANGELOG.md
@@ -25,6 +25,7 @@
 ## Bug Fixes
 
 - Updated border style + variables [#270](https://github.com/nylas/components/pull/270)
+- Scroll to latest message when thread is expanded [#314](https://github.com/nylas/components/pull/314)
 - Message content of emails failed to load if they were accessed while pagination was in progress [311](https://github.com/nylas/components/pull/311)
 - Fixed some attached files being treated as inline [283](https://github.com/nylas/components/pull/283)
 - Fixed TypeError was being thrown if all_threads prop was used and user clicked a message to expand it's body [315](https://github.com/nylas/components/pull/315)

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -310,6 +310,7 @@
         query,
         currentPage,
       );
+
       if (FilesStore.hasInlineFiles(message)) {
         message = await getMessageWithInlineFiles(message);
         threads = MailboxStore.hydrateMessageInThread(
@@ -318,6 +319,7 @@
           currentPage,
         );
       }
+
       if (currentlySelectedThread) {
         currentlySelectedThread.messages =
           currentlySelectedThread.messages?.map((currentMessage) =>


### PR DESCRIPTION
# Code changes

- [x] add a scroll to last message in expanded thread

# Screenshots

https://user-images.githubusercontent.com/34139730/148403258-ef49e328-58f8-4d43-9857-c9034909b55d.mov

Component should scroll in the `email-container` and not the entire window in cases where this component is not full screen.
https://user-images.githubusercontent.com/34139730/149184809-b80c4d79-145c-4a03-85ea-a2ca988a8813.mov


# Readiness checklist

- [x] Added changes to component `CHANGELOG.md`

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
