### PR TITLE
[mailbox] Error loading the mailbox component with our demo account

### DIFF
--- a/commons/src/connections/threads.ts
+++ b/commons/src/connections/threads.ts
@@ -25,10 +25,23 @@ export const fetchThreads = (
       (param) => (queryString = queryString.concat(`&${param[0]}=${param[1]}`)),
     );
   }
-  return fetch(queryString, getFetchConfig(query))
-    .then((response) => handleResponse<MiddlewareResponse<Thread[]>>(response))
-    .then((json) => json.response)
-    .catch((error) => handleError(query.component_id, error));
+  return (
+    fetch(queryString, getFetchConfig(query))
+      .then((response) =>
+        handleResponse<MiddlewareResponse<Thread[]>>(response),
+      )
+      .then((json) => json.response)
+      // TODO: Remove this ugly hack when we fix the API from returning ghost messages (e.g. w/o a from/to field)
+      .then((threads) =>
+        threads.map((thread) => ({
+          ...thread,
+          messages: thread.messages.filter(
+            (message) => message.from.length !== 0 || message.to.length !== 0,
+          ),
+        })),
+      )
+      .catch((error) => handleError(query.component_id, error))
+  );
 };
 
 export function fetchThreadCount(query: MailboxQuery): Promise<number> {


### PR DESCRIPTION
# Background
We have a strange inconsistency in the Nylas threads endpoint where a thread exists with a message that has no `to`, `from`, or other expected fields. While this seems to be more of a API issue, our components currently break because we made the assumption that such fields should always exist for messages.

# Implementation
- [x] Filtered out messages that do not have a TO or FROM value when fetching threads
- [ ] Added unit tests to check regressions

Story details: https://app.shortcut.com/nylas/story/80543