### PR TITLE
[Schedule Editor] Sections as cards pt 1: toggling expanded state

### DIFF
--- a/commons/src/types/ScheduleEditor.ts
+++ b/commons/src/types/ScheduleEditor.ts
@@ -64,13 +64,14 @@ interface SectionOptions {
   editable: boolean;
 }
 
-export type SectionNames =
-  | "basic-details"
-  | "time-date-details"
-  | "style-details"
-  | "booking-details"
-  | "custom-fields"
-  | "notification-details";
+export enum SectionNames {
+  BASIC_DETAILS = "basic-details",
+  TIME_DATE_DETAILS = "time-date-details",
+  STYLE_DETAILS = "style-details",
+  BOOKING_DETAILS = "booking-details",
+  CUSTOM_FIELDS = "custom-fields",
+  NOTIFICATION_DETAILS = "notification-details",
+}
 
 export type Sections = {
   [key in SectionNames]: SectionOptions;

--- a/commons/src/types/ScheduleEditor.ts
+++ b/commons/src/types/ScheduleEditor.ts
@@ -58,3 +58,20 @@ interface HostRules {
   method: "all" | "user_determined" | "random";
   host_count?: number;
 }
+
+interface SectionOptions {
+  expanded: boolean;
+  editable: boolean;
+}
+
+export type SectionNames =
+  | "basic-details"
+  | "time-date-details"
+  | "style-details"
+  | "booking-details"
+  | "custom-fields"
+  | "notification-details";
+
+export type Sections = {
+  [key in SectionNames]: SectionOptions;
+};

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -13,8 +13,9 @@
     Manifest,
     EventDefinition,
     Sections,
-    SectionNames,
   } from "@commons/types/ScheduleEditor";
+  import { SectionNames } from "@commons/types/ScheduleEditor";
+
   import type { CustomField } from "@commons/types/Scheduler";
   import { onDestroy, onMount, tick } from "svelte";
   import timezones from "timezones-list";
@@ -470,35 +471,45 @@
 
   //#region expand/collapse
 
-  const sections: Sections = {
-    "basic-details": {
-      expanded: true,
+  const sections = {};
+  console.log("SECNAME", SectionNames);
+
+  for (const name in SectionNames) {
+    sections[SectionNames[name]] = {
+      expanded: name === "BASIC_DETAILS" ? true : false,
       editable: true,
-    },
-    "time-date-details": {
-      expanded: false,
-      editable: true,
-    },
-    "style-details": {
-      expanded: false,
-      editable: true,
-    },
-    "booking-details": {
-      expanded: false,
-      editable: true,
-    },
-    "custom-fields": {
-      expanded: false,
-      editable: true,
-    },
-    "notification-details": {
-      expanded: false,
-      editable: true,
-    },
-  };
+    };
+  }
+
+  // const sections: Sections = {
+  //   [SectionNames.BASIC_DETAILS]: {
+  //     expanded: true,
+  //     editable: true,
+  //   },
+  //   "time-date-details": {
+  //     expanded: false,
+  //     editable: true,
+  //   },
+  //   "style-details": {
+  //     expanded: false,
+  //     editable: true,
+  //   },
+  //   "booking-details": {
+  //     expanded: false,
+  //     editable: true,
+  //   },
+  //   "custom-fields": {
+  //     expanded: false,
+  //     editable: true,
+  //   },
+  //   "notification-details": {
+  //     expanded: false,
+  //     editable: true,
+  //   },
+  // };
   function toggleCollapse(section: SectionNames) {
-    // console.log("toggle", section, sections[section].expanded);
-    sections[section].expanded = !sections[section].expanded;
+    // console.log("toggle", section, sections[section]?.expanded);
+    sections[section]?.expanded = !sections[section]?.expanded;
   }
   //#endregion expand/collapse
 </script>
@@ -520,7 +531,7 @@
     <div class="settings">
       <section
         class="basic-details"
-        class:expanded={sections["basic-details"].expanded}
+        class:expanded={sections["basic-details"]?.expanded}
       >
         <header>
           <h1>Event Details</h1>
@@ -607,7 +618,7 @@
       </section>
       <section
         class="time-date-details"
