### PR TITLE
[Mailbox]: fixed cannot listen to threadClicked event dispatched from Email using listener on Mailbox component

### DIFF
--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -1004,7 +1004,7 @@
                     show_reply={_this.show_reply}
                     show_reply_all={_this.show_reply_all}
                     show_forward={_this.show_forward}
-                    on:threadClicked|stopPropagation={threadClicked}
+                    on:threadClicked={threadClicked}
                     on:messageClicked={messageClicked}
                     on:threadStarred={threadStarred}
                     on:returnToMailbox={returnToMailbox}


### PR DESCRIPTION
# Code changes

- `stopPropagation` prevents the event threadClicked from being bubbled up to parent app from Mailbox


Not updating the changelog for this as this fix has not been released to a stable version yet.
