### PR TITLE
[Mailbox][Modal]: Removed width & height on the buttons and adjusted padding

### DIFF
--- a/components/mailbox/src/styles/modal.scss
+++ b/components/mailbox/src/styles/modal.scss
@@ -63,9 +63,7 @@
           align-items: center;
           font-family: sans-serif;
           border-radius: 4px;
-          padding: 1rem;
-          height: 1.5rem;
-          width: 4.5rem;
+          padding: 0.5rem 1rem;
           cursor: pointer;
           &.danger {
             background: #ee3248;


### PR DESCRIPTION
# Code changes

- Removed width & height on modal buttons
- Adjusted padding

The reason for doing this is because it is causing the buttons to not have any padding in customer's app.

![image](https://user-images.githubusercontent.com/16315004/150159882-e4f39c28-b161-4b76-a771-426314a24aa2.png)

