### PR TITLE
[Composer]: Updated file size error copy, added tooltip label for attach icon

### DIFF
--- a/components/composer/CHANGELOG.md
+++ b/components/composer/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Reset sendSuccess when composer is opened and closed [#300](https://github.com/nylas/components/pull/300)
 - Added a prop 'reset_after_close' which resets after closing[#301](https://github.com/nylas/components/pull/301)
 - Attachment icon size was too small making it inaccessible
+- Updated file size error copy, added tooltip label for attach icon[#317](https://github.com/nylas/components/pull/317)
 
 ## Breaking
 

--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -243,7 +243,7 @@
       if (beforeFileUpload) beforeFileUpload(file);
 
       if (file.size >= 4000000) {
-        throw "Error: File size is too large.";
+        throw `Maximum file size is 4MB. Please upload a different file.`;
       }
 
       const result = uploadFile
@@ -861,7 +861,11 @@
       </main>
       <footer>
         {#if _this.show_attachment_button && (id || uploadFile)}
-          <label for="file-upload" class="composer-btn file-upload">
+          <label
+            for="file-upload"
+            class="composer-btn file-upload"
+            title="Attach Files (Up to 4MB)"
+          >
             <AttachmentIcon class="AttachmentIcon" />
             <span class="sr-only">Attach Files</span>
           </label>

--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -864,7 +864,7 @@
           <label
             for="file-upload"
             class="composer-btn file-upload"
-            title="Attach Files (Up to 4MB)"
+            title="Attach Files (up to 4MB)"
           >
             <AttachmentIcon class="AttachmentIcon" />
             <span class="sr-only">Attach Files</span>


### PR DESCRIPTION
# Code changes

- Changed error message to `Maximum file size is 4MB. Please upload a different file.` as per Kelly's suggestion
- Added a tooltip label to attach icon `Attach files (up to 4MB)`

# Screenshot (after)
![image](https://user-images.githubusercontent.com/16315004/148597495-080f66b7-3645-4b12-9ece-ff0ac6431d80.png)
![image](https://user-images.githubusercontent.com/16315004/148597535-16be7ed0-bf00-4ae1-8fe5-b4487cf18a31.png)


# Readiness checklist

- [X] Added changes to component `CHANGELOG.md`
- [X] Cypress tests passing?
- [X] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