-        class:expanded={sections["time-date-details"].expanded}
+        class:expanded={sections["time-date-details"]?.expanded}
       >
         <header>
           <h1>Date/Time Details</h1>
@@ -771,7 +782,7 @@
       </section>
       <section
         class="style-details"
-        class:expanded={sections["style-details"].expanded}
+        class:expanded={sections["style-details"]?.expanded}
       >
         <header>
           <h1>Style Details</h1>
@@ -826,7 +837,7 @@
       </section>
       <section
         class="booking-details"
-        class:expanded={sections["booking-details"].expanded}
+        class:expanded={sections["booking-details"]?.expanded}
       >
         <header>
           <h1>Booking Details</h1>
@@ -986,7 +997,7 @@
 
       <section
         class="custom-fields"
-        class:expanded={sections["custom-fields"].expanded}
+        class:expanded={sections["custom-fields"]?.expanded}
       >
         <header>
           <h1>Custom Fields</h1>
@@ -1094,7 +1105,7 @@
 
       <section
         class="notification-details"
-        class:expanded={sections["notification-details"].expanded}
+        class:expanded={sections["notification-details"]?.expanded}
       >
         <header>
           <h1>Notification Details</h1>

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -12,6 +12,8 @@
   import type {
     Manifest,
     EventDefinition,
+    Sections,
+    SectionNames,
   } from "@commons/types/ScheduleEditor";
   import type { CustomField } from "@commons/types/Scheduler";
   import { onDestroy, onMount, tick } from "svelte";
@@ -465,6 +467,40 @@
   }
 
   //#endregion consecutive events
+
+  //#region expand/collapse
+
+  const sections: Sections = {
+    "basic-details": {
+      expanded: true,
+      editable: true,
+    },
+    "time-date-details": {
+      expanded: false,
+      editable: true,
+    },
+    "style-details": {
+      expanded: false,
+      editable: true,
+    },
+    "booking-details": {
+      expanded: false,
+      editable: true,
+    },
+    "custom-fields": {
+      expanded: false,
+      editable: true,
+    },
+    "notification-details": {
+      expanded: false,
+      editable: true,
+    },
+  };
+  function toggleCollapse(section: SectionNames) {
+    // console.log("toggle", section, sections[section].expanded);
+    sections[section].expanded = !sections[section].expanded;
+  }
+  //#endregion expand/collapse
 </script>
 
 <style lang="scss">
@@ -482,9 +518,17 @@
     bind:this={main}
   >
     <div class="settings">
-      <section class="basic-details">
-        <h1>Event Details</h1>
-        <p>
+      <section
+        class="basic-details"
+        class:expanded={sections["basic-details"].expanded}
+      >
+        <header>
+          <h1>Event Details</h1>
+          <button on:click={() => toggleCollapse("basic-details")}
+            >Toggle!</button
+          >
+        </header>
+        <p class="intro">
           Edit the details for your meeting. You can add consecutive meetings to
           allow users to book back-to-back events.
         </p>
@@ -561,8 +605,17 @@
         >
         <button on:click={saveProperties}>Save Editor Options</button>
       </section>
-      <section class="time-date-details">
-        <h1>Date/Time Details</h1>
+      <section
+        class="time-date-details"
+        class:expanded={sections["time-date-details"].expanded}
+      >
+        <header>
+          <h1>Date/Time Details</h1>
+          <button on:click={() => toggleCollapse("time-date-details")}
+            >Toggle!</button
+          >
+        </header>
+
         <div class="contents">
           <div>
             <label>
@@ -716,8 +769,16 @@
         </div>
         <button on:click={saveProperties}>Save Editor Options</button>
       </section>
-      <section class="style-details">
-        <h1>Style Details</h1>
+      <section
+        class="style-details"
+        class:expanded={sections["style-details"].expanded}
+      >
+        <header>
+          <h1>Style Details</h1>
+          <button on:click={() => toggleCollapse("style-details")}
+            >Toggle!</button
+          >
+        </header>
         <div class="contents">
           <div role="checkbox" aria-labelledby="show_ticks">
             <strong id="show_ticks">Show ticks</strong>
