### PR TITLE
[Composer]: Header should reactively update with the change in the subject

### DIFF
--- a/components/composer/CHANGELOG.md
+++ b/components/composer/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Bug Fixes
 
 - [Composer] focus the HTML editor textbox when a formatting option is clicked [#342](https://github.com/nylas/components/pull/342)
+- [Composer] Header should reactively update with the change in the subject [#367](https://github.com/nylas/components/pull/367)
 
 # v1.1.6 (Unreleased)
 

--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -151,7 +151,8 @@
   let showDatepicker = false;
   let themeLoaded = false;
   let visible = true;
-  $: subject = value?.subject ?? $message.subject;
+  let subject = _this.value?.subject ?? $message.subject;
+  $: subject = $message.subject;
 
   onMount(async () => {
     isLoading = true;


### PR DESCRIPTION
# Code changes

- Header should be reactive to the subject

# Screenshot

https://user-images.githubusercontent.com/16315004/151607678-6bbd7050-a0ab-4b1a-9ecb-911c7c91f191.mov


