### PR TITLE
[Mailbox][Bug-fix]: Reply-all feature should include all participants except to & me within cc

### DIFF
--- a/components/email/src/methods/participants.ts
+++ b/components/email/src/methods/participants.ts
@@ -10,8 +10,8 @@ export function includesMyEmail(
   );
 }
 
-export function participantsWithoutMe(
-  myEmail: string,
+export function participantsWithoutGivenEmails(
+  emails: string[],
   message: Message,
 ): Participant[] {
   const allParticipants = [
@@ -20,7 +20,7 @@ export function participantsWithoutMe(
     ...message.cc,
     ...message.bcc,
   ];
-  return allParticipants.filter((e) => e.email !== myEmail);
+  return allParticipants.filter((e) => !emails.includes(e.email));
 }
 
 type BuildParticipant = {
@@ -47,10 +47,14 @@ export function buildParticipants({
       break;
     case "reply_all":
       if (includesMyEmail(myEmail, message, "cc")) {
-        to = participantsWithoutMe(myEmail, message);
+        to = participantsWithoutGivenEmails([myEmail], message);
       } else {
         to = message.from;
-        cc = message.cc;
+        const fromEmails = message.from?.map((i) => i.email);
+        cc = [
+          ...message.cc,
+          ...participantsWithoutGivenEmails([...fromEmails, myEmail], message),
+        ];
       }
       break;
   }


### PR DESCRIPTION
# Code changes
Gmail and other providers add all the participants included in the message to `cc` field with `to` field set to the email that last sent the message. Updated Mailbox to handle reply-all feature in the same way.

- Replaced `participantsWithoutMe` function with `participantsWithoutGivenEmails`(This is makes it more general and adds reusability)
- Updated `cc` field for `reply-all` type to include all participants in the message except `to` and `me` fields

Not adding this to changelog as this was not released.

![image](https://user-images.githubusercontent.com/16315004/150852181-36003fbd-92cf-4b4c-83b8-4de545d38db4.png)


# Readiness checklist

- [X] Cypress tests passing?
- [X] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
