### PR TITLE
[email] Show attachments in email condensed and expanded views

### DIFF
--- a/commons/src/components/MessageBody.svelte
+++ b/commons/src/components/MessageBody.svelte
@@ -33,11 +33,14 @@
       for (const [fileIndex, file] of message.files.entries()) {
         if (
           file.content_disposition === "attachment" &&
-          !(file.content_id && InlineImageTypes.includes(file.content_type)) && // treat all files with content_id as inline
+          !(
+            file.content_id &&
+            message.cids?.includes(file.content_id) &&
+            InlineImageTypes.includes(file.content_type)
+          ) &&
           !DisallowedContentTypes.includes(file.content_type)
         ) {
-          attachedFiles.push(message.files[fileIndex]);
-          attachedFiles = attachedFiles;
+          attachedFiles = [...attachedFiles, message.files[fileIndex]];
         }
       }
     }

--- a/commons/src/components/MessageBody.svelte
+++ b/commons/src/components/MessageBody.svelte
@@ -4,6 +4,7 @@
   This is to ensure the styles in the html message body are encapsulated and 
   does not affect the global component enclosing it -->
 <script>
+  import { isNonInlineAttachment } from "@commons/methods/isNonInlineAttachment";
   import * as DOMPurify from "dompurify";
   import { getEventDispatcher } from "@commons/methods/component";
   import { get_current_component, onMount } from "svelte/internal";
