### PR TITLE
[agenda] dispatch eventClicked when event is clicked

### DIFF
--- a/components/agenda/CHANGELOG.md
+++ b/components/agenda/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## New Features
 
+- [Agenda] Dispatch `eventClicked` when event is clicked [#372](https://github.com/nylas/components/pull/372)
+
 ## Bug Fixes
 
 - [Agenda] Added min height to agenda body [#339](https://github.com/nylas/components/pull/339)

--- a/components/agenda/src/Agenda.svelte
+++ b/components/agenda/src/Agenda.svelte
@@ -657,6 +657,8 @@
     event: MouseEvent | KeyboardEvent,
     calendarEvent: Event,
   ) {
+    dispatchEvent("eventClicked", calendarEvent);
+
     if (typeof click_action === "function") {
       const clonedEvent = JSON.parse(JSON.stringify(calendarEvent));
       for (const internalProp of INTERNAL_EVENT_PROPS) {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -40,3 +40,11 @@ Cypress.Commands.add("batchIntercept", (method, fixtures) => {
     cy.intercept(method, url, { fixture }).as(fixture);
   });
 });
+
+Cypress.Commands.add(
+  "addListener",
+  { prevSubject: "element" },
+  ($element, eventName, callbackFn) => {
+    $element[0].addEventListener(eventName, callbackFn);
+  },
+);


### PR DESCRIPTION
# Code changes
## Context
While waiting for [a PR that allows cancelable custom events](https://github.com/sveltejs/svelte/pull/7064) to get merged,  we need to dispatching an `eventClicked` event on top of `click_action` since some users may want the event fired without overriding our set behaviour.

- [x] dispatch custom `eventClicked` event when event is clicked
- [x] adds custom cypress command `addListener` to add event listeners from chaining a getter.
## Before:
```
cy.get("@agenda").then((element) => {
      const agenda = element[0];
      agenda.addEventListener('event', () => {
        // logic goes here
      });
    });
```

## After:
```
cy.get("@agenda").addListener("dateChange", () => {
   // logic goes here
});
```
- [x] adds test for `dateChange` dispatch events

# Readiness checklist

- [x] Added changes to component `CHANGELOG.md`

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
