### PR TITLE
Add ability for Composer to save email to draft

### DIFF
--- a/commons/src/connections/messages.ts
+++ b/commons/src/connections/messages.ts
@@ -143,3 +143,39 @@ export const fetchEmail = async (
     })
     .catch((error) => handleError(query.component_id, error));
 };
+
+export const saveDraft = async (
+  component_id: string,
+  msg: Message,
+  access_token?: string,
+): Promise<NylasMessage> => {
+  return await fetch(
+    `${getMiddlewareApiUrl(component_id)}/drafts`,
+    getFetchConfig({ method: "POST", component_id, access_token, body: msg }),
+  )
+    .then((response) =>
+      handleResponse<MiddlewareResponse<NylasMessage>>(response),
+    )
+    .then((json) => {
+      return json.response;
+    })
+    .catch((error) => handleError(component_id, error));
+};
+
+export const updateDraft = async (
+  component_id: string,
+  msg: Message,
+  access_token?: string,
+): Promise<NylasMessage> => {
+  return await fetch(
+    `${getMiddlewareApiUrl(component_id)}/drafts/${msg.id}`,
+    getFetchConfig({ method: "PUT", component_id, access_token, body: msg }),
+  )
+    .then((response) =>
+      handleResponse<MiddlewareResponse<NylasMessage>>(response),
+    )
+    .then((json) => {
+      return json.response;
+    })
+    .catch((error) => handleError(component_id, error));
+};

--- a/commons/src/index.ts
+++ b/commons/src/index.ts
@@ -18,6 +18,8 @@ export {
   fetchMessages,
   fetchMessage,
   fetchEmail,
+  saveDraft,
+  updateDraft,
 } from "./connections/messages";
 export { fetchAccount } from "./connections/accounts";
 export {

--- a/commons/src/types/Composer.ts
+++ b/commons/src/types/Composer.ts
@@ -44,6 +44,7 @@ export interface Attributes {
   show_cc_button?: boolean;
   show_bcc_button?: boolean;
   show_attachment_button?: boolean;
+  show_save_as_draft?: boolean;
   show_editor_toolbar?: boolean;
 }
 

--- a/commons/src/types/Nylas.ts
+++ b/commons/src/types/Nylas.ts
@@ -234,6 +234,7 @@ export interface ComposerProperties extends Manifest {
   reset_after_send: boolean;
   reset_after_close: boolean;
   show_attachment_button: boolean;
+  show_save_as_draft: boolean;
   show_bcc_button: boolean;
   show_bcc: boolean;
   show_cc_button: boolean;
@@ -261,6 +262,8 @@ export interface ComposerProperties extends Manifest {
   beforeSend: (msg: Message) => Message | void;
   afterSendSuccess?: () => void | null;
   afterSendError?: () => void | null;
+  afterSaveSuccess?: () => void | null;
+  afterSaveError?: () => void | null;
   template: string;
   tracking: Tracking | null;
 

--- a/components/composer/CHANGELOG.md
+++ b/components/composer/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Added a prop `reset_after_close` which resets composer fields after closing
 - Added a prop `focus_body_onload` which allows to set focus on the 'body' field on load [#379](https://github.com/nylas/components/pull/379)
 - Added border-left css to visually differentiate the current message from the previous messages [#379](https://github.com/nylas/components/pull/379)
+- Added button for user to save email message as draft [#383](https://github.com/nylas/components/pull/383)
 
 ## Bug Fixes
 

--- a/components/composer/src/assets/drafts.svg
+++ b/components/composer/src/assets/drafts.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M21.99 8c0-.72-.37-1.35-.94-1.7L12 1 2.95 6.3C2.38 6.65 2 7.28 2 8v10c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2l-.01-10zm-2 0v.01L12 13 4 8l8-4.68L19.99 8zM4 18v-7.66l8 5.02 7.99-4.99L20 18H4z"/></svg>

--- a/components/composer/src/properties.json
+++ b/components/composer/src/properties.json
@@ -91,6 +91,13 @@
     "value": true
   },
   {
+    "label": "show_save_as_draft",
+    "title": "Show save as draft button",
+    "type": "boolean",
+    "options": [true, false],
+    "value": true
+  },
+  {
     "label": "show_subject",
     "title": "Show subject field",
     "type": "boolean",


### PR DESCRIPTION
# Code changes

- Added ability for composer to save email as a new draft
- Composer can update existing draft if draft message id is provided
- Uploaded files id is saved along with draft message, so saved draft will have the same file attached to it.


# Screenshot

![Screen Shot 2022-02-09 at 12 44 43 AM](https://user-images.githubusercontent.com/14408339/153129508-652b9355-e884-41ec-90dc-6709932c60c1.png)

# Readiness checklist

- [x] Added changes to component `CHANGELOG.md`
- [x] Cypress tests passing?
- [x] New cypress tests added?
- [x] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
