### PR TITLE
[Mailbox] Prevent threadClicked from firing twice

### DIFF
--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -251,9 +251,9 @@
   //#endregion methods
 
   // Callbacks
-  export async function sentMessageUpdate (message: Message): Promise<void> {
+  export async function sentMessageUpdate(message: Message): Promise<void> {
     threads = MailboxStore.hydrateMessageInThread(message, query, currentPage);
-  };
+  }
 
   //#region actions
   let areAllSelected = false;
@@ -982,7 +982,7 @@
                     show_reply={_this.show_reply}
                     show_reply_all={_this.show_reply_all}
                     show_forward={_this.show_forward}
-                    on:threadClicked={threadClicked}
+                    on:threadClicked|stopPropagation={threadClicked}
                     on:messageClicked={messageClicked}
                     on:threadStarred={threadStarred}
                     on:returnToMailbox={returnToMailbox}


### PR DESCRIPTION
Currently, when adding an event listener on `threadClicked` from the mailbox component, both the mailbox's event and the `nylas-email` event of the same name will bubble up to the parent app.

This means if the parent app were running a script on threadClicked, it would fire twice.

the `|stopPropagation` modifier ( see Svelte's Modifiers: https://svelte.dev/tutorial/event-modifiers) prevents this and gives us only a single event.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
