### PR TITLE
[Composer]: If no html passed, don't apply css

### DIFF
--- a/components/composer/src/components/HTMLEditor.svelte
+++ b/components/composer/src/components/HTMLEditor.svelte
@@ -1,6 +1,7 @@
 <svelte:options tag="nylas-html-editor" />
 
 <script lang="ts">
+  import { onMount } from "svelte/internal";
   import { defaultActions } from "../lib/html-editor";
   import type { ReplaceFields, ToolbarItem } from "@commons/types/Composer";
 
@@ -12,17 +13,20 @@
 
   let container: HTMLDivElement;
   let toolbar: ToolbarItem[] = defaultActions;
-  let htmlUpdated = false;
 
   $: if (focus_body_onload && container) {
     container.focus();
   }
 
-  $: if (html) {
-    if (!htmlUpdated) {
-      htmlUpdated = true;
+  onMount(() => {
+    // If html exist, means composer is loaded with a previous message,
+    // wrap it with border-left css to visually differentiate the current message
+    if (html) {
       html = `<div><br/><br/><div style="border-left: 3px solid #dfe1e8; padding-left: 1rem;">${html}</div></div>`;
     }
+  });
+
+  $: if (html) {
     const selection = window.getSelection();
 
     if (typeof replace_fields === "string") {

--- a/components/composer/src/init.spec.js
+++ b/components/composer/src/init.spec.js
@@ -486,7 +486,7 @@ describe("Composer customizations", () => {
       .invoke("prop", "innerHTML")
       .then((html) => {
         expect(html).to.equal(
-          `<div><br><br><div style="border-left: 3px solid #dfe1e8; padding-left: 1rem;">hello what up!<br>\n      <br>\n      <br>\n      Thanks,\n      -Phil</div></div>`,
+          `hello what up!<br>\n      <br>\n      <br>\n      Thanks,\n      -Phil`,
         );
       });
   });

--- a/components/email/src/methods/participants.ts
+++ b/components/email/src/methods/participants.ts
@@ -53,7 +53,8 @@ export function buildParticipants({
   }
 
   if (type === "reply_all") {
-    cc = [...message.cc];
+    const fromEmails = message.from?.map((i) => i.email);
+    cc = [...participantsWithoutGivenEmails([...fromEmails, myEmail], message)];
   }
 
   return { to, cc };


### PR DESCRIPTION
# Code changes

- We should only apply css on mount, when the html is not an empty string to avoid applying css for new messages. This PR fixes that.


# Screenshot:
### New message - no css:
<img width="1084" alt="image" src="https://user-images.githubusercontent.com/16315004/153039088-e89df32f-7fa8-496e-9353-1be324d78a9f.png">

### Reply, Reply-all, forward - css applied:
<img width="1531" alt="image" src="https://user-images.githubusercontent.com/16315004/153039213-79dd04bc-89db-4c48-962f-07b1a7dde54b.png">
