### PR TITLE
Mailbox component - Fixed type error occurring when `all_threads` prop is used and a message is clicked & fixed duplicate `threadClicked` dispatch event

### DIFF
--- a/components/composer/src/init.spec.js
+++ b/components/composer/src/init.spec.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-xdescribe("Composer loading state", () => {
+describe("Composer loading state", () => {
   it("displays loading screen", () => {
     cy.visit("/components/composer/src/cypress.html");
 
@@ -8,7 +8,7 @@ xdescribe("Composer loading state", () => {
   });
 });
 
-xdescribe("Composer dispatches events", () => {
+describe("Composer dispatches events", () => {
   const eventsFired = {
     minimized: false,
     maximized: false,
@@ -96,7 +96,7 @@ xdescribe("Composer dispatches events", () => {
   });
 });
 
-xdescribe("Composer `to` prop", () => {
+describe("Composer `to` prop", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -151,7 +151,7 @@ xdescribe("Composer `to` prop", () => {
   });
 });
 
-xdescribe("Composer interactions", () => {
+describe("Composer interactions", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -273,10 +273,9 @@ describe("Composer customizations", () => {
       { fixture: "composer/manifest.json" },
     ).as("getMiddlewareManifest");
 
-    cy.intercept(
-      "GET",
-      "https://web-components.nylas.com/middleware/account",
-    ).as("getMiddlewareAccount");
+    cy.intercept("GET", "https://web-components.nylas.com/middleware/account", {
+      fixture: "composer/manifest.json",
+    }).as("getMiddlewareAccount");
 
     cy.intercept("GET", "/users", [
       { name: "Test User", email: "tester@nylas.com" },
@@ -286,6 +285,7 @@ describe("Composer customizations", () => {
     cy.visit("/components/composer/src/cypress.html");
 
     cy.get("nylas-composer").should("exist").as("composer");
+    cy.wait(["@getMiddlewareManifest", "@getMiddlewareAccount"]);
   });
 
   it("show header", () => {
@@ -515,7 +515,7 @@ describe("Composer customizations", () => {
   });
 });
 
-xdescribe("Composer integration", () => {
+describe("Composer integration", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -646,7 +646,7 @@ xdescribe("Composer integration", () => {
   });
 });
 
-xdescribe("Composer callbacks and options", () => {
+describe("Composer callbacks and options", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -702,7 +702,7 @@ xdescribe("Composer callbacks and options", () => {
   });
 });
 
-xdescribe("Composer file upload", () => {
+describe("Composer file upload", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -800,7 +800,7 @@ xdescribe("Composer file upload", () => {
   });
 });
 
-xdescribe("Composer subject", () => {
+describe("Composer subject", () => {
   beforeEach(() => {
     cy.visitComponentPage(
       "/components/composer/src/index.html",

--- a/components/composer/src/init.spec.js
+++ b/components/composer/src/init.spec.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-describe("Composer loading state", () => {
+xdescribe("Composer loading state", () => {
   it("displays loading screen", () => {
     cy.visit("/components/composer/src/cypress.html");
 
@@ -8,7 +8,7 @@ describe("Composer loading state", () => {
   });
 });
 
-describe("Composer dispatches events", () => {
+xdescribe("Composer dispatches events", () => {
   const eventsFired = {
     minimized: false,
     maximized: false,
@@ -96,7 +96,7 @@ describe("Composer dispatches events", () => {
   });
 });
 
-describe("Composer `to` prop", () => {
+xdescribe("Composer `to` prop", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -151,7 +151,7 @@ describe("Composer `to` prop", () => {
   });
 });
 
-describe("Composer interactions", () => {
+xdescribe("Composer interactions", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -273,9 +273,10 @@ describe("Composer customizations", () => {
       { fixture: "composer/manifest.json" },
     ).as("getMiddlewareManifest");
 
-    cy.intercept("GET", "https://web-components.nylas.com/middleware/account", {
-      fixture: "composer/manifest.json", // We don't want account loaded so from field is empty
-    }).as("getMiddlewareAccount");
+    cy.intercept(
+      "GET",
+      "https://web-components.nylas.com/middleware/account",
+    ).as("getMiddlewareAccount");
 
     cy.intercept("GET", "/users", [
       { name: "Test User", email: "tester@nylas.com" },
@@ -514,7 +515,7 @@ describe("Composer customizations", () => {
   });
 });
 
-describe("Composer integration", () => {
+xdescribe("Composer integration", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -645,7 +646,7 @@ describe("Composer integration", () => {
   });
 });
 
-describe("Composer callbacks and options", () => {
+xdescribe("Composer callbacks and options", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -701,7 +702,7 @@ describe("Composer callbacks and options", () => {
   });
 });
 
-describe("Composer file upload", () => {
+xdescribe("Composer file upload", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -799,7 +800,7 @@ describe("Composer file upload", () => {
   });
 });
 
-describe("Composer subject", () => {
+xdescribe("Composer subject", () => {
   beforeEach(() => {
     cy.visitComponentPage(
       "/components/composer/src/index.html",

--- a/components/mailbox/CHANGELOG.md
+++ b/components/mailbox/CHANGELOG.md
@@ -23,8 +23,10 @@
 ## Bug Fixes
 
 - Updated border style + variables [#270](https://github.com/nylas/components/pull/270)
-- Message content of emails failed to load if they were accessed while pagination was in progress
+- Message content of emails failed to load if they were accessed while pagination was in progress [311](https://github.com/nylas/components/pull/311)
 - Fixed some attached files being treated as inline [283](https://github.com/nylas/components/pull/283)
+- Fixed TypeError was being thrown if all_threads prop was used and user clicked a message to expand it's body [315](https://github.com/nylas/components/pull/315)
+- Fixed dispatched event `threadClicked` being dispatched multiple times on a single click [315](https://github.com/nylas/components/pull/315)
 
 # v1.1.5 (2021-12-15)
 

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -247,13 +247,11 @@
         );
       }
       if (currentlySelectedThread) {
-        currentlySelectedThread = {
-          ...currentlySelectedThread,
-          messages:
-            currentlySelectedThread.messages?.map((currentMessage) =>
-              currentMessage.id === message.id ? message : currentMessage,
-            ) ?? [],
-        };
+        currentlySelectedThread.messages =
+          currentlySelectedThread.messages?.map((currentMessage) =>
+            currentMessage.id === message.id ? message : currentMessage,
+          ) ?? [];
+        currentlySelectedThread = currentlySelectedThread;
       }
     }
   }
@@ -300,13 +298,11 @@
         );
       }
       if (currentlySelectedThread) {
-        currentlySelectedThread = {
-          ...currentlySelectedThread,
-          messages:
-            currentlySelectedThread.messages?.map((currentMessage) =>
-              currentMessage.id === message.id ? message : currentMessage,
-            ) ?? [],
-        };
+        currentlySelectedThread.messages =
+          currentlySelectedThread.messages?.map((currentMessage) =>
+            currentMessage.id === message.id ? message : currentMessage,
+          ) ?? [];
+        currentlySelectedThread = currentlySelectedThread;
       }
     }
   }

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -231,7 +231,7 @@
   async function messageClicked(event: CustomEvent) {
     let message = event.detail.message;
 
-    if (message && currentlySelectedThread) {
+    if (!_this.all_threads && message && currentlySelectedThread) {
       message = await fetchIndividualMessage(message);
       threads = MailboxStore.hydrateMessageInThread(
         message,
@@ -277,7 +277,6 @@
   async function threadClicked(event: CustomEvent) {
     const thread = event.detail.thread;
 
-    dispatchEvent("threadClicked", { event, thread });
     currentlySelectedThread = thread;
     if (!_this.all_threads && thread?.expanded) {
       if (thread.unread) {

--- a/components/mailbox/src/init.spec.js
+++ b/components/mailbox/src/init.spec.js
@@ -75,7 +75,7 @@ describe("MailBox  component", () => {
     cy.visitMailbox();
   });
 
-  xit("Shows Mailbox with demo id and threads", () => {
+  it("Shows Mailbox with demo id and threads", () => {
     const nylasEmail = cy
       .get("nylas-mailbox")
       .shadow()
@@ -675,6 +675,36 @@ describe("MailBox  component", () => {
   });
 
   describe("Custom data", () => {
+    it("Should successfully update a thread's message body when threadClicked is called", () => {
+      cy.get("nylas-mailbox")
+        .as("mailbox")
+        .then((element) => {
+          const body = "This is a custom body";
+          const component = element[0];
+          component.addEventListener("threadClicked", function (v) {
+            let { thread } = v.detail;
+            thread = {
+              ...thread,
+              messages: thread.messages.map((m) => {
+                m.body = body;
+                return m;
+              }),
+            };
+          });
+          component.all_threads = threads;
+
+          const cyComponent = cy.wrap(component);
+          cyComponent.find(".email-row.condensed").then((emailRowElement) => {
+            const firstEmailRowElement = emailRowElement[0];
+            firstEmailRowElement.click();
+            cy.get("@mailbox")
+              .shadow()
+              .find("nylas-message-body", { timeout: 5000 })
+              .contains(body);
+          });
+        });
+    });
+
     it("Should toggle between threads via props and fetched threads", () => {
       cy.get("nylas-mailbox")
         .as("mailbox")


### PR DESCRIPTION
# Implementation
- [x] Under `messageClicked` added a check to ensure that we only run the hydration function if `all_threads` prop is NOT used.
- [x] Fixed: dispatched event `threadClicked` being dispatched multiple times
- [x] Fixed: Email stays expanded after clicking return back to mailbox [sc-77743](https://app.shortcut.com/nylas/story/77743/mailbox-expanding-an-email-and-clicking-the-back-to-mailbox-button-will-sometimes-leave-the-email-expanded)

Story details: https://app.shortcut.com/nylas/story/77587