### PR TITLE
[Mailbox]: Added a 'click_action' prop whose default value is set to 'default'

### DIFF
--- a/commons/src/enums/Nylas.ts
+++ b/commons/src/enums/Nylas.ts
@@ -20,3 +20,8 @@ export enum MessageType {
   DRAFTS = "drafts",
   MESSAGES = "messages",
 }
+
+export enum MailboxClickAction {
+  DEFAULT = "default",
+  CUSTOM = "custom",
+}

--- a/commons/src/enums/Nylas.ts
+++ b/commons/src/enums/Nylas.ts
@@ -21,7 +21,7 @@ export enum MessageType {
   MESSAGES = "messages",
 }
 
-export enum MailboxClickAction {
+export enum MailboxThreadClickAction {
   DEFAULT = "default",
   CUSTOM = "custom",
 }

--- a/commons/src/types/Nylas.ts
+++ b/commons/src/types/Nylas.ts
@@ -2,6 +2,7 @@ import type {
   AccountOrganizationUnit,
   AccountSyncState,
   MailboxActions,
+  MailboxClickAction,
 } from "@commons/enums/Nylas";
 import type { Contact, HydratedContact } from "@commons/types/Contacts";
 import type { Event } from "@commons/types/Events";
@@ -219,6 +220,7 @@ export interface MailboxProperties extends Manifest {
   show_reply: boolean;
   show_reply_all: boolean;
   show_forward: boolean;
+  click_action: MailboxClickAction;
 }
 
 export type ContactSearchCallback = Participant[] | FetchContactsCallback;

--- a/commons/src/types/Nylas.ts
+++ b/commons/src/types/Nylas.ts
@@ -2,7 +2,7 @@ import type {
   AccountOrganizationUnit,
   AccountSyncState,
   MailboxActions,
-  MailboxClickAction,
+  MailboxThreadClickAction,
 } from "@commons/enums/Nylas";
 import type { Contact, HydratedContact } from "@commons/types/Contacts";
 import type { Event } from "@commons/types/Events";
@@ -220,7 +220,7 @@ export interface MailboxProperties extends Manifest {
   show_reply: boolean;
   show_reply_all: boolean;
   show_forward: boolean;
-  click_action: MailboxClickAction;
+  thread_click_action: MailboxThreadClickAction;
 }
 
 export type ContactSearchCallback = Participant[] | FetchContactsCallback;

--- a/components/mailbox/CHANGELOG.md
+++ b/components/mailbox/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Show confirmation pop up, when deleting emails
 - Pass z-index css to confirmation pop up's modal & overlay using css variables `z-index-modal` & `z-index-overlay` respectively
 - Draft, reply, reply all and forwarded messages include inline images and attachments
+- [Mailbox] Added new prop 'thread_click_action' that allows to specify the action on clicking an email thread [#369](https://github.com/nylas/components/pull/369)
 
 ## Bug Fixes
 

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -7,7 +7,7 @@
     AccountOrganizationUnit,
     MailboxActions,
     MessageType,
-    MailboxClickAction,
+    MailboxThreadClickAction,
   } from "@commons/enums/Nylas";
 
   import {
@@ -62,7 +62,8 @@
   export let show_reply: boolean;
   export let show_reply_all: boolean;
   export let show_forward: boolean;
-  export let click_action: MailboxClickAction = MailboxClickAction.DEFAULT;
+  export let thread_click_action: MailboxThreadClickAction =
+    MailboxThreadClickAction.DEFAULT;
 
   const defaultValueMap: Partial<MailboxProperties> = {
     actions_bar: [],
@@ -73,7 +74,7 @@
     show_reply: false,
     show_reply_all: false,
     show_forward: false,
-    click_action: MailboxClickAction.DEFAULT,
+    thread_click_action: MailboxThreadClickAction.DEFAULT,
   };
 
   let mouseEvent: CustomEvent;
@@ -319,7 +320,7 @@
   async function threadClicked(event: CustomEvent) {
     const { thread, messageType } = event.detail;
     const messages = thread[messageType];
-    if (_this.click_action === MailboxClickAction.DEFAULT) {
+    if (_this.thread_click_action === MailboxThreadClickAction.DEFAULT) {
       let message = await fetchIndividualMessage(messages[messages.length - 1]);
 
       if (messageType === MessageType.DRAFTS) {

--- a/components/mailbox/src/properties.json
+++ b/components/mailbox/src/properties.json
@@ -100,5 +100,12 @@
     "type": "boolean",
     "options": [true, false],
     "value": false
+  },
+  {
+    "label": "click_action",
+    "title": "This option allows to specify the type of click action. By setting it to 'custom', you can listen to 'threadClicked' event from email component to perform actions as per your need",
+    "type": "string",
+    "options": ["default", "custom"],
+    "value": "default"
   }
 ]


### PR DESCRIPTION
For the React CRM app that I'm working on, as a user I want the flexibility to control / handle the click action as per my requirements, which is to spin up a conversation component based on the thread id information dispatched from the Mailbox component.

In order to achieve that, adding a new property `thread_click_action` to Mailbox component.

# Code changes

- Added a new property `click_action` to Mailbox component which allows to specify how the user wants to handle click action on an email thread with 2 values `default` and `custom`
- Setting this property's default value to `default`
- Created enum MailboxThreadClickAction

# Readiness checklist

- [X] Added changes to component `CHANGELOG.md`
- [X] New property added? make sure to update `component/src/properties.json`
- [X] Cypress tests passing?
