### PR TITLE
[Mailbox][Composer]: css for reply thread, focus prop for composer, css vars for attachment icon

### DIFF
--- a/commons/src/types/Nylas.ts
+++ b/commons/src/types/Nylas.ts
@@ -244,6 +244,7 @@ export interface ComposerProperties extends Manifest {
   show_header: boolean;
   show_minimize_button: boolean;
   show_subject: boolean;
+  focus_body_onload: boolean;
   show_to: boolean;
   theme: "auto" | "light" | "dark" | "light-2" | "dark-2";
   visible: boolean;

--- a/components/composer/CHANGELOG.md
+++ b/components/composer/CHANGELOG.md
@@ -17,6 +17,8 @@
 - Allow sending with CMD/CTRL + Enter
 - Added tooltip labels to the WYSIWYG editor icons & attachment icons for improved accessibility
 - Added a prop `reset_after_close` which resets composer fields after closing
+- Added a prop `focus_body_onload` which allows to set focus on the 'body' field on load [#379](https://github.com/nylas/components/pull/379)
+- Added border-left css to visually differentiate the current message from the previous messages [#379](https://github.com/nylas/components/pull/379)
 
 ## Bug Fixes
 

--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -108,6 +108,7 @@
   export let uploadFile: Function | null = null;
   export let beforeFileRemove: Function | null = null;
   export let afterFileRemove: Function | null = null;
+  export let focus_body_onload: boolean;
 
   const defaultValueMap: Partial<ComposerProperties> = {
     show_to: true,
@@ -125,6 +126,7 @@
     show_attachment_button: true,
     show_editor_toolbar: true,
     theme: "auto",
+    focus_body_onload: false,
   };
 
   // Callbacks
@@ -869,6 +871,7 @@
           data-cy="html-editor"
           html={$message.body || template}
           onchange={handleBodyChange}
+          focus_body_onload={_this.focus_body_onload}
           replace_fields={_this.replace_fields}
           show_editor_toolbar={_this.show_editor_toolbar}
           on:keydown={handleKeyDown}

--- a/components/composer/src/components/HTMLEditor.svelte
+++ b/components/composer/src/components/HTMLEditor.svelte
@@ -209,7 +209,6 @@
     contenteditable="true"
     class="html-editor"
     role="textbox"
-    class:focus_body_onload
     on:keyup={updateToolbarUI}
     on:mouseup={updateToolbarUI}
   />

--- a/components/composer/src/components/HTMLEditor.svelte
+++ b/components/composer/src/components/HTMLEditor.svelte
@@ -8,11 +8,21 @@
   export let html = "";
   export let show_editor_toolbar = true;
   export let replace_fields: ReplaceFields[] | null = null;
+  export let focus_body_onload: boolean = false;
 
   let container: HTMLDivElement;
   let toolbar: ToolbarItem[] = defaultActions;
+  let htmlUpdated = false;
+
+  $: if (focus_body_onload && container) {
+    container.focus();
+  }
 
   $: if (html) {
+    if (!htmlUpdated) {
+      htmlUpdated = true;
+      html = `<div><br/><br/><div style="border-left: 3px solid #dfe1e8; padding-left: 1rem;">${html}</div></div>`;
+    }
     const selection = window.getSelection();
 
     if (typeof replace_fields === "string") {

--- a/components/composer/src/components/HTMLEditor.svelte
+++ b/components/composer/src/components/HTMLEditor.svelte
@@ -209,6 +209,7 @@
     contenteditable="true"
     class="html-editor"
     role="textbox"
+    class:focus_body_onload
     on:keyup={updateToolbarUI}
     on:mouseup={updateToolbarUI}
   />

--- a/components/composer/src/init.spec.js
+++ b/components/composer/src/init.spec.js
@@ -486,7 +486,7 @@ describe("Composer customizations", () => {
       .invoke("prop", "innerHTML")
       .then((html) => {
         expect(html).to.equal(
-          "hello what up!<br>\n      <br>\n      <br>\n      Thanks,\n      -Phil",
+          `<div><br><br><div style="border-left: 3px solid #dfe1e8; padding-left: 1rem;">hello what up!<br>\n      <br>\n      <br>\n      Thanks,\n      -Phil</div></div>`,
         );
       });
   });

--- a/components/composer/src/init.spec.js
+++ b/components/composer/src/init.spec.js
@@ -524,7 +524,7 @@ describe("Composer customizations", () => {
       .get("nylas-html-editor")
       .shadow()
       .get("div.html-editor[contenteditable]")
-      .should("have.class", "focus_body_onload");
+      .should("have.focus");
   });
 
   it("should not focus body on load", () => {
@@ -537,7 +537,7 @@ describe("Composer customizations", () => {
       .get("nylas-html-editor")
       .shadow()
       .get("div.html-editor[contenteditable]")
-      .should("not.have.class", "focus_body_onload");
+      .should("not.have.focus");
   });
 });
 

--- a/components/composer/src/init.spec.js
+++ b/components/composer/src/init.spec.js
@@ -615,14 +615,14 @@ describe("Composer integration", () => {
     );
   });
 
-  it("Shows template in email body", () => {
+  it.only("Shows template in email body", () => {
     cy.get("@composer").then((element) => {
       const component = element[0];
-      component.template = `Hey what up!<br />
+      component.template = `<div><br><br><div style="border-left: 3px solid #dfe1e8; padding-left: 1rem;">Hey what up!<br />
       <br />
       <br />
       Thanks,
-      -Phil`;
+      -Phil</div></div>`;
     });
 
     cy.get(".html-editor[contenteditable=true]")

--- a/components/composer/src/init.spec.js
+++ b/components/composer/src/init.spec.js
@@ -513,6 +513,32 @@ describe("Composer customizations", () => {
         );
       });
   });
+
+  it("should focus body on load", () => {
+    cy.get("@composer").then((el) => {
+      const component = el[0];
+      component.focus_body_onload = true;
+    });
+    cy.get("@composer")
+      .shadow()
+      .get("nylas-html-editor")
+      .shadow()
+      .get("div.html-editor[contenteditable]")
+      .should("have.class", "focus_body_onload");
+  });
+
+  it("should not focus body on load", () => {
+    cy.get("@composer").then((el) => {
+      const component = el[0];
+      component.focus_body_onload = false;
+    });
+    cy.get("@composer")
+      .shadow()
+      .get("nylas-html-editor")
+      .shadow()
+      .get("div.html-editor[contenteditable]")
+      .should("not.have.class", "focus_body_onload");
+  });
 });
 
 describe("Composer integration", () => {

--- a/components/composer/src/init.spec.js
+++ b/components/composer/src/init.spec.js
@@ -615,7 +615,7 @@ describe("Composer integration", () => {
     );
   });
 
-  it.only("Shows template in email body", () => {
+  it("Shows template in email body", () => {
     cy.get("@composer").then((element) => {
       const component = element[0];
       component.template = `<div><br><br><div style="border-left: 3px solid #dfe1e8; padding-left: 1rem;">Hey what up!<br />

--- a/components/composer/src/properties.json
+++ b/components/composer/src/properties.json
@@ -134,7 +134,7 @@
   },
   {
     "label": "focus_body_onload",
-    "title": "When replying to a message using Composer component, this value allows to set body as the focus on load",
+    "title": "By default 'to' field is focussed, set this prop to set focus on the 'body' field.",
     "type": "boolean",
     "options": [true, false],
     "value": false

--- a/components/composer/src/properties.json
+++ b/components/composer/src/properties.json
@@ -22,7 +22,9 @@
     "label": "value",
     "title": "Message object that you can pass in",
     "type": "Message",
-    "value": { "subject": "string" }
+    "value": {
+      "subject": "string"
+    }
   },
   {
     "label": "minimized",
@@ -129,5 +131,12 @@
     "type": "boolean",
     "options": [true, false],
     "value": true
+  },
+  {
+    "label": "focus_body_onload",
+    "title": "When replying to a message using Composer component, this value allows to set body as the focus on load",
+    "type": "boolean",
+    "options": [true, false],
+    "value": false
   }
 ]

--- a/components/email/CHANGELOG.md
+++ b/components/email/CHANGELOG.md
@@ -7,6 +7,14 @@
 - [Email] Show CC participants when reply all button is clicked [#319](https://github.com/nylas/components/pull/319)
 - [Email] Added ability to forward email [#320](https://github.com/nylas/components/pull/320)
 - [Email] Show CC and BCC fields on expanded email [#361](https://github.com/nylas/components/pull/361)
+- [Email] Added customizable css variables for attachment button [#379](https://github.com/nylas/components/pull/379)
+
+```
+  -  --nylas-email-attachment-border-style
+  -  --nylas-email-attachment-button-color
+  -  --nylas-email-attachment-button-bg
+  -  --nylas-email-attachment-button-hover-bg
+```
 
 ## Bug Fixes
 

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -1337,12 +1337,19 @@
 
           button {
             padding: 0.3rem 1rem;
-            border: 1px solid var(--grey);
+            border: var(
+              --nylas-email-attachment-border-style,
+              1px solid var(--grey)
+            );
             border-radius: 30px;
-            background: white;
+            color: var(--nylas-email-attachment-button-color, inherit);
+            background: var(--nylas-email-attachment-button-bg, white);
             cursor: pointer;
             &:hover {
-              background: var(--grey-light);
+              background: var(
+                --nylas-email-attachment-button-hover-bg,
+                var(--grey-light)
+              );
             }
           }
         }

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -1154,12 +1154,20 @@
                 margin: $spacing-xs;
                 height: fit-content;
                 padding: 0.3rem 1rem;
-                border: 1px solid var(--grey);
+                border: var(
+                  --nylas-email-attachment-border-style,
+                  1px solid var(--grey)
+                );
                 border-radius: 30px;
-                background: white;
+                color: var(--nylas-email-attachment-button-color, inherit);
+                background: var(--nylas-email-attachment-button-bg, white);
                 cursor: pointer;
+
                 &:hover {
-                  background: var(--grey-light);
+                  background: var(
+                    --nylas-email-attachment-button-hover-bg,
+                    var(--grey-light)
+                  );
                 }
               }
             }

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -571,6 +571,7 @@
       message: message,
       thread: activeThread,
       value,
+      focus_body_onload: true,
     });
   }
 
@@ -586,6 +587,7 @@
       message,
       thread: activeThread,
       value,
+      focus_body_onload: false,
     });
   }
 

--- a/components/mailbox/src/index.html
+++ b/components/mailbox/src/index.html
@@ -19,11 +19,16 @@
       }
     </style>
     <script type="module">
-      function toggleComposer(event, component) {
+      function toggleComposer(event, component, eventType) {
         component.removeAttribute("hidden");
         component.value = event.detail.value;
         if (Object.keys(event.detail.message).length) {
           component.message_with_body = event.detail.message;
+        }
+        if (eventType === "replyClicked" || eventType === "replyAllClicked") {
+          component.focus_body_onload = true;
+        } else {
+          component.focus_body_onload = false;
         }
         component.open();
       }
@@ -67,8 +72,10 @@
           "forwardClicked",
           "draftThreadEvent",
         ];
-        events.forEach((event) =>
-          mailbox.addEventListener(event, (e) => toggleComposer(e, composer)),
+        events.forEach((eventType) =>
+          mailbox.addEventListener(eventType, (e) =>
+            toggleComposer(e, composer, eventType),
+          ),
         );
       });
     </script>

--- a/components/mailbox/src/index.html
+++ b/components/mailbox/src/index.html
@@ -22,13 +22,9 @@
       function toggleComposer(event, component, eventType) {
         component.removeAttribute("hidden");
         component.value = event.detail.value;
+        component.focus_body_onload = event.detail.focus_body_onload;
         if (Object.keys(event.detail.message).length) {
           component.message_with_body = event.detail.message;
-        }
-        if (eventType === "replyClicked" || eventType === "replyAllClicked") {
-          component.focus_body_onload = true;
-        } else {
-          component.focus_body_onload = false;
         }
         component.open();
       }


### PR DESCRIPTION
When forwarding & composing new email from Mailbox component, auto focus should be on `to` field, When replying (reply, reply-all) focus should be `body`

# Code changes

- Added a new prop `focus_body_onload` to Composer component, which is passed to HTMLEditor component, this value allows the user to set focus on the body when replying, if not defaults to focus on `to` field.
- Updated Mailbox `index.html` to show an example of how this can be set up
- Added css variables to customize the attachment button including background, hover background, border & color
```
      --nylas-email-attachment-border-style
      --nylas-email-attachment-button-color
      --nylas-email-attachment-button-bg
      --nylas-email-attachment-button-hover-bg
```
- Added border-left css to previously replied thread, wrapping `html` prop in HTMLEditor with a `div` element.
- Added tests for new prop `focus_body_onload` & fixed the existing tests which expects the reply css to be added

# Screenshot
https://user-images.githubusercontent.com/16315004/152602315-9f7b9274-62c8-4785-853b-af4d383c84e3.mov

# Readiness checklist

- [X] Added changes to component `CHANGELOG.md`
- [X] New property added? make sure to update `component/src/properties.json`
- [X] Cypress tests passing?
- [X] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
