### PR TITLE
[Mailbox]: Show confirmation pop up, when deleting emails

### DIFF
--- a/components/email/CHANGELOG.md
+++ b/components/email/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## New Features
 
 - [Email] Show CC participants when reply all button is clicked [#319](https://github.com/nylas/components/pull/319)
+- [Email] Added ability to forward email [#320](https://github.com/nylas/components/pull/320)
 
 ## Bug Fixes
 

--- a/components/mailbox/CHANGELOG.md
+++ b/components/mailbox/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 ## Breaking
+
 ## New Features
 
 - [Mailbox] Add pagination when `keyword_to_search` is used [#313](https://github.com/nylas/components/pull/313)
@@ -21,6 +22,8 @@
   - to
   - from
   - subject
+- Added ability to forward email [#320](https://github.com/nylas/components/pull/320)
+- Show confirmation pop up, when deleting emails
 
 ## Bug Fixes
 

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -72,7 +72,7 @@
   };
 
   let mouseEvent: CustomEvent;
-  const showConfirmDelete: {
+  const confirmDeleteModal: {
     isOpen: boolean;
     type: string;
     event: CustomEvent;
@@ -464,22 +464,22 @@
     });
   }
 
-  function confirmDelete(event: CustomEvent, type = "") {
-    showConfirmDelete.isOpen = true;
-    showConfirmDelete.event = event;
-    showConfirmDelete.type = type;
+  function showConfirmDeleteModal(event: CustomEvent, type = "") {
+    confirmDeleteModal.isOpen = true;
+    confirmDeleteModal.event = event;
+    confirmDeleteModal.type = type;
   }
 
-  function handleConfirmDeleteClicked() {
-    if (showConfirmDelete.type === "selected") {
-      onDeleteSelected(showConfirmDelete.event);
+  function confirmDeleteClickHandler() {
+    if (confirmDeleteModal.type === "selected") {
+      onDeleteSelected(confirmDeleteModal.event);
     } else {
-      deleteThread(showConfirmDelete.event);
+      deleteThread(confirmDeleteModal.event);
     }
-    // reset showConfirmDelete
-    showConfirmDelete.isOpen = false;
-    showConfirmDelete.type = "";
-    showConfirmDelete.event = mouseEvent;
+    // reset confirmDeleteModal
+    confirmDeleteModal.isOpen = false;
+    confirmDeleteModal.type = "";
+    confirmDeleteModal.event = mouseEvent;
   }
 
   async function deleteThread(event: CustomEvent) {
@@ -820,7 +820,7 @@
           on:threadStarred={threadStarred}
           on:returnToMailbox={returnToMailbox}
           on:toggleThreadUnreadStatus={toggleThreadUnreadStatus}
-          on:threadDeleted={confirmDelete}
+          on:threadDeleted={showConfirmDeleteModal}
           on:downloadClicked={downloadSelectedFile}
         />
       </div>
@@ -869,7 +869,7 @@
                   disabled={!threads.filter((thread) => thread.selected).length}
                   aria-label="Delete selected email(s)"
                   on:click={(e) => {
-                    confirmDelete(e, "selected");
+                    showConfirmDeleteModal(e, "selected");
                   }}><TrashIcon /></button
                 >
               </div>
@@ -958,7 +958,7 @@
                     on:threadStarred={threadStarred}
                     on:returnToMailbox={returnToMailbox}
                     on:toggleThreadUnreadStatus={toggleThreadUnreadStatus}
-                    on:threadDeleted={confirmDelete}
+                    on:threadDeleted={showConfirmDeleteModal}
                     on:downloadClicked={downloadSelectedFile}
                     show_thread_actions={thread.selected}
                   />
@@ -999,8 +999,8 @@
   {/if}
 </main>
 
-{#if showConfirmDelete.isOpen}
-  <div class="overlay" on:click={() => (showConfirmDelete.isOpen = false)}>
+{#if confirmDeleteModal.isOpen}
+  <div class="overlay" on:click={() => (confirmDeleteModal.isOpen = false)}>
     <div class="modal">
       {#await threads.filter((thread) => thread.selected).length > 1 then isDeletingMultipleEmails}
         <h3 class="title">
@@ -1016,12 +1016,12 @@
         </p>
       {/await}
       <div class="footer">
-        <button class="danger" on:click={handleConfirmDeleteClicked}>
+        <button class="danger" on:click={confirmDeleteClickHandler}>
           Confirm
         </button>
         <button
           class="cancel"
-          on:click={() => (showConfirmDelete.isOpen = false)}
+          on:click={() => (confirmDeleteModal.isOpen = false)}
         >
           Cancel
         </button>

--- a/components/mailbox/src/init.spec.js
+++ b/components/mailbox/src/init.spec.js
@@ -480,9 +480,8 @@ describe("MailBox  component", () => {
     });
   });
 
-  describe("Delete action", () => {
-    // TODO: write when Folders are implemented
-    xit("Should delete selected email", () => {
+  describe.only("Delete action", () => {
+    it("Should show delete confirmation pop up", () => {
       cy.get("nylas-mailbox")
         .as("mailbox")
         .then((element) => {
@@ -499,6 +498,20 @@ describe("MailBox  component", () => {
             .find("div.delete")
             .find("button")
             .click();
+          // Clicking delete should open modal
+          cy.get(".modal").should("exist");
+          // Clicking cancel should close the modal
+          cy.get(".modal").find("button.cancel").click();
+          cy.get(".modal").should("not.exist");
+
+          cy.get("div[role='toolbar']")
+            .find("div.delete")
+            .find("button")
+            .click();
+          cy.get(".modal").should("exist");
+          // Clicking confirm should delete email and close modal
+          cy.get(".modal").find("button.danger").click();
+          cy.get(".modal").should("not.exist");
           cy.get("nylas-email").should("have.length", threads.length - 1);
         });
     });

--- a/components/mailbox/src/init.spec.js
+++ b/components/mailbox/src/init.spec.js
@@ -480,43 +480,6 @@ describe("MailBox  component", () => {
     });
   });
 
-  describe("Delete action", () => {
-    it("Should show delete confirmation pop up", () => {
-      cy.get("nylas-mailbox")
-        .as("mailbox")
-        .then((element) => {
-          const component = element[0];
-          component.all_threads = threads;
-          component.actions_bar = ["delete"];
-          cy.get("nylas-email").should("have.length", threads.length);
-          cy.get(component)
-            .find("div.checkbox-container")
-            .first()
-            .find("input")
-            .check();
-          cy.get("div[role='toolbar']")
-            .find("div.delete")
-            .find("button")
-            .click();
-          // Clicking delete should open modal
-          cy.get(".modal").should("exist");
-          // Clicking cancel should close the modal
-          cy.get(".modal").find("button.cancel").click();
-          cy.get(".modal").should("not.exist");
-
-          cy.get("div[role='toolbar']")
-            .find("div.delete")
-            .find("button")
-            .click();
-          cy.get(".modal").should("exist");
-          // Clicking confirm should delete email and close modal
-          cy.get(".modal").find("button.danger").click();
-          cy.get(".modal").should("not.exist");
-          cy.get("nylas-email").should("have.length", threads.length - 1);
-        });
-    });
-  });
-
   describe("Bulk actions", () => {
     it("Should mark all unread then read", () => {
       cy.get("nylas-mailbox")
@@ -683,6 +646,43 @@ describe("MailBox  component", () => {
             .click();
           cy.get(component).find("nylas-email").should("not.exist");
           cy.get(component).find("mailbox-empty").should("exist");
+        });
+    });
+  });
+
+  describe("Delete action", () => {
+    it("Should show delete confirmation pop up", () => {
+      cy.get("nylas-mailbox")
+        .as("mailbox")
+        .then((element) => {
+          const component = element[0];
+          component.all_threads = threads;
+          component.actions_bar = ["delete"];
+          cy.get("nylas-email").should("have.length", threads.length);
+          cy.get(component)
+            .find("div.checkbox-container")
+            .first()
+            .find("input")
+            .check();
+          cy.get("div[role='toolbar']")
+            .find("div.delete")
+            .find("button")
+            .click();
+          // Clicking delete should open modal
+          cy.get(".modal").should("exist");
+          // Clicking cancel should close the modal
+          cy.get(".modal").find("button.cancel").click();
+          cy.get(".modal").should("not.exist");
+
+          cy.get("div[role='toolbar']")
+            .find("div.delete")
+            .find("button")
+            .click();
+          cy.get(".modal").should("exist");
+          // Clicking confirm should delete email and close modal
+          cy.get(".modal").find("button.danger").click();
+          cy.get(".modal").should("not.exist");
+          cy.get("nylas-email").should("have.length", threads.length - 1);
         });
     });
   });

--- a/components/mailbox/src/init.spec.js
+++ b/components/mailbox/src/init.spec.js
@@ -480,7 +480,7 @@ describe("MailBox  component", () => {
     });
   });
 
-  describe.only("Delete action", () => {
+  describe("Delete action", () => {
     it("Should show delete confirmation pop up", () => {
       cy.get("nylas-mailbox")
         .as("mailbox")

--- a/components/mailbox/src/styles/modal.scss
+++ b/components/mailbox/src/styles/modal.scss
@@ -1,0 +1,89 @@
+@mixin modal-styles {
+  // #region modal-style
+  .overlay {
+    background: rgba(0, 0, 0, 0.5);
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1001;
+    overflow-x: hidden;
+    overflow-y: auto;
+    display: grid;
+    justify-content: center;
+    align-items: center;
+    .modal {
+      position: relative;
+      width: calc(100% - 5rem);
+      margin: 1rem;
+
+      z-index: 1002;
+
+      background-color: white;
+      padding: 1.5rem;
+      display: flex;
+      align-items: center;
+      flex-direction: column;
+
+      .title {
+        font-family: sans-serif;
+        font-style: normal;
+        font-weight: bold;
+        font-size: 20px;
+        line-height: 28px;
+
+        display: flex;
+        align-items: center;
+
+        color: var(--black);
+      }
+
+      .description {
+        font-family: sans-serif;
+        font-style: normal;
+        font-weight: normal;
+        font-size: 16px;
+        line-height: 24px;
+        color: #636671;
+        margin-top: 0.5rem;
+      }
+
+      .footer {
+        width: inherit;
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+        gap: 0.75rem;
+        margin-top: 1.5rem;
+
+        button {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          font-family: sans-serif;
+          border-radius: 4px;
+          padding: 1rem;
+          height: 1.5rem;
+          width: 4.5rem;
+          cursor: pointer;
+          &.danger {
+            background: #ee3248;
+            color: white;
+          }
+          &.cancel {
+            background: transparent;
+          }
+        }
+      }
+    }
+  }
+  @media #{$desktop} {
+    .overlay {
+      .modal {
+        width: 365px;
+      }
+    }
+  }
+  // #endregion modal-style
+}

--- a/components/schedule-editor/src/init.spec.js
+++ b/components/schedule-editor/src/init.spec.js
@@ -20,12 +20,12 @@ describe("schedule-editor component", () => {
   describe("Allows for multiple meetings", () => {
     it("Allows the user to add consecutive meetings", () => {
       cy.get(".basic-details button.add-event").click();
-      cy.get(".basic-details fieldset").should("have.length", 2);
-      cy.get(".basic-details button.add-event").click();
       cy.get(".basic-details fieldset").should("have.length", 3);
+      cy.get(".basic-details button.add-event").click();
+      cy.get(".basic-details fieldset").should("have.length", 4);
       cy.get(".basic-details button.remove-event").eq(0).click();
       cy.get(".basic-details button.remove-event").eq(0).click();
-      cy.get(".basic-details fieldset").should("have.length", 1);
+      cy.get(".basic-details fieldset").should("have.length", 2);
     });
   });
 });


### PR DESCRIPTION
# Code changes

- Added a confirmation modal when delete email in clicked
- Extracted modal styles into `styles/modal.scss`
- Added test for the modal, cancel & confirm button actions

For the time being (until we have a solid way for implementing child components with styles), added the modal element within Mailbox.

# Figma
![image](https://user-images.githubusercontent.com/16315004/149228886-0059da71-29d2-44aa-9221-2e39dbc47e64.png)

# Screenshot
![image](https://user-images.githubusercontent.com/16315004/149226100-142df1d5-6fa0-4a38-9a73-fdaee4c6706a.png)
![image](https://user-images.githubusercontent.com/16315004/149226130-5777958b-0af0-4c0a-bdb8-9744d49be68d.png)

# Readiness checklist

- [X] Added changes to component `CHANGELOG.md`
- [X] Cypress tests passing?
- [X] New cypress tests added?
- [X] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
