### PR TITLE
[Mailbox]: Pass z-index to modal, overlay and fix for footer buttons in mobile

### DIFF
--- a/components/mailbox/CHANGELOG.md
+++ b/components/mailbox/CHANGELOG.md
@@ -24,6 +24,7 @@
   - subject
 - Added ability to forward email [#320](https://github.com/nylas/components/pull/320)
 - Show confirmation pop up, when deleting emails
+- Pass z-index css to confirmation pop up's modal & overalay using css variables `z-index-modal` & `z-index-overlay` respectively
 
 ## Bug Fixes
 

--- a/components/mailbox/CHANGELOG.md
+++ b/components/mailbox/CHANGELOG.md
@@ -24,7 +24,7 @@
   - subject
 - Added ability to forward email [#320](https://github.com/nylas/components/pull/320)
 - Show confirmation pop up, when deleting emails
-- Pass z-index css to confirmation pop up's modal & overalay using css variables `z-index-modal` & `z-index-overlay` respectively
+- Pass z-index css to confirmation pop up's modal & overlay using css variables `z-index-modal` & `z-index-overlay` respectively
 
 ## Bug Fixes
 

--- a/components/mailbox/src/styles/modal.scss
+++ b/components/mailbox/src/styles/modal.scss
@@ -7,7 +7,7 @@
     left: 0;
     width: 100%;
     height: 100%;
-    z-index: 1001;
+    z-index: var(--z-index-overlay, 1001);
     overflow-x: hidden;
     overflow-y: auto;
     display: grid;
@@ -18,7 +18,7 @@
       width: calc(100% - 5rem);
       margin: 1rem;
 
-      z-index: 1002;
+      z-index: var(--z-index-modal, 1002);
 
       background-color: white;
       padding: 1.5rem;
@@ -50,7 +50,7 @@
       }
 
       .footer {
-        width: inherit;
+        width: 100%;
         display: flex;
         justify-content: flex-start;
         align-items: center;
@@ -82,6 +82,10 @@
     .overlay {
       .modal {
         width: 365px;
+
+        .footer {
+          width: inherit;
+        }
       }
     }
   }


### PR DESCRIPTION
# Code changes

- Added css variables `z-index-overlay` & `z-index-modal` for `overlay` & `modal` respectively
- Fixed footer button alignment on mobile

# Readiness checklist

- [X] Added changes to component `CHANGELOG.md`
- [X] Cypress tests passing?
- [X] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
