### PR TITLE
[composer] return focus to email textbox when formatting option clicked

### DIFF
--- a/components/composer/CHANGELOG.md
+++ b/components/composer/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Unreleased
+
+## Breaking
+
+## New Features
+
+## Bug Fixes
+
+- [Composer] focus the HTML editor textbox when a formatting option is clicked [#342](https://github.com/nylas/components/pull/342)
+
 # v1.1.6 (Unreleased)
 
 ## New Features

--- a/components/composer/src/components/HTMLEditor.svelte
+++ b/components/composer/src/components/HTMLEditor.svelte
@@ -7,7 +7,7 @@
   export let show_editor_toolbar: boolean;
   export let replace_fields: ReplaceFields[] | null = null;
 
-  let container: Element;
+  let container: HTMLDivElement;
   let toolbar: ToolbarItem[] = defaultActions;
 
   $: if (html) {
@@ -75,8 +75,15 @@
   }
 
   const handleAction = (item: ToolbarItem) => () => {
-    if (item.result) item.result();
+    if (item.result) {
+      item.result();
+    }
+
     updateToolbarUI();
+
+    if (container) {
+      container.focus();
+    }
   };
 
   // This function updates the toolbar UI state when you select text (eg. select bold text)
@@ -185,11 +192,12 @@
   {/if}
 
   <div
-    contenteditable="true"
-    class="html-editor"
-    on:keyup={updateToolbarUI}
-    on:mouseup={updateToolbarUI}
     bind:this={container}
     bind:innerHTML={html}
+    contenteditable="true"
+    class="html-editor"
+    role="textbox"
+    on:keyup={updateToolbarUI}
+    on:mouseup={updateToolbarUI}
   />
 </div>


### PR DESCRIPTION
# Code changes

- [x] adds focus back to textbox container when formatting button clicked.

# Screenshots

https://user-images.githubusercontent.com/34139730/150205496-4d95af82-dd2f-4201-80e2-d1148fe6fb1e.mov


# Readiness checklist

- [x] Added changes to component `CHANGELOG.md`

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
