### PR TITLE
[Availability] Indicate that a slot in the past can't be booked

### DIFF
--- a/commons/src/types/Availability.ts
+++ b/commons/src/types/Availability.ts
@@ -79,7 +79,7 @@ export interface TimeSlot {
   expirySelection?: string;
   recurrence_cadence?: string;
   recurrence_expiry?: Date | string;
-  isBookable: boolean;
+  fallsWithinAllowedTimeRange: boolean;
 }
 
 export interface BookableSlot extends TimeSlot {

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -25,7 +25,6 @@
   import { timeWeek, timeDay, timeHour, timeMinute } from "d3-time";
   import { scaleTime, scaleLinear } from "d3-scale";
   import { lightenHexColour } from "@commons/methods/colour";
-
   import {
     SelectionStatus,
     AvailabilityStatus,
@@ -1054,7 +1053,7 @@
 
   // Expand hovered / clicked time slots to show the full consecutive event span
   function inspectConsecutiveBlock(slot: TimeSlot) {
-    if (!slot.isBookable) {
+    if (!slot.fallsWithinAllowedTimeRange) {
       return null;
     }
 
@@ -1222,6 +1221,14 @@
                   class:pending={event_to_hover && slot.selectionPending}
                   data-start-time={new Date(slot.start_time).toLocaleString()}
                   data-end-time={new Date(slot.end_time).toLocaleString()}
+                  class:outside-of-time-range={!slot.fallsWithinAllowedTimeRange}
+                  title={slot.fallsWithinAllowedTimeRange
+                    ? null
+                    : `You may only select timeslots in the future, between ${timeDay
+                        .offset(new Date(), min_book_ahead_days)
+                        .toLocaleDateString()} and ${timeDay
+                        .offset(new Date(), max_book_ahead_days)
+                        .toLocaleDateString()}`}
                   on:click={() => {
                     handleSlotInteractionStart(slot);
                   }}

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -70,9 +70,6 @@ describe("Booking time slots", () => {
     //Get the closest full hour prior to current time, slots fallsWithinAllowedTimeRange should be false
     cy.get(
       `button.slot.unselected[data-start-time="${currentHour.toLocaleString()}"]`,
-    ).should("have.class", "outside-of-time-range");
-    cy.get(
-      `button.slot.unselected[data-start-time="${currentHour.toLocaleString()}"]`,
     )
       .first()
       .click();

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -70,6 +70,9 @@ describe("Booking time slots", () => {
     //Get the closest full hour prior to current time, slots fallsWithinAllowedTimeRange should be false
     cy.get(
       `button.slot.unselected[data-start-time="${currentHour.toLocaleString()}"]`,
+    ).should("have.class", "outside-of-time-range");
+    cy.get(
+      `button.slot.unselected[data-start-time="${currentHour.toLocaleString()}"]`,
     )
       .first()
       .click();

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -67,7 +67,7 @@ describe("Booking time slots", () => {
     currentHour.setHours(currentHour.getHours() + 6);
     cy.wait(["@consecutive", "@availability"]);
 
-    //Get the closest full hour prior to current time, slots isBookable should be false
+    //Get the closest full hour prior to current time, slots fallsWithinAllowedTimeRange should be false
     cy.get(
       `button.slot.unselected[data-start-time="${currentHour.toLocaleString()}"]`,
     )
@@ -75,7 +75,7 @@ describe("Booking time slots", () => {
       .click();
     cy.get(".slot.selected").should("not.exist");
 
-    //Get the closest next hour after the current hour, slots isBookable should be true
+    //Get the closest next hour after the current hour, slots fallsWithinAllowedTimeRange should be true
     currentHour.setHours(currentHour.getHours() + 2);
     cy.get(
       `button.slot.unselected[data-start-time="${currentHour.toLocaleString()}"]`,

--- a/components/availability/src/method/availabilityUtils.ts
+++ b/components/availability/src/method/availabilityUtils.ts
@@ -42,7 +42,7 @@ export const generateDaySlots = (
           expirySelection: "",
           recurrence_cadence: "",
           recurrence_expiry: "",
-          isBookable: false,
+          fallsWithinAllowedTimeRange: false,
         };
         for (const calendar of allCalendars) {
           // Adjust calendar.timeslots for buffers
@@ -239,7 +239,7 @@ export const generateDaySlots = (
         available_calendars: freeCalendars,
         start_time: time,
         end_time: endTime,
-        isBookable:
+        fallsWithinAllowedTimeRange:
           timeOffset >= 0 &&
           dayOffset >= internalProps.min_book_ahead_days &&
           dayOffset <= internalProps.max_book_ahead_days,

--- a/components/availability/src/styles/availability.scss
+++ b/components/availability/src/styles/availability.scss
@@ -346,6 +346,10 @@ main {
           margin-left: 8px;
         }
 
+        &.outside-of-time-range:hover {
+          cursor: not-allowed;
+        }
+
         .selected-heading {
           position: absolute;
           top: 3px;


### PR DESCRIPTION
- Clarifies `isBookable` to be `fallsWithinAllowedTimeRange` as a slot property
- adds a `cursor: not-allowed` and a `title` attr indicating why a slot outside of range is not bookable.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
