### PR TITLE
[Mailbox][Email]: If thread uses folder, move individual messages to trash folder

### DIFF
--- a/commons/src/connections/messages.ts
+++ b/commons/src/connections/messages.ts
@@ -33,6 +33,28 @@ export const sendMessage = async (
     .catch((error) => handleError(component_id, error));
 };
 
+export async function updateMessage(
+  component_id: string,
+  message: NylasMessage,
+  access_token?: string,
+): Promise<NylasMessage> {
+  const url = `${getMiddlewareApiUrl(component_id)}/messages/${message.id}`;
+  const fetchConfig = getFetchConfig({
+    method: "PUT",
+    component_id,
+    access_token,
+    body: { folder_id: message.folder_id },
+  });
+  return await fetch(url, fetchConfig)
+    .then((response) =>
+      handleResponse<MiddlewareResponse<NylasMessage>>(response),
+    )
+    .then((json) => {
+      return json.response;
+    })
+    .catch((error) => handleError(component_id, error));
+}
+
 export const uploadFile = async (
   component_id: string,
   file: File,

--- a/commons/src/connections/threads.ts
+++ b/commons/src/connections/threads.ts
@@ -25,10 +25,23 @@ export const fetchThreads = (
       (param) => (queryString = queryString.concat(`&${param[0]}=${param[1]}`)),
     );
   }
