### PR TITLE
Added auto theme based on user selected system theme for composer

### DIFF
--- a/commons/src/types/Nylas.ts
+++ b/commons/src/types/Nylas.ts
@@ -240,7 +240,7 @@ export interface ComposerProperties extends Manifest {
   show_minimize_button: boolean;
   show_subject: boolean;
   show_to: boolean;
-  theme: "string";
+  theme: "auto" | "light" | "dark" | "light-2" | "dark-2";
   visible: boolean;
 
   value: Partial<Message> | void;

--- a/components/composer/src/Composer.wc.svelte
+++ b/components/composer/src/Composer.wc.svelte
@@ -123,7 +123,7 @@
     show_bcc_button: true,
     show_attachment_button: true,
     show_editor_toolbar: true,
-    theme: "theme-1",
+    theme: "auto",
   };
 
   // Callbacks

--- a/components/composer/src/index.html
+++ b/components/composer/src/index.html
@@ -62,6 +62,6 @@
   </head>
 
   <body>
-    <nylas-composer id="demo-composer" theme="dark"> </nylas-composer>
+    <nylas-composer id="demo-composer" theme="auto"> </nylas-composer>
   </body>
 </html>

--- a/components/composer/src/properties.json
+++ b/components/composer/src/properties.json
@@ -15,7 +15,7 @@
     "label": "theme",
     "title": "Theme",
     "type": "string",
