### PR TITLE
[mailbox] empty and loading UI states adhere to parent container height

### DIFF
--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -828,17 +828,15 @@
 
   .mailbox-loader,
   .mailbox-empty {
+    position: absolute;
+    top: 0;
+    bottom: 0;
     width: calc(100% - 16px);
-    height: 100vh;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
     box-shadow: none;
-  }
-
-  .mailbox-loader {
-    position: absolute;
   }
 
   @keyframes rotate {

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -650,6 +650,16 @@
       gap: 8px;
     }
 
+    &.loading {
+      grid-template-rows: minmax(auto, calc(100vh - 16px));
+    }
+    &.empty {
+      grid-template-rows: 68px 33.5px minmax(auto, calc(100vh - 117.5px));
+      ul {
+        height: 100%;
+      }
+    }
+
     header {
       @include barStyle;
       border-bottom: none;
@@ -810,10 +820,14 @@
   }
 
   ul {
-    position: relative;
-    &:before {
+    &::before {
       z-index: 1;
     }
+    &.deleting,
+    &.refreshing {
+      position: relative;
+    }
+
     &.refreshing {
       @include progress-bar(top, 0, left, 0, var(--blue), var(--blue-lighter));
     }
@@ -826,12 +840,11 @@
     padding: 4px;
   }
 
+  .mailbox-empty {
+    height: 100%;
+  }
   .mailbox-loader,
   .mailbox-empty {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    width: calc(100% - 16px);
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -867,7 +880,10 @@
   }
 </style>
 
-<main>
+<main
+  class:loading={!hasComponentLoaded}
+  class:empty={!(threads && threads?.length) && hasComponentLoaded}
+>
   {#if hasComponentLoaded}
     {#if currentlySelectedThread}
       <div class="email-container">
@@ -1034,11 +1050,13 @@
           {/each}
         {:else}
           <div class="mailbox-empty">
-            {#if _this.header}
-              {header}
-            {:else}
-              Your Mailbox
-            {/if} is empty!
+            <p>
+              {#if _this.header}
+                {header}
+              {:else}
+                Your Mailbox
+              {/if} is empty!
+            </p>
           </div>
         {/each}
         {#if threads && threads.length > 0}
@@ -1060,7 +1078,7 @@
         class="spinner"
         style="height:18px; animation: rotate 2s linear infinite; margin:10px;"
       />
-      Loading...
+      <p>Loading...</p>
     </div>
   {/if}
 </main>

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -651,10 +651,13 @@
     }
 
     &.loading {
-      grid-template-rows: minmax(auto, calc(100vh - 16px));
+      grid-template-rows: minmax(
+        auto,
+        calc(100vh - 16px)
+      ); /** loading mailbox minus padding **/
     }
     &.empty {
-      grid-template-rows: 68px 33.5px minmax(auto, calc(100vh - 117.5px));
+      grid-template-rows: 68px 33.5px minmax(auto, calc(100vh - 117.5px)); /** header, toolbar, empty mailbox (100vh) minus header, toolbar and padding **/
       ul {
         height: 100%;
       }

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -882,7 +882,7 @@
 
 <main
   class:loading={!hasComponentLoaded}
-  class:empty={!(threads && threads?.length) && hasComponentLoaded}
+  class:empty={!threads?.length && hasComponentLoaded}
 >
   {#if hasComponentLoaded}
     {#if currentlySelectedThread}


### PR DESCRIPTION
# Code changes

- Added conditional `loading` and `empty` classes to `<main>` element, so the loading/empty UI states are either the height of the viewport or the height of the HTML element wrapping the mailbox component

[Loom demo](https://www.loom.com/share/7b02d840a9b74a5ea09284f0f9c4d8a6)
# Readiness checklist

- [ ] Added changes to component `CHANGELOG.md`
- [ ] New property added? make sure to update `component/src/properties.json`
- [ ] Cypress tests passing?
- [ ] New cypress tests added?
- [ ] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