-  return fetch(queryString, getFetchConfig(query))
-    .then((response) => handleResponse<MiddlewareResponse<Thread[]>>(response))
-    .then((json) => json.response)
-    .catch((error) => handleError(query.component_id, error));
+  return (
+    fetch(queryString, getFetchConfig(query))
+      .then((response) =>
+        handleResponse<MiddlewareResponse<Thread[]>>(response),
+      )
+      .then((json) => json.response)
+      // TODO: Remove this ugly hack when we fix the API from returning ghost messages (e.g. w/o a from/to field)
+      .then((threads) =>
+        threads.map((thread) => ({
+          ...thread,
+          messages: thread.messages.filter(
+            (message) => message.from.length !== 0 || message.to.length !== 0,
+          ),
+        })),
+      )
+      .catch((error) => handleError(query.component_id, error))
+  );
 };
 
 export function fetchThreadCount(query: MailboxQuery): Promise<number> {

--- a/commons/src/types/Nylas.ts
+++ b/commons/src/types/Nylas.ts
@@ -126,6 +126,8 @@ export interface Message {
   files: File[];
   reply_to: Participant[];
   reply_to_message_id?: string;
+  folder_id?: string;
+  label_ids?: string[];
 }
 
 export interface RadialMessage extends Message {

--- a/components/mailbox/CHANGELOG.md
+++ b/components/mailbox/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Fixed some attached files being treated as inline [283](https://github.com/nylas/components/pull/283)
 - Fixed TypeError was being thrown if all_threads prop was used and user clicked a message to expand it's body [315](https://github.com/nylas/components/pull/315)
 - Fixed dispatched event `threadClicked` being dispatched multiple times on a single click [315](https://github.com/nylas/components/pull/315)
+- Fixed the issue where deleting a sent thread by self using non-gmail account was not working [#374](https://github.com/nylas/components/pull/374)
 
 # v1.1.5 (2021-12-15)
 

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -1,7 +1,7 @@
 <svelte:options tag="nylas-mailbox" />
 
 <script lang="ts">
-  import { ErrorStore, fetchAccount, ManifestStore } from "@commons";
+  import { ErrorStore, fetchAccount, ManifestStore, silence } from "@commons";
   import { fetchMessage, updateMessage } from "@commons/connections/messages";
   import {
     AccountOrganizationUnit,
@@ -524,13 +524,16 @@
          * individual messages to trash folder as a workaround
          **/
         if (id) {
-          thread.messages.forEach(async (message: Message, i: number) => {
+          for (let message of thread.messages) {
             await updateMessage(
               query.component_id,
               { ...message, folder_id: trashFolderID },
               access_token,
-            );
-          });
+            ).catch((err) => {
+              silence(err);
+              deleting = false;
+            });
+          }
         }
       }
       await updateDisplayedThreads(true);

--- a/components/mailbox/src/init.spec.js
+++ b/components/mailbox/src/init.spec.js
@@ -107,6 +107,7 @@ const defaultSize = 13;
 describe("Mailbox Display", () => {
   let thread1;
   let thread2;
+  let THREAD_WITH_MESSAGE_THAT_DOES_NOT_HAVE_FROM_OR_TO_FIELDS;
 
   beforeEach(() => {
     cy.intercept(
@@ -137,6 +138,21 @@ describe("Mailbox Display", () => {
       },
     );
 
+    cy.intercept(
+      "GET",
+      "https://web-components.nylas.com/middleware/threads?view=expanded&not_in=trash&limit=13&offset=0&in=inbox",
+      {
+        fixture:
+          "mailbox/threads/threadWithMessageThatDoesNotHaveFromOrToFields.json",
+      },
+    );
+
+    cy.fixture(
+      "mailbox/threads/threadWithMessageThatDoesNotHaveFromOrToFields.json",
+    ).then((f) => {
+      THREAD_WITH_MESSAGE_THAT_DOES_NOT_HAVE_FROM_OR_TO_FIELDS = f.response;
+    });
+
     cy.fixture("mailbox/threads/SAMPLE_1.json").then((f) => {
       thread1 = f;
     });
@@ -161,6 +177,17 @@ describe("Mailbox Display", () => {
 
   it("Shows empty message", () => {
     cy.get("@mailbox").invoke("prop", "all_threads", [EMPTY_THREAD]);
+    cy.get("@email")
+      .find(".snippet")
+      .contains("Sorry, looks like this thread is currently unavailable");
+  });
+
+  it("Filters out messages with no 'to' or 'from' fields", () => {
+    cy.get("@mailbox").invoke(
+      "prop",
+      "all_threads",
+      THREAD_WITH_MESSAGE_THAT_DOES_NOT_HAVE_FROM_OR_TO_FIELDS,
+    );
     cy.get("@email")
       .find(".snippet")
       .contains("Sorry, looks like this thread is currently unavailable");

--- a/cypress/fixtures/mailbox/threads/threadWithMessageThatDoesNotHaveFromOrToFields.json
+++ b/cypress/fixtures/mailbox/threads/threadWithMessageThatDoesNotHaveFromOrToFields.json
@@ -1,0 +1,60 @@
+{
+  "component": {
+    "theming": {}
+  },
+  "response": [
+    {
+      "account_id": "1xrddnl99frq3b7son9j32aba",
+      "drafts": [],
+      "first_message_timestamp": 1643903027,
+      "has_attachments": false,
+      "id": "5xpfczn3ruyg21as6d0wxvefy",
+      "labels": [
+        {
+          "display_name": "INBOX",
+          "id": "dx62wkpj57erbkargbr3zew3j",
+          "name": "inbox"
+        }
+      ],
+      "last_message_received_timestamp": 1643903027,
+      "last_message_sent_timestamp": null,
+      "last_message_timestamp": 1643903027,
+      "last_updated_timestamp": 1643917866,
+      "messages": [
+        {
+          "account_id": "1xrddnl99frq3b7son9j32aba",
+          "bcc": [],
+          "body": "",
+          "cc": [],
+          "date": 1643903027,
+          "events": [],
+          "files": [],
+          "from": [],
+          "id": "2hw263r2j8fu7h0gtj404uwm2",
+          "labels": [
+            {
+              "display_name": "INBOX",
+              "id": "dx62wkpj57erbkargbr3zew3j",
+              "name": "inbox"
+            }
+          ],
+          "object": "message",
+          "reply_to": [],
+          "snippet": "",
+          "starred": false,
+          "subject": "",
+          "thread_id": "5xpfczn3ruyg21as6d0wxvefy",
+          "to": [],
+          "unread": false
+        }
+      ],
+      "object": "thread",
+      "participants": [],
+      "snippet": "",
+      "starred": false,
+      "subject": "",
+      "unread": false,
+      "version": 1
+    }
+  ]
+}


### PR DESCRIPTION
Renegade reported an issue where they’re not able to (delete) move an email sent by self to trash folder using a microsoft (non-gmail) account. It looks like this is due to the way our API is set up, where we exclude drafts and sent messages from thread-level moves: [CC code reference](https://github.com/nylas/cloud-core/blob/33b0e4c4af733f54051956e540776bfe5ce21004/nylas/services/api/update.py#L111-L117)

This PR is a workaround, where we will move each message within the thread individually to the trash folder.

# Code changes
- Update the logic in Email and Mailbox components to iterate through individual messages in the thread and move it to trash folder, if the thread / account uses folders instead of labels. For labels, moving a thread to trash folder works fine (that is unchanged)
- Added a new endpoint to `messages.ts` called `updateMessage` to update the folder of the message.

# Screenshot

https://user-images.githubusercontent.com/16315004/152178595-6c7408b2-d4ea-4285-af23-e478bb93500d.mov


# Readiness checklist

- [X] Added changes to component `CHANGELOG.md`
- [X] Cypress tests passing?
- [X] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
