### PR TITLE
[Mailbox]: Update thread when message is sent via composer

### DIFF
--- a/components/composer/src/Composer.wc.svelte
+++ b/components/composer/src/Composer.wc.svelte
@@ -332,6 +332,9 @@
           if (_this.reset_after_send) resetAfterSend($message.from);
           sendPending = false;
           sendSuccess = true;
+          dispatchEvent("messageSent", {
+            message: res,
+          });
         })
         .catch((err) => {
           if (afterSendError) afterSendError(err);

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -252,7 +252,7 @@
   //#endregion methods
 
   // Callbacks
-  export const sentMessageUpdate = async (message: Message): Promise<void> => {
+  export async function sentMessageUpdate (message: Message): Promise<void> {
     threads = MailboxStore.hydrateMessageInThread(message, query, currentPage);
   };
 

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -251,6 +251,11 @@
 
   //#endregion methods
 
+  // Callbacks
+  export const sentMessageUpdate = async (message: Message): Promise<void> => {
+    threads = MailboxStore.hydrateMessageInThread(message, query, currentPage);
+  };
+
   //#region actions
   let areAllSelected = false;
   $: areAllSelected = threads.some((thread) => thread.selected);

--- a/components/mailbox/src/index.html
+++ b/components/mailbox/src/index.html
@@ -61,7 +61,17 @@
           composer.classList.add("hidden");
         };
 
-        const events = ["replyClicked", "replyAllClicked", "forwardClicked", "draftThreadEvent"];
+        composer.addEventListener("messageSent", (event) => {
+          const message = event.detail.message;
+          mailbox.sentMessageUpdate(message);
+        });
+
+        const events = [
+          "replyClicked",
+          "replyAllClicked",
+          "forwardClicked",
+          "draftThreadEvent",
+        ];
         events.forEach((event) =>
           mailbox.addEventListener(event, (e) => toggleComposer(e, composer)),
         );


### PR DESCRIPTION
We want to update the mailbox as soon as someone sends a message using composer, without needing to refresh the page / mailbox. In order to to do this, we have to set up an event listener in `index.html` which can listen to composer when a message is sent and update mailbox accordingly.

# Code changes

- Added a dispatch event in composer `messageSent`
- Added an event listener in `index.html` which listens to `messageSent` event and calls `sentMessageUpdate` on mailbox component
- Added an exported function `sentMessageUpdate` to Mailbox which updates the existing thread with the message sent, thus not requiring a refresh

# Screenshot

https://user-images.githubusercontent.com/16315004/150214464-13b57f6c-f4cb-4dae-b2fa-5225010b38b7.mov

# Readiness checklist

- [X] Added changes to component `CHANGELOG.md`
- [X] Cypress tests passing?
- [ ] New cypress tests added?
- [X] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
