### PR TITLE
Added timezone prop support to Agenda

### DIFF
--- a/commons/src/methods/convertDateTimeZone.ts
+++ b/commons/src/methods/convertDateTimeZone.ts
@@ -60,3 +60,14 @@ export function getSpecifiedTimeZoneOffset(zone?: string): number {
   const dtz = DateTime.now().setZone(zone, { keepLocalTime: true });
   return dt.diff(dtz).milliseconds;
 }
+
+/**
+ *
+ * @param date Date
+ * @param zone string
+ * @returns number (in milliseconds)
+ */
+export function getTimeInTimezone(date: Date, zone?: string): number {
+  const timeValue = date.getTime();
+  return timeValue + getSpecifiedTimeZoneOffset(zone);
+}

--- a/commons/src/methods/convertDateTimeZone.ts
+++ b/commons/src/methods/convertDateTimeZone.ts
@@ -47,8 +47,6 @@ export function setTimeZoneOffset(slot: Date, zone?: string): string {
 }
 
 /**
- *
- *
  * @param zone string
  * @returns number (in milliseconds)
  */
@@ -59,6 +57,18 @@ export function getSpecifiedTimeZoneOffset(zone?: string): number {
   const dt = DateTime.now();
   const dtz = DateTime.now().setZone(zone, { keepLocalTime: true });
   return dt.diff(dtz).milliseconds;
+}
+
+/**
+ * @param zone string
+ * @returns string (UTC Offset)
+ */
+export function getSpecifiedTimeZoneOffsetName(zone?: string): string {
+  if (!zone || !isValidTimezone(zone)) {
+    return DateTime.now().offsetNameShort;
+  }
+  const dt = DateTime.now().setZone(zone);
+  return dt.offsetNameShort;
 }
 
 /**

--- a/commons/src/methods/convertDateTimeZone.ts
+++ b/commons/src/methods/convertDateTimeZone.ts
@@ -45,3 +45,18 @@ export function setTimeZoneOffset(slot: Date, zone?: string): string {
   }
   return dateTimeSlot.offsetNameShort;
 }
+
+/**
+ *
+ *
+ * @param zone string
+ * @returns number (in milliseconds)
+ */
+export function getSpecifiedTimeZoneOffset(zone?: string): number {
+  if (!zone || !isValidTimezone(zone)) {
+    return 0;
+  }
+  const dt = DateTime.now();
+  const dtz = DateTime.now().setZone(zone, { keepLocalTime: true });
+  return dt.diff(dtz).milliseconds;
+}