-    "options": ["light", "dark"],
+    "options": ["auto", "light", "dark"],
     "value": "light"
   },
   {

--- a/components/composer/themes/auto.css
+++ b/components/composer/themes/auto.css
@@ -2,7 +2,7 @@
 @media (prefers-color-scheme: light) {
   .nylas-composer {
     --composer-background-color: #fff;
-    --composer-background-muted-color: #fff;
+    --composer-background-muted-color: #edf1ff;
     --composer-text-color: #00000;
     --composer-text-light-color: #6e6e7a;
     --composer-text-secondary-color: #ffffff;
@@ -11,9 +11,9 @@
     --composer-font-size-small: 12px;
 
     --composer-border-color: #f4f4f4;
-    --composer-primary-color: #012cb4;
-    --composer-primary-light-color: #0037e5;
-    --composer-primary-dark-color: #0037e5;
+    --composer-primary-color: #0037e5;
+    --composer-primary-light-color: #3f6bff;
+    --composer-primary-dark-color: #00a88b;
     --composer-icons-color: #a5a6b9;
     --composer-header-background-color: var(--composer-background-color);
 
@@ -30,8 +30,8 @@
 
 @media (prefers-color-scheme: dark) {
   .nylas-composer {
-    --composer-background-color: #1c1c1c;
-    --composer-background-muted-color: #1c1c1c;
+    --composer-background-color: rgb(40, 43, 43);
+    --composer-background-muted-color: #454949;
     --composer-text-color: #fff;
     --composer-text-light-color: #b0b0c0;
     --composer-text-secondary-color: #ffffff;
@@ -40,9 +40,9 @@
     --composer-font-size-small: 12px;
 
     --composer-border-color: #282828;
-    --composer-primary-color: #012cb4;
-    --composer-primary-light-color: #0037e5;
-    --composer-primary-dark-color: #0037e5;
+    --composer-primary-color: #0037e5;
+    --composer-primary-light-color: #012cb4;
+    --composer-primary-dark-color: #00a88b;
     --composer-icons-color: #8e8e98;
     --composer-header-background-color: var(--composer-background-color);
 

--- a/components/composer/themes/auto.css
+++ b/components/composer/themes/auto.css
@@ -1,0 +1,58 @@
+/* auto.css based on user selected system theme */
+@media (prefers-color-scheme: light) {
+  .nylas-composer {
+    --composer-background-color: #fff;
+    --composer-background-muted-color: #fff;
+    --composer-text-color: #00000;
+    --composer-text-light-color: #6e6e7a;
+    --composer-text-secondary-color: #ffffff;
+    --composer-font: lato, sans-serif;
+    --composer-font-size: 14px;
+    --composer-font-size-small: 12px;
+
+    --composer-border-color: #f4f4f4;
+    --composer-primary-color: #012cb4;
+    --composer-primary-light-color: #0037e5;
+    --composer-primary-dark-color: #0037e5;
+    --composer-icons-color: #a5a6b9;
+    --composer-header-background-color: var(--composer-background-color);
+
+    --composer-success-color: white;
+    --composer-success-light-color: var(--composer-primary-color);
+
+    --composer-danger-color: #ff0000;
+    --composer-danger-light-color: #ffdddd;
+
+    --composer-info-color: var(--composer-primary-light-color);
+    --composer-info-light-color: #d2dcff;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .nylas-composer {
+    --composer-background-color: #1c1c1c;
+    --composer-background-muted-color: #1c1c1c;
+    --composer-text-color: #fff;
+    --composer-text-light-color: #b0b0c0;
+    --composer-text-secondary-color: #ffffff;
+    --composer-font: lato, sans-serif;
+    --composer-font-size: 14px;
+    --composer-font-size-small: 12px;
+
+    --composer-border-color: #282828;
+    --composer-primary-color: #012cb4;
+    --composer-primary-light-color: #0037e5;
+    --composer-primary-dark-color: #0037e5;
+    --composer-icons-color: #8e8e98;
+    --composer-header-background-color: var(--composer-background-color);
+
+    --composer-success-color: white;
+    --composer-success-light-color: var(--composer-primary-color);
+
+    --composer-danger-color: #ffffff;
+    --composer-danger-light-color: #ff5454;
+
+    --composer-info-color: var(--composer-primary-light-color);
+    --composer-info-light-color: #aebff9;
+  }
+}

--- a/public/themes/auto.css
+++ b/public/themes/auto.css
@@ -1,0 +1,58 @@
+/* auto.css based on user selected system theme */
+@media (prefers-color-scheme: light) {
+  .nylas-composer {
+    --composer-background-color: #fff;
+    --composer-background-muted-color: #fff;
+    --composer-text-color: #00000;
+    --composer-text-light-color: #6e6e7a;
+    --composer-text-secondary-color: #ffffff;
+    --composer-font: lato, sans-serif;
+    --composer-font-size: 14px;
+    --composer-font-size-small: 12px;
+
+    --composer-border-color: #f4f4f4;
+    --composer-primary-color: #012cb4;
+    --composer-primary-light-color: #0037e5;
+    --composer-primary-dark-color: #0037e5;
+    --composer-icons-color: #a5a6b9;
+    --composer-header-background-color: var(--composer-background-color);
+
+    --composer-success-color: white;
+    --composer-success-light-color: var(--composer-primary-color);
+
+    --composer-danger-color: #ff0000;
+    --composer-danger-light-color: #ffdddd;
+
+    --composer-info-color: var(--composer-primary-light-color);
+    --composer-info-light-color: #d2dcff;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .nylas-composer {
+    --composer-background-color: #1c1c1c;
+    --composer-background-muted-color: #1c1c1c;
+    --composer-text-color: #fff;
+    --composer-text-light-color: #b0b0c0;
+    --composer-text-secondary-color: #ffffff;
+    --composer-font: lato, sans-serif;
+    --composer-font-size: 14px;
+    --composer-font-size-small: 12px;
+
+    --composer-border-color: #282828;
+    --composer-primary-color: #012cb4;
+    --composer-primary-light-color: #0037e5;
+    --composer-primary-dark-color: #0037e5;
+    --composer-icons-color: #8e8e98;
+    --composer-header-background-color: var(--composer-background-color);
+
+    --composer-success-color: white;
+    --composer-success-light-color: var(--composer-primary-color);
+
+    --composer-danger-color: #ffffff;
+    --composer-danger-light-color: #ff5454;
+
+    --composer-info-color: var(--composer-primary-light-color);
+    --composer-info-light-color: #aebff9;
+  }
+}


### PR DESCRIPTION
# Code changes

- Added a new theme option `auto` for Composer component, which will use corresponding theme related to `prefers-color-scheme`.

# Readiness checklist

- [x] Cypress tests passing?
- [x] Included before/after screenshots, if the change is visual

# Screen Capture
https://user-images.githubusercontent.com/14408339/150432006-881949fa-d616-4598-a5b2-18252ab68963.mov



# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
