### PR TITLE
[email] refactor tests and re-enable skipped tests

### DIFF
--- a/components/email/src/cypress.html
+++ b/components/email/src/cypress.html
@@ -10,9 +10,6 @@
   </head>
 
   <body>
-    <div id="emails"></div>
-    <div class="demo">
-      <nylas-email id="test-email" show_star="true"> </nylas-email>
-    </div>
+    <nylas-email id="test-email"></nylas-email>
   </body>
 </html>

--- a/components/email/src/init.spec.js
+++ b/components/email/src/init.spec.js
@@ -739,63 +739,30 @@ const MULTIPLE_SENDER_THREAD = {
 
 describe("Email: Displays threads and messages", () => {
   beforeEach(() => {
-    cy.intercept(
-      "GET",
-      "https://web-components.nylas.com/middleware/manifest",
-      {
-        fixture: "email/manifest.json",
-      },
-    ).as("manifest");
-    cy.intercept(
-      "GET",
-      "https://web-components.nylas.com/middleware/messages/affxolvozy2pcqh4303w7pc9n",
-      {
-        fixture: "email/messages/id.json",
-      },
-    );
-    cy.intercept(
-      "GET",
-      "https://web-components.nylas.com/middleware/messages/7w3i9u9xk95w331zuw40yvm4j",
-      {
-        fixture: "email/messages/idWithImage.json",
-      },
-    );
-    cy.intercept("GET", "https://web-components.nylas.com/middleware/account", {
-      fixture: "email/account.json",
+    cy.batchIntercept("GET", {
+      "**/middleware/manifest": "email/manifest",
+      "**/middleware/account": "email/account",
+      "**/middleware/labels": "email/labels",
+      "**/middleware/threads/b3z0fd5kbbwcxbvf4q1ele5us6*": "email/threads/id",
+      "**/middleware/messages/c5xjcjlhzldqctpud8zeufa6t":
+        "email/messages/idWithImage",
+      "**/middleware/messages/affxolvozy2pcqh4303w7pc9n": "email/messages/id",
+      "**/middleware/files/6dywzoo80moag1it135co9zv8/download":
+        "email/files/download",
     });
-    cy.intercept(
-      "GET",
-      "https://web-components.nylas.com/middleware/files/6dywzoo80moag1it135co9zv8/download",
-      {
-        fixture: "email/files/download.json",
-      },
-    ).as("filesDownload");
-    cy.intercept(
-      "GET",
-      "https://web-components.nylas.com/middleware/threads/b3z0fd5kbbwcxvf4q1ele5us6*",
-      {
-        fixture: "email/threads/id.json",
-      },
-    ).as("threads");
-    cy.intercept(
-      "GET",
-      "https://web-components.nylas.com/middleware/threads/c5xjcjlhzldqctpud8zeufa6t*",
-      {
-        fixture: "email/threads/idWithImage.json",
-      },
-    ).as("threadWithImage");
 
     cy.visit("/components/email/src/cypress.html");
 
-    cy.get("nylas-email").as("email");
-
-    cy.get("@email").invoke("prop", "show_expanded_email_view_onload", false);
+    cy.get("nylas-email")
+      .as("email")
+      .invoke("prop", "show_expanded_email_view_onload", false);
   });
 
-  it("Shows Email with thread_id", () => {
-    cy.get("@email").invoke("prop", "thread_id", "b3z0fd5kbbwcxvf4q1ele5us6");
+  it("Shows Email with demo id and thread", () => {
+    cy.get("@email").invoke("prop", "thread_id", "b3z0fd5kbbwcxbvf4q1ele5us6");
 
-    cy.get("@email").find(".subject").should("contain", "Test Email Subject");
+    cy.get("@email").find(".subject").should("exist");
+    cy.get("@email").find(".subject").should("contain", "Test subject");
   });
 
   it("Shows Email with passed thread", () => {
@@ -873,34 +840,6 @@ describe("Email: Displays threads and messages", () => {
     });
   });
 
-  it.skip("Renders inline file appropriately", () => {
-    cy.get("@email").invoke("prop", "thread_id", "c5xjcjlhzldqctpud8zeufa6t");
-    cy.get("@email").invoke("prop", "click_action", "default");
-    cy.get("@email").invoke("prop", "show_expanded_email_view_onload", true);
-
-    cy.wait("@filesDownload");
-
-    cy.get("@email")
-      .find("img[alt='Streams Automation.jpg']")
-      .should("have.attr", "src")
-      .and(($div) => {
-        expect($div).to.contain("data:image/jpeg");
-      });
-  });
-
-  it("Shows attached file when condensed", () => {
-    cy.get("@email").then((element) => {
-      const component = element[0];
-      component.show_expanded_email_view_onload = false;
-      component.thread = SAMPLE_THREAD;
-    });
-
-    cy.get("@email").find(".email-row.condensed .attachment").should("exist");
-    cy.get("@email")
-      .find(".email-row.condensed .attachment button")
-      .should("have.text", "invoice_2062.pdf ");
-  });
-
   it("Shows empty message", () => {
     cy.get("@email").then((element) => {
       const component = element[0];
@@ -934,27 +873,60 @@ describe("Email: Displays threads and messages", () => {
   });
 });
 
-describe("Email: Stars", () => {
+describe("Email: Images and Files", () => {
   beforeEach(() => {
-    cy.intercept("GET", "https://web-components.nylas.com/middleware/account", {
-      fixture: "email/account.json",
+    cy.batchIntercept("GET", {
+      "**/middleware/manifest": "email/manifest",
+      "**/middleware/account": "email/account",
+      "**/middleware/labels": "email/labels",
+      "**/middleware/threads/c5xjcjlhzldqctpud8zeufa6t*":
+        "email/threads/idWithImage",
+      "**/middleware/messages/7w3i9u9xk95w331zuw40yvm4j*":
+        "email/messages/idWithImage",
+      "**/middleware/files/b6113komjjjzsmhkphxf8nw8g/download*":
+        "email/files/download",
     });
 
-    cy.intercept(
-      "GET",
-      "https://web-components.nylas.com/middleware/messages/affxolvozy2pcqh4303w7pc9n",
-      {
-        fixture: "email/messages/id.json",
-      },
-    );
+    cy.visit("/components/email/src/cypress.html");
 
-    cy.intercept(
-      "GET",
-      "https://web-components.nylas.com/middleware/threads/b3z0fd5kbbwcxvf4q1ele5us6*",
-      {
-        fixture: "email/threads/id.json",
-      },
-    );
+    cy.get("nylas-email").as("email");
+  });
+
+  it("Renders inline file appropriately", () => {
+    cy.get("@email").invoke("prop", "thread_id", "c5xjcjlhzldqctpud8zeufa6t");
+    cy.get("@email").invoke("prop", "click_action", "default");
+    cy.get("@email").invoke("attr", "show_expanded_email_view_onload", true);
+
+    cy.wait("@email/files/download");
+
+    cy.get("@email")
+      .find("img[alt='Streams Automation.jpg']")
+      .should("have.attr", "src")
+      .and(($div) => {
+        expect($div).to.contain("data:image/jpeg");
+      });
+  });
+
+  it("Shows attached file when condensed", () => {
+    cy.get("@email").invoke("prop", "show_expanded_email_view_onload", false);
+    cy.get("@email").invoke("prop", "thread", SAMPLE_THREAD);
+
+    cy.get("@email").find(".email-row.condensed .attachment").should("exist");
+    cy.get("@email")
+      .find(".email-row.condensed .attachment button")
+      .should("have.text", "invoice_2062.pdf ");
+  });
+});
+
+describe("Email: Stars", () => {
+  beforeEach(() => {
+    cy.batchIntercept("GET", {
+      "**/middleware/manifest": "email/manifest",
+      "**/middleware/account": "email/account",
+      "**/middleware/labels": "email/labels",
+      "**/middleware/messages/affxolvozy2pcqh4303w7pc9n": "email/messages/id",
+      "**/middleware/threads/b3z0fd5kbbwcxvf4q1ele5us6*": "email/threads/id",
+    });
 
     cy.visit("/components/email/src/cypress.html");
 
@@ -1051,60 +1023,37 @@ describe("Email: Unread status", () => {
 
 describe("Email: Reply, Reply-all, Forward", () => {
   beforeEach(() => {
-    cy.intercept("GET", "https://web-components.nylas.com/middleware/account", {
-      fixture: "email/account.json",
+    cy.batchIntercept("GET", {
+      "**/middleware/manifest": "email/manifest",
+      "**/middleware/account": "email/account",
+      "**/middleware/labels": "email/labels",
+      "**/middleware/threads/83v13r9lj6kzh109c3l1yznnf*":
+        "email/threads/idWithMultipleSenders",
+      "**/middleware/messages/epgslj6wocxcnuyy6h9yyle6v":
+        "email/messages/idWithMultipleSenders",
     });
-    cy.intercept(
-      "GET",
-      "https://web-components.nylas.com/middleware/messages/affxolvozy2pcqh4303w7pc9n",
-      {
-        fixture: "email/messages/id.json",
-      },
-    );
-    cy.intercept(
-      "GET",
-      "https://web-components.nylas.com/middleware/messages/epgslj6wocxcnuyy6h9yyle6v",
-      {
-        fixture: "email/messages/idWithMultipleSenders.json",
-      },
-    );
-    cy.intercept(
-      "GET",
-      "https://web-components.nylas.com/middleware/threads/b3z0fd5kbbwcxvf4q1ele5us6*",
-      {
-        fixture: "email/threads/id.json",
-      },
-    ).as("threads");
-    cy.intercept(
-      "GET",
-      "https://web-components.nylas.com/middleware/threads/b3z0fd5multiplesenders*",
-      {
-        fixture: "email/threads/idWithMultipleSenders.json",
-      },
-    ).as("multipleSendersThread");
 
     cy.visit("/components/email/src/cypress.html");
 
-    cy.get("nylas-email").as("email");
+    cy.get("nylas-email")
+      .as("email")
+      .invoke("prop", "thread_id", "83v13r9lj6kzh109c3l1yznnf");
     cy.get("@email").invoke("prop", "show_expanded_email_view_onload", true);
   });
 
   it("shows reply icon", () => {
-    cy.get("@email").invoke("prop", "thread_id", "b3z0fd5kbbwcxvf4q1ele5us6");
     cy.get("@email").invoke("prop", "show_reply", true);
 
     cy.get("@email").find(".reply").should("exist");
   });
 
   it("shows reply-all icon", () => {
-    cy.get("@email").invoke("prop", "thread_id", "b3z0fd5multiplesenders");
     cy.get("@email").invoke("prop", "show_reply_all", true);
 
     cy.get("@email").find(".reply-all").should("exist");
   });
 
   it("shows forward icon", () => {
-    cy.get("@email").invoke("prop", "thread_id", "b3z0fd5kbbwcxvf4q1ele5us6");
     cy.get("@email").invoke("prop", "show_forward", true);
 
     cy.get("@email").find(".forward").should("exist");
@@ -1113,30 +1062,19 @@ describe("Email: Reply, Reply-all, Forward", () => {
 
 describe("Email: Toggle email of sender/recipient", () => {
   beforeEach(() => {
-    cy.intercept("GET", "https://web-components.nylas.com/middleware/account", {
-      fixture: "email/account.json",
+    cy.batchIntercept("GET", {
+      "**/middleware/manifest": "email/manifest",
+      "**/middleware/account": "email/account",
+      "**/middleware/labels": "email/labels",
+      "**/middleware/messages/affxolvozy2pcqh4303w7pc9n": "email/messages/id",
+      "**/middleware/threads/b3z0fd5kbbwcxvf4q1ele5us6*": "email/threads/id",
     });
-
-    cy.intercept(
-      "GET",
-      "https://web-components.nylas.com/middleware/messages/affxolvozy2pcqh4303w7pc9n*",
-      {
-        fixture: "email/messages/id.json",
-      },
-    );
-    cy.intercept(
-      "GET",
-      "https://web-components.nylas.com/middleware/threads/b3z0fd5kbbwcxvf4q1ele5us6*",
-      {
-        fixture: "email/threads/id.json",
-      },
-    );
 
     cy.visit("/components/email/src/cypress.html");
 
-    cy.get("nylas-email").as("email");
-
-    cy.get("@email").invoke("prop", "thread_id", "b3z0fd5kbbwcxvf4q1ele5us6");
+    cy.get("nylas-email")
+      .as("email")
+      .invoke("prop", "thread_id", "b3z0fd5kbbwcxvf4q1ele5us6");
     cy.get("@email").invoke("prop", "show_expanded_email_view_onload", true);
   });
 
@@ -1350,16 +1288,23 @@ describe("Should Render Reply Button And Dispatch Event When Clicked", () => {
     cy.get("@email").find("div.reply button").should("exist");
   });
 
-  xit("Should Dispatch Event When Reply Button Is Clicked", () => {
+  it("Should Dispatch Event When Reply Button Is Clicked", () => {
+    let replyClicked = false;
     cy.get("@email").invoke("prop", "message", SINGLE_SENDER_MESSAGE);
     cy.get("@email").find("div.reply button").as("replyButton");
     cy.get("@replyButton").should("exist");
     cy.get("@email").then((elements) => {
       const component = elements[0];
-      component.addEventListener("replyClicked", cy.stub().as("replyClicked"));
+      component.addEventListener("replyClicked", () => {
+        replyClicked = true;
+      });
     });
-    cy.get("@replyButton").click();
-    cy.get("@replyClicked").should("have.been.calledOnce");
+
+    cy.get("@replyButton")
+      .click()
+      .then(() => {
+        expect(replyClicked).to.be.true;
+      });
   });
 });
 
@@ -1372,18 +1317,18 @@ describe("Should Render Reply All Button And Respond To Clicks", () => {
     cy.get("@email").invoke("attr", "show_reply_all", "true");
   });
 
-  xit("Should Render Reply All Button When Passed A Message", () => {
+  it("Should Render Reply All Button When Passed A Message", () => {
     cy.get("@email").invoke("prop", "message", MULTIPLE_SENDER_MESSAGE);
     cy.get("@email").find("div.reply-all button").should("exist");
   });
 
-  xit("Should Render Reply All Button When Passed A Thread", () => {
+  it("Should Render Reply All Button When Passed A Thread", () => {
     cy.get("@email").invoke("prop", "thread", MULTIPLE_SENDER_THREAD);
     cy.get("@email").invoke("attr", "show_expanded_email_view_onload", "true");
     cy.get("@email").find("div.reply-all button").should("exist");
   });
 
-  xit("Should Render Reply All Button When Passed A Message ID", () => {
+  it("Should Render Reply All Button When Passed A Message ID", () => {
     cy.intercept(
       {
         method: "GET",
@@ -1400,7 +1345,7 @@ describe("Should Render Reply All Button And Respond To Clicks", () => {
     cy.get("@email").find("div.reply-all button").should("exist");
   });
 
-  xit("Should Render Reply All Button When Passed A Thread ID", () => {
+  it("Should Render Reply All Button When Passed A Thread ID", () => {
     cy.intercept(
       {
         method: "GET",
@@ -1432,20 +1377,23 @@ describe("Should Render Reply All Button And Respond To Clicks", () => {
     cy.get("@email").find("div.reply-all button").should("not.exist");
   });
 
-  xit("Should Dispatch Event When Reply All Button Is Clicked", () => {
+  it("Should Dispatch Event When Reply All Button Is Clicked", () => {
+    let replyAllClicked = false;
     cy.get("@email").invoke("prop", "message", MULTIPLE_SENDER_MESSAGE);
     cy.get("@email").find("div.reply-all button").as("replyAllButton");
     cy.get("@replyAllButton").should("exist");
 
     cy.get("@email").then((elements) => {
       const component = elements[0];
-      component.addEventListener(
-        "replyAllClicked",
-        cy.stub().as("replyAllClicked"),
-      );
+      component.addEventListener("replyAllClicked", () => {
+        replyAllClicked = true;
+      });
     });
 
-    cy.get("@replyAllButton").click();
-    cy.get("@replyAllClicked").should("have.been.calledOnce");
+    cy.get("@replyAllButton")
+      .click()
+      .then(() => {
+        expect(replyAllClicked).to.be.true;
+      });
   });
 });

--- a/cypress/fixtures/email/labels.json
+++ b/cypress/fixtures/email/labels.json
@@ -1,0 +1,72 @@
+{
+  "component": {
+    "theming": {
+      "show_received_timestamp": true,
+      "thread_id": "b3z0fd5kbbwcxvf4q1ele5us6",
+      "clean_conversation": false,
+      "unread": false,
+      "show_star": false,
+      "show_contact_avatar": true,
+      "show_number_of_messages": true,
+      "click_action": "select"
+    }
+  },
+  "response": [
+    {
+      "account_id": "1xrddnl99frq3b7son9j32aba",
+      "display_name": "DRAFT",
+      "id": "7yv75k10rd3rw4kghwm9rxmqz",
+      "name": "drafts",
+      "object": "label"
+    },
+    {
+      "account_id": "1xrddnl99frq3b7son9j32aba",
+      "display_name": "SPAM",
+      "id": "7zbydny6jklh8hxvrpp8fq3bv",
+      "name": "spam",
+      "object": "label"
+    },
+    {
+      "account_id": "1xrddnl99frq3b7son9j32aba",
+      "display_name": "IMPORTANT",
+      "id": "5852fv5ompdk51g0ve17mvej9",
+      "name": "important",
+      "object": "label"
+    },
+    {
+      "account_id": "1xrddnl99frq3b7son9j32aba",
+      "display_name": "INBOX",
+      "id": "dx62wkpj57erbkargbr3zew3j",
+      "name": "inbox",
+      "object": "label"
+    },
+    {
+      "account_id": "1xrddnl99frq3b7son9j32aba",
+      "display_name": "TRASH",
+      "id": "6a5yymoenf5c8by1vsulv9mc3",
+      "name": "trash",
+      "object": "label"
+    },
+    {
+      "account_id": "1xrddnl99frq3b7son9j32aba",
+      "display_name": "SENT",
+      "id": "17ocjrnqb2w5m402t1lwswkkl",
+      "name": "sent",
+      "object": "label"
+    },
+    {
+      "account_id": "1xrddnl99frq3b7son9j32aba",
+      "display_name": "Google",
+      "id": "d6kj33l6m9c50griqdk14sli5",
+      "name": null,
+      "object": "label"
+    },
+    {
+      "account_id": "1xrddnl99frq3b7son9j32aba",
+      "display_name": "All Mail",
+      "id": "78im4dxnn2mj0hl038vcnezwn",
+      "name": "all",
+      "object": "label"
+    }
+  ]
+}

--- a/cypress/fixtures/email/messages/idWithImage.json
+++ b/cypress/fixtures/email/messages/idWithImage.json
@@ -1,48 +1,40 @@
 {
-  "component": {
-    "theming": {
-      "show_received_timestamp": true,
-      "thread_id": "b3z0fd5kbbwcxvf4q1ele5us6",
-      "clean_conversation": false,
-      "unread": false,
-      "show_star": false,
-      "show_contact_avatar": true,
-      "show_number_of_messages": true,
-      "click_action": "select"
-    }
-  },
+  "component": { "theming": {} },
   "response": {
-    "account_id": "1xrddnl99frq3b7son9j32aba",
+    "account_id": "byh51hf1ru70i28jkxapbwguc",
     "bcc": [],
+    "body": "<div dir=\"ltr\"><div dir=\"ltr\" class=\"gmail_signature\" data-smartmail=\"gmail_signature\"><div dir=\"ltr\"><span><div dir=\"ltr\" style=\"margin-left:0pt\" align=\"left\">Inline image test:</div><div dir=\"ltr\" style=\"margin-left:0pt\" align=\"left\"><img src=\"cid:ii_kwwc5np40\" alt=\"Streams Automation.jpg\" width=\"542\" height=\"283\"><br>Does it render properly?<table style=\"border:none;border-collapse:collapse\"><colgroup><col width=\"84\"><col width=\"540\"></colgroup><tbody><tr style=\"height:79pt\"><td style=\"vertical-align:top;padding:5pt 5pt 5pt 5pt;overflow:hidden\"></td><td style=\"vertical-align:top;padding:5pt 5pt 5pt 5pt;overflow:hidden\"><p dir=\"ltr\" style=\"line-height:1.38;margin-top:0pt;margin-bottom:0pt\"><font color=\"#000000\" face=\"Source Sans Pro, sans-serif\"><span style=\"font-size:10.6667px;white-space:pre-wrap\">\n</span></font></p><p dir=\"ltr\" style=\"line-height:1.38;margin-top:0pt;margin-bottom:0pt\"><span><br></span></p><div dir=\"ltr\" style=\"margin-left:0pt\" align=\"left\"><table style=\"border:none;border-collapse:collapse\"><colgroup><col width=\"84\"><col width=\"540\"></colgroup><tbody><tr style=\"height:63pt\"><td colspan=\"2\" style=\"vertical-align:top;padding:5pt 5pt 5pt 5pt;overflow:hidden\"><p dir=\"ltr\" style=\"line-height:1.2;margin-top:0pt;margin-bottom:0pt\"><span style=\"text-decoration:underline;font-size:11pt;font-family:Arial;color:rgb(17,85,204);background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;vertical-align:baseline;white-space:pre-wrap\"><span style=\"border:none;display:inline-block;overflow:hidden;width:306px;height:45px\"></span></span></p><div dir=\"ltr\" style=\"margin-left:0pt\" align=\"left\"><table style=\"border:none;border-collapse:collapse\"><colgroup><col width=\"84\"><col width=\"540\"></colgroup><tbody><tr style=\"height:63pt\"><td colspan=\"2\" style=\"vertical-align:top;padding:5pt 5pt 5pt 5pt;overflow:hidden\"><p dir=\"ltr\" style=\"line-height:1.2;margin-top:0pt;margin-bottom:0pt\"><span style=\"text-decoration:underline;font-size:11pt;font-family:Arial;color:rgb(17,85,204);background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;vertical-align:baseline;white-space:pre-wrap\"><span style=\"border:none;display:inline-block;overflow:hidden;width:306px;height:45px\"></span></span></p></td></tr></tbody></table></div></td></tr></tbody></table></div></td></tr></tbody></table></div></span></div></div></div>",
     "cc": [],
+    "cids": ["ii_kwwc5np40"],
     "date": 1638895701,
+    "events": [],
     "files": [
       {
         "content_disposition": "inline",
         "content_id": "ii_kwwc5np40",
         "content_type": "image/jpeg",
         "filename": "Streams Automation.jpg",
-        "id": "6dywzoo80moag1it135co9zv8",
+        "id": "b6113komjjjzsmhkphxf8nw8g",
         "size": 1022500
       }
     ],
-    "from": [{ "email": "test@nylas.com", "name": "First User" }],
-    "id": "7w3i9u9xk95w331zuw40yvm4j",
+    "from": [{ "email": "person@email.com", "name": "Test Person" }],
+    "id": "c6uq0gr1g5f52mr0b8nzwx6br",
     "labels": [
       {
-        "display_name": "INBOX",
-        "id": "dx62wkpj57erbkargbr3zew3j",
-        "name": "inbox"
+        "display_name": "All Mail",
+        "id": "28hrl3nzl7tupfl0xd5zlfn6h",
+        "name": "all"
       },
       {
         "display_name": "IMPORTANT",
-        "id": "5852fv5ompdk51g0ve17mvej9",
+        "id": "6ile0fjv14zjg9k01m1595qm",
         "name": "important"
       },
       {
-        "display_name": "All Mail",
-        "id": "78im4dxnn2mj0hl038vcnezwn",
-        "name": "all"
+        "display_name": "INBOX",
+        "id": "26z3bxbz3c0grgr0u4ssx7k0g",
+        "name": "inbox"
       }
     ],
     "object": "message",
@@ -50,7 +42,7 @@
     "snippet": "Inline image test: Does it render properly?",
     "starred": false,
     "subject": "Inline image rendering",
-    "thread_id": "c5xjcjlhzldqctpud8zeufa6t",
+    "thread_id": "bpp3gwfyloaf6tim7bpcxlxdz",
     "to": [{ "email": "nylascypresstest@gmail.com", "name": "Test User" }],
     "unread": false
   }

--- a/cypress/fixtures/email/threads/id.json
+++ b/cypress/fixtures/email/threads/id.json
@@ -154,9 +154,9 @@
         "name": "Phil Renaud"
       }
     ],
-    "snippet": "Test Email Snippet",
+    "snippet": "Test snippet",
     "starred": false,
-    "subject": "Test Email Subject",
+    "subject": "Test subject",
     "unread": true,
     "version": 1
   }

--- a/cypress/fixtures/email/threads/idWithImage.json
+++ b/cypress/fixtures/email/threads/idWithImage.json
@@ -24,24 +24,26 @@
         "name": "important"
       },
       {
-        "display_name": "INBOX",
-        "id": "dx62wkpj57erbkargbr3zew3j",
-        "name": "inbox"
-      },
-      {
         "display_name": "All Mail",
         "id": "78im4dxnn2mj0hl038vcnezwn",
         "name": "all"
+      },
+      {
+        "display_name": "INBOX",
+        "id": "dx62wkpj57erbkargbr3zew3j",
+        "name": "inbox"
       }
     ],
     "last_message_received_timestamp": 1638895701,
     "last_message_sent_timestamp": null,
     "last_message_timestamp": 1638895701,
+    "last_updated_timestamp": 1639002001,
     "messages": [
       {
         "account_id": "1xrddnl99frq3b7son9j32aba",
         "bcc": [],
         "cc": [],
+        "cids": ["ii_kwwc5np40"],
         "date": 1638895701,
         "files": [
           {
@@ -53,14 +55,9 @@
             "size": 1022500
           }
         ],
-        "from": [{ "email": "test@nylas.com", "name": "First User" }],
+        "from": [{ "email": "person@email.com", "name": "Test Person" }],
         "id": "7w3i9u9xk95w331zuw40yvm4j",
         "labels": [
-          {
-            "display_name": "INBOX",
-            "id": "dx62wkpj57erbkargbr3zew3j",
-            "name": "inbox"
-          },
           {
             "display_name": "IMPORTANT",
             "id": "5852fv5ompdk51g0ve17mvej9",
@@ -70,6 +67,11 @@
             "display_name": "All Mail",
             "id": "78im4dxnn2mj0hl038vcnezwn",
             "name": "all"
+          },
+          {
+            "display_name": "INBOX",
+            "id": "dx62wkpj57erbkargbr3zew3j",
+            "name": "inbox"
           }
         ],
         "object": "message",
@@ -84,7 +86,7 @@
     ],
     "object": "thread",
     "participants": [
-      { "email": "test@nylas.com", "name": "First User" },
+      { "email": "person@email.com", "name": "Test Person" },
       { "email": "nylascypresstest@gmail.com", "name": "Test User" }
     ],
     "snippet": "Inline image test: Does it render properly?",

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -30,3 +30,15 @@ Cypress.Commands.add(
     });
   },
 );
+
+/**
+ * Define the fetch request `method` in the first parameter.
+ * The second parameter is a set of key:value pairs where the
+ * KEY is the url path to be intercepted and the VALUE is the
+ * path of the fixture for the response.
+ */
+Cypress.Commands.add("batchIntercept", (method, fixtures) => {
+  Object.entries(fixtures).forEach(([url, fixture]) => {
+    cy.intercept(method, url, { fixture }).as(fixture);
+  });
+});


### PR DESCRIPTION
# Code changes

- [x] refactor email tests
- [x] re-enable skipped tests
- [x] add intercepts
- [x] introduce `cy.batchIntercept`
Previously, intercepting each request in some test suites can add a lot of lines of code to the tests making it harder to read. With `batchIntercept` we can greatly reduce the amount of code. 

### Before
```
cy.intercept(
      "GET",
      "https://web-components.nylas.com/middleware/messages/c5xjcjlhzldqctpud8zeufa6t",
      {
        fixture: "email/messages/idWithImage.json",
      },
    ).as("messageWithImage");
    cy.intercept(
      "GET",
      "https://web-components.nylas.com/middleware/messages/affxolvozy2pcqh4303w7pc9n",
      {
        fixture: "email/messages/id.json",
      },
    );
    cy.intercept("GET", "https://web-components.nylas.com/middleware/account", {
      fixture: "email/account.json",
    });
    cy.intercept(
      "GET",
      "https://web-components.nylas.com/middleware/files/6dywzoo80moag1it135co9zv8/download",
      {
        fixture: "email/files/download.json",
      },
    ).as("filesDownload");
```

### After
Define the fetch request `method` in the first parameter and the second parameter is a set of key:value pairs where the key is the `url path` to be intercepted and the value is the `path of the fixture` for the response.
```
cy.batchIntercept("GET", {
      "**/middleware/manifest": "email/manifest",
      "**/middleware/account": "email/account",
      "**/middleware/labels": "email/labels",
      "**/middleware/threads/b3z0fd5kbbwcxbvf4q1ele5us6*": "email/threads/id",
      "**/middleware/messages/c5xjcjlhzldqctpud8zeufa6t": "email/messages/idWithImage",
      "**/middleware/messages/affxolvozy2pcqh4303w7pc9n": "email/messages/id",
      "**/middleware/files/6dywzoo80moag1it135co9zv8/download": "email/files/download",
    });
```

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