--- a/commons/src/types/Nylas.ts
+++ b/commons/src/types/Nylas.ts
@@ -187,6 +187,7 @@ export interface AgendaProperties extends Manifest {
   theme: "theme-1" | "theme-2" | "theme-3" | "theme-4" | "theme-5";
   hide_ticks: boolean;
   timezone_agnostic_all_day_events: boolean;
+  timezone: string;
 }
 
 export interface EmailProperties extends Manifest {

--- a/commons/src/types/Nylas.ts
+++ b/commons/src/types/Nylas.ts
@@ -179,15 +179,15 @@ export interface AgendaProperties extends Manifest {
   header_type: "full" | "day" | "none";
   hide_all_day_events: boolean;
   hide_current_time: boolean;
+  hide_ticks: boolean;
   prevent_zoom: boolean;
   selected_date: Date;
   show_as_busy: boolean;
   show_no_events_message: boolean;
   start_minute: number;
   theme: "theme-1" | "theme-2" | "theme-3" | "theme-4" | "theme-5";
-  hide_ticks: boolean;
-  timezone_agnostic_all_day_events: boolean;
   timezone: string;
+  timezone_agnostic_all_day_events: boolean;
 }
 
 export interface EmailProperties extends Manifest {

--- a/components/agenda/CHANGELOG.md
+++ b/components/agenda/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [Agenda] Add overrideable css vars to customize agenda appearance [#378](https://github.com/nylas/components/pull/378)
 - [Agenda] Dispatch `eventClicked` when event is clicked [#372](https://github.com/nylas/components/pull/372)
+- [Agenda] Added timezone prop support to Agenda [#368](https://github.com/nylas/components/pull/368)
 
 ## Bug Fixes
 

--- a/components/agenda/src/Agenda.svelte
+++ b/components/agenda/src/Agenda.svelte
@@ -13,6 +13,7 @@
     isValidTimezone,
     getSpecifiedTimeZoneOffset,
     formatTimeSlot,
+    getTimeInTimezone,
   } from "@commons/methods/convertDateTimeZone";
   import type { EventPosition } from "./methods/position";
   import { populatePositionMap, updateEventPosition } from "./methods/position";
@@ -97,7 +98,7 @@
     show_no_events_message: false,
     start_minute: 0,
     theme: "theme-1",
-    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    timezone: undefined,
     timezone_agnostic_all_day_events: true,
   };
 
@@ -186,9 +187,7 @@
     } else {
       let date = new Date();
       if (_this.timezone) {
-        date = new Date(
-          date.toLocaleString("default", { timeZone: _this.timezone }),
-        );
+        date = new Date(getTimeInTimezone(date, _this.timezone));
       }
       date.setHours(0, 0, 0, 0);
       selectedDate = date;
@@ -464,11 +463,7 @@
 
           let startTime = new Date(event.when.start_time * 1000);
           if (_this.timezone) {
-            startTime = new Date(
-              startTime.toLocaleString("default", {
-                timeZone: _this.timezone,
-              }),
-            );
+            startTime = new Date(getTimeInTimezone(startTime, _this.timezone));
           }
 
           let minutesInVisibleDay =
@@ -604,9 +599,7 @@
     };
   });
 
-  $: currentTime = new Date(
-    new Date(now).toLocaleString("default", { timeZone: _this.timezone }), // seems redundant, right? new Date() does the same thing. But, the inclusion of "now" means that changes to it are observed -- and we change every setInterval loop.
-  );
+  $: currentTime = new Date(now + timezoneOffset); // seems redundant, right? new Date() does the same thing. But, the inclusion of "now" means that changes to it are observed -- and we change every setInterval loop.
 
   $: currentTimePosition = () => {
     let currentStart = new Date(currentTime.getTime());

--- a/components/agenda/src/Agenda.svelte
+++ b/components/agenda/src/Agenda.svelte
@@ -9,7 +9,10 @@
     buildInternalProps,
     getEventDispatcher,
   } from "@commons/methods/component";
-  import { isValidTimezone } from "@commons/methods/convertDateTimeZone";
+  import {
+    isValidTimezone,
+    getSpecifiedTimeZoneOffset,
+  } from "@commons/methods/convertDateTimeZone";
   import type { EventPosition } from "./methods/position";
   import { populatePositionMap, updateEventPosition } from "./methods/position";
   import { getDynamicEndTime, getDynamicStartTime } from "./methods/time";
@@ -200,6 +203,15 @@
     calendarIDs = setCalendarIDs();
   }
 
+  let timezoneOffset: number;
+  $: {
+    if (_this.timezone && isValidTimezone(_this.timezone)) {
+      timezoneOffset = getSpecifiedTimeZoneOffset(_this.timezone);
+    } else {
+      timezoneOffset = 0;
+    }
+  }
+
   $: clickDefault = typeof click_action === "function" ? "none" : "expand";
   // #endregion props
 
@@ -255,9 +267,13 @@
   let endOfDay: number;
 
   $: startOfDay =
-    new Date(new Date(selectedDate).setHours(0, 0, 0, 0)).getTime() / 1000;
+    (new Date(new Date(selectedDate).setHours(0, 0, 0, 0)).getTime() -
+      timezoneOffset) /
+    1000;
   $: endOfDay =