@@ -31,15 +32,7 @@
   onMount(() => {
     if (message && message.files.length > 0) {
       for (const [fileIndex, file] of message.files.entries()) {
-        if (
-          file.content_disposition === "attachment" &&
-          !(
-            file.content_id &&
-            message.cids?.includes(file.content_id) &&
-            InlineImageTypes.includes(file.content_type)
-          ) &&
-          !DisallowedContentTypes.includes(file.content_type)
-        ) {
+        if (isNonInlineAttachment(message, file)) {
           attachedFiles = [...attachedFiles, message.files[fileIndex]];
         }
       }

--- a/commons/src/components/MessageBody.svelte
+++ b/commons/src/components/MessageBody.svelte
@@ -4,7 +4,7 @@
   This is to ensure the styles in the html message body are encapsulated and 
   does not affect the global component enclosing it -->
 <script>
-  import { isNonInlineAttachment } from "@commons/methods/isNonInlineAttachment";
+  import { isFileAnAttachment } from "@commons/methods/isFileAnAttachment";
   import * as DOMPurify from "dompurify";
   import { getEventDispatcher } from "@commons/methods/component";
   import { get_current_component, onMount } from "svelte/internal";
@@ -32,7 +32,7 @@
   onMount(() => {
     if (message && message.files.length > 0) {
       for (const [fileIndex, file] of message.files.entries()) {
-        if (isNonInlineAttachment(message, file)) {
+        if (isFileAnAttachment(message, file)) {
           attachedFiles = [...attachedFiles, message.files[fileIndex]];
         }
       }

--- a/commons/src/methods/isFileAnAttachment.ts
+++ b/commons/src/methods/isFileAnAttachment.ts
@@ -4,7 +4,7 @@ import {
   InlineImageTypes,
 } from "@commons/constants/attachment-content-types";
 
-export const isNonInlineAttachment = (message: Message, file: File): boolean =>
+export const isFileAnAttachment = (message: Message, file: File): boolean =>
   file.content_disposition === "attachment" &&
   !(
     file.content_id &&

--- a/commons/src/methods/isNonInlineAttachment.ts
+++ b/commons/src/methods/isNonInlineAttachment.ts
@@ -1,0 +1,14 @@
+import type { Message, File } from "@commons/types/Nylas";
+import {
+  DisallowedContentTypes,
+  InlineImageTypes,
+} from "@commons/constants/attachment-content-types";
+
+export const isNonInlineAttachment = (message: Message, file: File): boolean =>
+  file.content_disposition === "attachment" &&
+  !(
+    file.content_id &&
+    message.cids?.includes(file.content_id) &&
+    InlineImageTypes.includes(file.content_type) &&
+    !DisallowedContentTypes.includes(file.content_type)
+  );

--- a/commons/src/types/Nylas.ts
+++ b/commons/src/types/Nylas.ts
@@ -115,6 +115,7 @@ export interface Message {
   from: Participant[];
   to: Participant[];
   cc: Participant[];
+  cids?: string[];
   bcc: Participant[];
   conversation?: string;
   model_version?: string;

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -56,7 +56,7 @@
   import ReplyIcon from "./assets/reply.svg";
   import ReplyAllIcon from "./assets/reply-all.svg";
   import ForwardIcon from "./assets/forward.svg";
-  import { isNonInlineAttachment } from "@commons/methods/isNonInlineAttachment";
+  import { isFileAnAttachment } from "@commons/methods/isFileAnAttachment";
 
   const dispatchEvent = getEventDispatcher(get_current_component());
   $: dispatchEvent("manifestLoaded", manifest);
@@ -778,7 +778,7 @@
     attachedFiles = activeThread.messages?.reduce(
       (files: Record<string, File[]>, message) => {
         for (const [fileIndex, file] of message.files.entries()) {
-          if (isNonInlineAttachment(message, file)) {
+          if (isFileAnAttachment(message, file)) {
             if (!files[message.id]) {
               files[message.id] = [];
             }

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -56,10 +56,7 @@
   import ReplyIcon from "./assets/reply.svg";
   import ReplyAllIcon from "./assets/reply-all.svg";
   import ForwardIcon from "./assets/forward.svg";
-  import {
-    DisallowedContentTypes,
-    InlineImageTypes,
-  } from "@commons/constants/attachment-content-types";
+  import { isNonInlineAttachment } from "@commons/methods/isNonInlineAttachment";
 
   const dispatchEvent = getEventDispatcher(get_current_component());
   $: dispatchEvent("manifestLoaded", manifest);
@@ -781,15 +778,7 @@
     attachedFiles = activeThread.messages?.reduce(
       (files: Record<string, File[]>, message) => {
         for (const [fileIndex, file] of message.files.entries()) {
-          if (
-            file.content_disposition === "attachment" &&
-            !(
-              file.content_id &&
-              message.cids?.includes(file.content_id) &&
-              InlineImageTypes.includes(file.content_type)
-            ) &&
-            !DisallowedContentTypes.includes(file.content_type)
-          ) {
+          if (isNonInlineAttachment(message, file)) {
             if (!files[message.id]) {
               files[message.id] = [];
             }

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -784,14 +784,19 @@
           if (
             file.content_disposition === "attachment" &&
             !(
-              file.content_id && InlineImageTypes.includes(file.content_type)
-            ) && // treat all files with content_id as inline
+              file.content_id &&
+              message.cids?.includes(file.content_id) &&
+              InlineImageTypes.includes(file.content_type)
+            ) &&
             !DisallowedContentTypes.includes(file.content_type)
           ) {
             if (!files[message.id]) {
               files[message.id] = [];
             }
-            files[message.id].push(message.files[fileIndex]);
+            files[message.id] = [
+              ...files[message.id],
+              message.files[fileIndex],
+            ];
           }
         }
         return files;
@@ -1880,7 +1885,8 @@
                   {/if}
                   <span
                     class="snippet"
-                    class:deleted={activeThread.messages.length <= 0 && !isDraft}
+                    class:deleted={activeThread.messages.length <= 0 &&
+                      !isDraft}
                   >
                     {activeThread.messages.length <= 0 && !isDraft
                       ? `Sorry, looks like this thread is currently unavailable. It may


### PR DESCRIPTION
# Code changes

- Added conditional logic to `initializeAttachedFiles()` in the `Email` and `MessageBody` components to filter out attachments with a `content_id` that matches an element in the `cids` array

# Screenshots
## Before
<img width="970" alt="Screen Shot 2022-01-25 at 4 07 50 PM" src="https://user-images.githubusercontent.com/55773810/151059902-e3b889d6-8010-4ecd-aad1-4f775770829c.png">
<img width="966" alt="Screen Shot 2022-01-25 at 4 11 40 PM" src="https://user-images.githubusercontent.com/55773810/151060423-1a1932ea-ef31-4280-934d-b6cad0d82d24.png">

## After
<img width="966" alt="Screen Shot 2022-01-25 at 4 07 09 PM" src="https://user-images.githubusercontent.com/55773810/151059934-4731eec0-f993-4315-9428-e9ea286d41ec.png">
<img width="963" alt="Screen Shot 2022-01-25 at 4 11 21 PM" src="https://user-images.githubusercontent.com/55773810/151060453-65f7ee7e-bb09-44cd-ba66-aaf592c8aa0b.png">


# Readiness checklist
- [ ] Added changes to component `CHANGELOG.md`
- [ ] New property added? make sure to update `component/src/properties.json`
- [ ] Cypress tests passing?
- [ ] New cypress tests added?
- [ ] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
