### PR TITLE
Fixed reply, reply-to feature to have a default if reply_to is not available

### DIFF
--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -523,6 +523,7 @@
 
     const from = [me];
     const { to, cc } = buildParticipants({
+      myEmail: me.email,
       message: message,
       type,
     });

--- a/components/email/src/methods/participants.ts
+++ b/components/email/src/methods/participants.ts
@@ -34,20 +34,26 @@ type BuildParticipant = {
 };
 
 export function buildParticipants({
+  myEmail,
   message,
   type,
 }: BuildParticipant): Record<string, Participant[]> {
   let to: Participant[] = [];
   let cc: Participant[] = [];
+  to = message.reply_to;
+  // if message does not have 'reply_to':
+  // - AND if message from self set 'to' as the default 'to'
+  // - else set 'from' as the default 'to'
+  if (!to.length) {
+    if (includesMyEmail(myEmail, message, "from")) {
+      to = message.to;
+    } else {
+      to = message.from;
+    }
+  }
 
-  switch (type) {
-    case "reply":
-      to = message.reply_to;
-      break;
-    case "reply_all":
-      to = message.reply_to;
-      cc = [...message.cc];
-      break;
+  if (type === "reply_all") {
+    cc = [...message.cc];
   }
 
   return { to, cc };


### PR DESCRIPTION

# Code changes
- `reply_to` is not always populated in the message object, which can cause issues on reply, reply-all, if we don't have a fallback value.

This fix adds back the fallback value while defaulting to `reply_to`