-    new Date(new Date(selectedDate).setHours(24, 0, 0, 0)).getTime() / 1000;
+    (new Date(new Date(selectedDate).setHours(24, 0, 0, 0)).getTime() -
+      timezoneOffset) /
+    1000;
 
   // #endregion time constants
 
@@ -305,10 +321,12 @@
         access_token: access_token,
         calendarIDs: calendarIDs,
         starts_after:
-          new Date(new Date(previousDate).setHours(0, 0, 0, 0)).getTime() /
+          (new Date(new Date(previousDate).setHours(0, 0, 0, 0)).getTime() -
+            timezoneOffset) /
           1000,
         ends_before:
-          new Date(new Date(previousDate).setHours(24, 0, 0, 0)).getTime() /
+          (new Date(new Date(previousDate).setHours(24, 0, 0, 0)).getTime() -
+            timezoneOffset) /
           1000,
       },
       {
@@ -316,9 +334,13 @@
         access_token: access_token,
         calendarIDs: calendarIDs,
         starts_after:
-          new Date(new Date(nextDate).setHours(0, 0, 0, 0)).getTime() / 1000,
+          (new Date(new Date(nextDate).setHours(0, 0, 0, 0)).getTime() -
+            timezoneOffset) /
+          1000,
         ends_before:
-          new Date(new Date(nextDate).setHours(24, 0, 0, 0)).getTime() / 1000,
+          (new Date(new Date(nextDate).setHours(24, 0, 0, 0)).getTime() -
+            timezoneOffset) /
+          1000,
       },
     ];
   }

--- a/components/agenda/src/index.html
+++ b/components/agenda/src/index.html
@@ -26,6 +26,9 @@
             hour: "numeric",
             minute: "numeric",
             hour12: true,
+            timeZone:
+              agenda.timezone ??
+              Intl.DateTimeFormat().resolvedOptions().timeZone,
           });
           endTimeInput.value = new Date(
             newEvent.when.end_time * 1000,
@@ -33,6 +36,9 @@
             hour: "numeric",
             minute: "numeric",
             hour12: true,
+            timeZone:
+              agenda.timezone ??
+              Intl.DateTimeFormat().resolvedOptions().timeZone,
           });
           save = saveEvent;
           cancel = cancelEvent;
@@ -96,11 +102,17 @@
             return false;
           }
 
-          newEvent.when.start_time = new Date(
-            currentDay.setHours(startTime24h.hours, startTime24h.minutes, 0, 0),
+          newEvent.when.start_time = currentDay.setHours(
+            startTime24h.hours,
+            startTime24h.minutes,
+            0,
+            0,
           );
-          newEvent.when.end_time = new Date(
-            currentDay.setHours(endTime24h.hours, endTime24h.minutes, 0, 0),
+          newEvent.when.end_time = currentDay.setHours(
+            endTime24h.hours,
+            endTime24h.minutes,
+            0,
+            0,
           );
           return true;
         }
@@ -160,7 +172,7 @@
 
         let i = document.querySelector("input.start");
         let i2 = document.querySelector("input.end");
-        let checkbox = document.querySelector("input.auto-time");
+        let autoTimeCheckbox = document.querySelector("input.auto-time");
         let condensedBox = document.querySelector("input.condensed-view");
         let tickBox = document.querySelector("input.hide-ticks");
         let theme = document.querySelectorAll("input[name='theme']");
@@ -191,11 +203,11 @@
           false,
         );
 
-        checkbox.addEventListener(
+        autoTimeCheckbox.addEventListener(
           "input",
           function () {
             document.querySelectorAll("nylas-agenda").forEach((element) => {
-              element.auto_time_box = checkbox.checked;
+              element.auto_time_box = autoTimeCheckbox.checked;
             });
           },
           false,

--- a/components/agenda/src/init.spec.js
+++ b/components/agenda/src/init.spec.js
@@ -370,3 +370,34 @@ describe("Agenda custom events", () => {
     });
   });
 });
