### PR TITLE
[availability] emit an event when displayed dates change

### DIFF
--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -826,6 +826,19 @@
       slots: [],
     });
   }
+
+  // Track and dispatch active dates whenever they change
+  let canonicalDates: Date[] = [];
+  $: if (
+    JSON.stringify(canonicalDates) !==
+    JSON.stringify(days.map((d) => d.timestamp))
+  ) {
+    canonicalDates = days.map((day) => day.timestamp);
+    dispatchEvent("dateChange", {
+      dates: canonicalDates,
+    });
+  }
+
   // #endregion Date Change
 
   //#region slot selection

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -831,7 +831,7 @@
   let canonicalDates: Date[] = [];
   $: if (
     JSON.stringify(canonicalDates) !==
-    JSON.stringify(days.map((d) => d.timestamp))
+    JSON.stringify(days.map((day) => day.timestamp))
   ) {
     canonicalDates = days.map((day) => day.timestamp);
     dispatchEvent("dateChange", {

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -80,6 +80,10 @@
         component.participants = [];
         component.events = [event];
 
+        component.addEventListener("dateChange", (event) => {
+          console.log("date change", event.detail.dates);
+        });
+
         component.addEventListener("timeSlotChosen", (event) => {
           console.log(event.detail.timeSlots);
         });

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -692,6 +692,49 @@ describe("Booking time slots", () => {
       cy.get("div.day:eq(0) header h2").invoke("text").should("eq", "27 Mon");
       cy.get("div.day:eq(4) header h2").invoke("text").should("eq", "31 Fri");
     });
+
+    let mockParentStore = [];
+
+    it("Dispatches active dates to the parent application", () => {
+      cy.get("@testComponent").then((el) => {
+        // Event Listeners
+        const component = el[0];
+        component.addEventListener("dateChange", (e) => {
+          mockParentStore = e.detail.dates;
+        });
+      });
+
+      cy.get(".change-dates button:eq(1)")
+        .click()
+        .then(() => {
+          cy.get("div.day:eq(0) header h2")
+            .invoke("text")
+            .should("eq", "21 Tue");
+          expect(mockParentStore).to.have.length(1);
+          expect(mockParentStore[0].toString()).to.equal(
+            "Tue Dec 21 2021 00:00:00 GMT-0500 (Eastern Standard Time)",
+          );
+        });
+
+      cy.get(".change-dates button:eq(1)")
+        .click()
+        .then(() => {
+          cy.get("div.day:eq(0) header h2")
+            .invoke("text")
+            .should("eq", "22 Wed");
+          expect(mockParentStore).to.have.length(1);
+          expect(mockParentStore[0].toString()).to.equal(
+            "Wed Dec 22 2021 00:00:00 GMT-0500 (Eastern Standard Time)",
+          );
+        });
+
+      cy.get("@testComponent").invoke("attr", "dates_to_show", 7);
+      cy.get(".change-dates button:eq(0)")
+        .click()
+        .then(() => {
+          expect(mockParentStore).to.have.length(7);
+        });
+    });
   });
 
   describe("change colours", () => {

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -728,11 +728,28 @@ describe("Booking time slots", () => {
           );
         });
 
+      cy.viewport(1500, 550);
       cy.get("@testComponent").invoke("attr", "dates_to_show", 7);
       cy.get(".change-dates button:eq(0)")
         .click()
         .then(() => {
           expect(mockParentStore).to.have.length(7);
+        });
+
+      cy.viewport(1200, 550);
+      cy.get("@testComponent").invoke("attr", "dates_to_show", 7);
+      cy.get(".change-dates button:eq(0)")
+        .click()
+        .then(() => {
+          expect(mockParentStore).to.have.length(6);
+        });
+
+      cy.viewport(600, 550);
+      cy.get("@testComponent").invoke("attr", "dates_to_show", 7);
+      cy.get(".change-dates button:eq(0)")
+        .click()
+        .then(() => {
+          expect(mockParentStore).to.have.length(1);
         });
     });
   });


### PR DESCRIPTION
Adds a dispatcher that can be observed from a parent app anytime the dates in the Availability component change. Will only fire if the dates themselves change, regardless of how often the `days` reactive object changes.

Added an event listener from the index demo for availability

Note: had trouble working out how to get Cypress to wait for viewport changes in order to test dispatched array length, but manually testing reveals this works.

![image](https://user-images.githubusercontent.com/713991/151067734-40ec5257-d777-468b-9a81-c5be143cbceb.png)


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
