### PR TITLE
Adds the ability for a dev to pass a hardcoded image url

### DIFF
--- a/components/contact-list/src/ContactList.svelte
+++ b/components/contact-list/src/ContactList.svelte
@@ -571,9 +571,13 @@
                 />
               {/if}
             {:else if contact.picture_url}
-              {#await fetchContactImage(query, contact.id).then((image) => (contact.picture = image))}
-                {(contact.picture = "Loading")}
-              {/await}
+              {#if _this.contacts.length}
+                <img src={contact.picture_url} alt={contact.emails[0].email} />
+              {:else}
+                {#await fetchContactImage(query, contact.id).then((image) => (contact.picture = image))}
+                  {(contact.picture = "Loading")}
+                {/await}
+              {/if}
             {:else if contact.default_picture}
               <img
                 src={contact.default_picture}


### PR DESCRIPTION
Small change to allow for better DevEx when passing data to the contact list component.

Currently, there's no way to pass an image via URL along with contact details. The contact.picture_url always expects to do a Nylas API-based image lookup and set the src as image data after the fact, but this leaves no room for a static URL for an image to be passed in.

Now the user can do something like:

```
	let contacts = [
		{
			emails: [
				{
					email: 'phil.r@nylas.com'
				}
			],
			given_name: 'Phil',
			surname: 'Renaud',
			picture_url: 'https://pbs.twimg.com/profile_images/497537241405612032/TqVgj3zv_400x400.jpeg'
		}
        ]
<nylas-contact-list contacts={contacts} />
```

and get an image as expected

![image](https://user-images.githubusercontent.com/713991/151906945-dd757a74-2a92-4024-830e-56e6ce73e9ae.png)



# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