+
+describe("Display events in different timezone is specified", () => {
+  beforeEach(() => {
+    //Set current time to 2am
+    cy.clock(1642143600000);
+    cy.batchIntercept("GET", {
+      "**/middleware/manifest": "agenda/manifest",
+      "**/middleware/calendars/test-calendar-id": "agenda/calendars/calendarId",
+      "**/middleware/agenda/events?*": "agenda/events",
+    });
+
+    cy.visit("/components/agenda/src/cypress.html");
+    cy.get("nylas-agenda").should("exist").as("agenda");
+  });
+
+  it("displays current day of week and date in cooresponding timezone", () => {
+    cy.get("@agenda").invoke("attr", "timezone", "America/Toronto");
+    cy.get("@agenda").contains("Friday 14");
+    cy.get("@agenda").invoke("attr", "timezone", "America/Los_Angeles");
+    cy.get("@agenda").contains("Thursday 13");
+  });
+
+  it("displays fetched events time with corresponding timezone", () => {
+    cy.get("@agenda").invoke("attr", "timezone", "America/Toronto");
+    cy.get("@agenda").get(".event").eq(0).contains(".time", "10:00 AM");
+    cy.get("@agenda").get(".event").eq(1).contains(".time", "12:35 PM");
+    cy.get("@agenda").invoke("attr", "timezone", "America/Los_Angeles");
+    cy.get("@agenda").get(".event").eq(0).contains(".time", "7:00 AM");
+    cy.get("@agenda").get(".event").eq(1).contains(".time", "9:35 AM");
+  });
+});

--- a/components/agenda/src/properties.json
+++ b/components/agenda/src/properties.json
@@ -19,6 +19,12 @@
     "value": "theme-1"
   },
   {
+    "label": "timezone",
+    "title": "Specified timezone for agenda",
+    "type": "string",
+    "noPreview": true
+  },
+  {
     "label": "header_type",
     "title": "Header type",
     "type": "string",

--- a/components/agenda/src/styles/agenda.scss
+++ b/components/agenda/src/styles/agenda.scss
@@ -161,17 +161,38 @@ h2 {
   display: grid;
   grid-column: 1/3;
   grid-template-columns: 40px 1fr;
+  grid-template-rows: 1rem 1fr;
   overflow: hidden;
   line-height: 100%;
   min-height: 200px;
 
   &.hide-ticks {
     grid-template-columns: 0px 1fr;
+    grid-template-rows: 0px 1fr;
     grid-column-gap: 0;
 
     .ticks {
       visibility: hidden;
     }
+    .offset {
+      visibility: hidden;
+    }
+  }
+}
+
+.offset {
+  display: relative;
+  grid-row: 1/2;
+  grid-column: 1/3;
+  span {
+    position: absolute;
+    left: 0;
+    width: 40px;
+    text-align: right;
+    display: block;
+    white-space: nowrap;
+    font-size: 11px;
+    opacity: 0.6;
   }
 }
 


### PR DESCRIPTION
# Code changes

- Added `timezone` property to Agenda component
- When specifying a `timezone` to the component that's different from client system's IANA timezone, it will show the following elements in the specified timezone:
    - Selected day and date (if current date of the timezone is different from client's local date, and if `selected_date` prop is not set).
    - Events start time
    - Current time indicator
- Agenda ticks order remain unchanged  (From _12AM_ to _11PM_,  similar to changing timezone in Google Calendar)

# Screen Capture

https://user-images.githubusercontent.com/14408339/151813722-5d4a2378-e8b3-4953-b800-06064e17fd9b.mov


# Readiness checklist

- [x] Added changes to component `CHANGELOG.md`
- [x] New property added? make sure to update `component/src/properties.json`
- [x] Cypress tests passing?
- [x] New cypress tests added?
- [x] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