@@ -763,8 +824,17 @@
         </div>
         <button on:click={saveProperties}>Save Editor Options</button>
       </section>
-      <section class="booking-details">
-        <h1>Booking Details</h1>
+      <section
+        class="booking-details"
+        class:expanded={sections["booking-details"].expanded}
+      >
+        <header>
+          <h1>Booking Details</h1>
+          <button on:click={() => toggleCollapse("booking-details")}
+            >Toggle!</button
+          >
+        </header>
+
         <div class="contents">
           <div role="checkbox" aria-labelledby="allow_booking">
             <strong id="allow_booking">Allow booking</strong>
@@ -914,8 +984,17 @@
         <button on:click={saveProperties}>Save Editor Options</button>
       </section>
 
-      <section class="custom-fields">
-        <h1>Custom Fields</h1>
+      <section
+        class="custom-fields"
+        class:expanded={sections["custom-fields"].expanded}
+      >
+        <header>
+          <h1>Custom Fields</h1>
+          <button on:click={() => toggleCollapse("custom-fields")}
+            >Toggle!</button
+          >
+        </header>
+
         <p class="intro">
           Ask users to fill out a few details before booking an event with you.
           By deafult, they will be asked for their name and email address.
@@ -1013,8 +1092,17 @@
         </div>
       </section>
 
-      <section class="Notification-details">
-        <h1>Notification Details</h1>
+      <section
+        class="notification-details"
+        class:expanded={sections["notification-details"].expanded}
+      >
+        <header>
+          <h1>Notification Details</h1>
+          <button on:click={() => toggleCollapse("notification-details")}
+            >Toggle!</button
+          >
+        </header>
+
         <div class="contents">
           <div role="radiogroup" aria-labelledby="notification_mode">
             <strong id="notification_mode"

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -128,6 +128,10 @@
 
     _this = buildInternalProps($$props, manifest, defaultValueMap) as Manifest;
     transformPropertyValues();
+
+    // Initialize sections
+    establishSections();
+
     initialized = true;
 
     // Setup temporary ids for custom fields for drag reorder functionality
@@ -471,45 +475,20 @@
 
   //#region expand/collapse
 
-  const sections = {};
-  console.log("SECNAME", SectionNames);
+  let sections: Partial<Sections> = {};
 
-  for (const name in SectionNames) {
-    sections[SectionNames[name]] = {
-      expanded: name === "BASIC_DETAILS" ? true : false,
-      editable: true,
-    };
+  function establishSections() {
+    Object.values(SectionNames).forEach((name, iter) => {
+      sections[name] = {
+        expanded: iter === 0 ? true : false,
+        editable: true,
+      };
+    });
   }
 
-  // const sections: Sections = {
-  //   [SectionNames.BASIC_DETAILS]: {
-  //     expanded: true,
-  //     editable: true,
-  //   },
-  //   "time-date-details": {
-  //     expanded: false,
-  //     editable: true,
-  //   },
-  //   "style-details": {
-  //     expanded: false,
-  //     editable: true,
-  //   },
-  //   "booking-details": {
-  //     expanded: false,
-  //     editable: true,
-  //   },
-  //   "custom-fields": {
-  //     expanded: false,
-  //     editable: true,
-  //   },
-  //   "notification-details": {
-  //     expanded: false,
-  //     editable: true,
-  //   },
-  // };
-  function toggleCollapse(section: SectionNames) {
-    // console.log("toggle", section, sections[section]?.expanded);
-    sections[section]?.expanded = !sections[section]?.expanded;
+  function toggleCollapse(name: SectionNames) {
+    sections[name].expanded = !sections[name].expanded;
+    sections = { ...sections };
   }
   //#endregion expand/collapse
 </script>
@@ -531,11 +510,11 @@
     <div class="settings">
       <section
         class="basic-details"
-        class:expanded={sections["basic-details"]?.expanded}
+        class:expanded={sections[SectionNames.BASIC_DETAILS]?.expanded}
       >
         <header>
           <h1>Event Details</h1>
-          <button on:click={() => toggleCollapse("basic-details")}
+          <button on:click={() => toggleCollapse(SectionNames.BASIC_DETAILS)}
             >Toggle!</button
           >
         </header>
@@ -618,11 +597,12 @@
       </section>
       <section
         class="time-date-details"
-        class:expanded={sections["time-date-details"]?.expanded}
+        class:expanded={sections[SectionNames.TIME_DATE_DETAILS]?.expanded}
       >
         <header>
           <h1>Date/Time Details</h1>
-          <button on:click={() => toggleCollapse("time-date-details")}
+          <button
+            on:click={() => toggleCollapse(SectionNames.TIME_DATE_DETAILS)}
             >Toggle!</button
           >
         </header>
@@ -782,11 +762,11 @@
       </section>
       <section
         class="style-details"
-        class:expanded={sections["style-details"]?.expanded}
+        class:expanded={sections[SectionNames.STYLE_DETAILS]?.expanded}
       >
         <header>
           <h1>Style Details</h1>
-          <button on:click={() => toggleCollapse("style-details")}
+          <button on:click={() => toggleCollapse(SectionNames.STYLE_DETAILS)}
             >Toggle!</button
           >
         </header>
@@ -837,11 +817,11 @@
       </section>
       <section
         class="booking-details"
-        class:expanded={sections["booking-details"]?.expanded}
+        class:expanded={sections[SectionNames.BOOKING_DETAILS]?.expanded}
       >
         <header>
           <h1>Booking Details</h1>
-          <button on:click={() => toggleCollapse("booking-details")}
+          <button on:click={() => toggleCollapse(SectionNames.BOOKING_DETAILS)}
             >Toggle!</button
           >
         </header>
@@ -997,11 +977,11 @@
 
       <section
         class="custom-fields"
-        class:expanded={sections["custom-fields"]?.expanded}
+        class:expanded={sections[SectionNames.CUSTOM_FIELDS]?.expanded}
       >
         <header>
           <h1>Custom Fields</h1>
-          <button on:click={() => toggleCollapse("custom-fields")}
+          <button on:click={() => toggleCollapse(SectionNames.CUSTOM_FIELDS)}
             >Toggle!</button
           >
         </header>
@@ -1105,11 +1085,12 @@
 
       <section
         class="notification-details"
-        class:expanded={sections["notification-details"]?.expanded}
+        class:expanded={sections[SectionNames.NOTIFICATION_DETAILS]?.expanded}
       >
         <header>
           <h1>Notification Details</h1>
-          <button on:click={() => toggleCollapse("notification-details")}
+          <button
+            on:click={() => toggleCollapse(SectionNames.NOTIFICATION_DETAILS)}
             >Toggle!</button
           >
         </header>

--- a/components/schedule-editor/src/styles/schedule-editor.scss
+++ b/components/schedule-editor/src/styles/schedule-editor.scss
@@ -17,11 +17,153 @@ main {
   display: grid;
   grid-template-columns: 1fr 5px auto;
   gap: 1rem;
-  padding: 0 1rem;
+  // padding: 0 1rem;
+  background: var(--grey-background);
 
   .settings {
     resize: both;
     overflow: auto;
+    display: grid;
+    gap: 1rem;
+    padding: 1rem;
+
+    & > section {
+      display: flex;
+      flex-direction: column;
+      background-color: white;
+      box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.15);
+      padding: 1rem;
+
+      & > header {
+        margin-bottom: 1rem;
+        display: grid;
+        grid-template-columns: auto 100px;
+        h1 {
+          font-weight: bold;
+          font-size: 1.5rem;
+        }
+      }
+
+      &:not(.expanded) .intro,
+      &:not(.expanded) .contents {
+        display: none;
+      }
+
+      .intro {
+        margin-top: 0;
+        padding-top: 0;
+        margin-bottom: 2rem;
+      }
+      .contents {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+        gap: 24px;
+        margin-bottom: 24px;
+
+        table {
+          border-collapse: colapse;
+
+          tr.add-new td {
+            background-color: var(--grey-light);
+          }
+          th,
+          td {
+            text-align: left;
+            border-bottom: 1px solid rgba(0, 0, 0, 0.25);
+            padding: 0.25rem;
+
+            input[type="text"],
+            select {
+              padding: 0.25rem;
+            }
+
+            label {
+              display: block;
+              white-space: nowrap;
+            }
+
+            &.cta {
+              display: flex;
+              justify-content: space-between;
+              align-items: center;
+            }
+
+            button {
+              &.add-custom-field {
+                background-color: var(--blue);
+
+                &:disabled {
+                  background-color: var(--grey-warm);
+                  cursor: not-allowed;
+                }
+              }
+              &.remove {
+                background-color: var(--red);
+              }
+            }
+          }
+
+          th {
+            text-transform: capitalize;
+            border-bottom: 2px solid black;
+          }
+
+          tr:last-child td {
+            border-bottom: none;
+          }
+        }
+
+        label {
+          display: flex;
+          flex-direction: column;
+          gap: 12px;
+          input {
+            padding: 12px;
+          }
+        }
+        [role="radiogroup"],
+        [role="checkbox"] {
+          display: flex;
+          flex-direction: column;
+          gap: 12px;
+
+          label {
+            flex-direction: row;
+          }
+        }
+        & > .available-hours {
+          grid-column: -1 / 1;
+        }
+      }
+
+      button {
+        align-self: flex-end;
+        padding: 8px 16px;
+        border-radius: 4px;
+        background-color: var(--blue);
+        color: white;
+        border: none;
+        font-weight: 600;
+      }
+
+      &.basic-details .contents {
+        grid-template-columns: 1fr;
+        & > fieldset {
+          border: none;
+          padding: 0;
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+          padding: 1rem;
+          gap: 1rem;
+          background-color: var(--grey-background);
+
+          .remove-event {
+            grid-column: -1 / 1;
+            justify-self: end;
+          }
+        }
+      }
+    }
   }
 
   aside#preview {
@@ -37,125 +179,6 @@ main {
   .gutter {
     background: #999;
     cursor: col-resize;
-  }
-}
-section {
-  display: flex;
-  flex-direction: column;
-  margin-bottom: 96px;
-  .intro {
-    margin-top: 0;
-    padding-top: 0;
-    margin-bottom: 2rem;
-  }
-  .contents {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 24px;
-    margin-bottom: 24px;
-
-    table {
-      border-collapse: colapse;
-
-      tr.add-new td {
-        background-color: var(--grey-light);
-      }
-      th,
-      td {
-        text-align: left;
-        border-bottom: 1px solid rgba(0, 0, 0, 0.25);
-        padding: 0.25rem;
-
-        input[type="text"],
-        select {
-          padding: 0.25rem;
-        }
-
-        label {
-          display: block;
-          white-space: nowrap;
-        }
-
-        &.cta {
-          display: flex;
-          justify-content: space-between;
-          align-items: center;
-        }
-
-        button {
-          &.add-custom-field {
-            background-color: var(--blue);
-
-            &:disabled {
-              background-color: var(--grey-warm);
-              cursor: not-allowed;
-            }
-          }
-          &.remove {
-            background-color: var(--red);
-          }
-        }
-      }
-
-      th {
-        text-transform: capitalize;
-        border-bottom: 2px solid black;
-      }
-
-      tr:last-child td {
-        border-bottom: none;
-      }
-    }
-
-    label {
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-      input {
-        padding: 12px;
-      }
-    }
-    [role="radiogroup"],
-    [role="checkbox"] {
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-
-      label {
-        flex-direction: row;
-      }
-    }
-    & > .available-hours {
-      grid-column: -1 / 1;
-    }
-  }
-
-  button {
-    align-self: flex-end;
-    padding: 8px 16px;
-    border-radius: 4px;
-    background-color: var(--blue);
-    color: white;
-    border: none;
-    font-weight: 600;
-  }
-
-  &.basic-details .contents {
-    grid-template-columns: 1fr;
-    & > fieldset {
-      border: none;
-      padding: 0;
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-      padding: 1rem;
-      gap: 1rem;
-      background-color: var(--grey-background);
-
-      .remove-event {
-        grid-column: -1 / 1;
-        justify-self: end;
-      }
-    }
   }
 }
 


### PR DESCRIPTION
Adds a "toggle" button to affect the expanded state of individual sections. Sets the groundwork to eventually set `editable` there as well.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
