### PR TITLE
[composer] Remove message_with_body prop and update value prop

### DIFF
--- a/commons/src/types/Composer.ts
+++ b/commons/src/types/Composer.ts
@@ -4,6 +4,8 @@ import type { File } from "@commons/types/Nylas";
 export interface Message {
   [key: string]: unknown;
   component_id?: string;
+  account_id?: string;
+  id?: string;
   subject?: string;
   body?: string;
   from?: Participant[];

--- a/components/composer/CHANGELOG.md
+++ b/components/composer/CHANGELOG.md
@@ -28,7 +28,6 @@
 - Added a prop 'reset_after_close' which resets after closing[#301](https://github.com/nylas/components/pull/301)
 - Attachment icon size was too small making it inaccessible
 - Updated file size error copy, added tooltip label for attach icon[#317](https://github.com/nylas/components/pull/317)
-- Removed duplicate property `message_with_body` and added `body`, `cids`, `account_id`, and `ids` to `value` prop. [#396](https://github.com/nylas/components/pull/396)
 
 ## Breaking
 

--- a/components/composer/CHANGELOG.md
+++ b/components/composer/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Added a prop 'reset_after_close' which resets after closing[#301](https://github.com/nylas/components/pull/301)
 - Attachment icon size was too small making it inaccessible
 - Updated file size error copy, added tooltip label for attach icon[#317](https://github.com/nylas/components/pull/317)
+- Removed duplicate property `message_with_body` and added `body`, `cids`, `account_id`, and `ids` to `value` prop. [#396](https://github.com/nylas/components/pull/396)
 
 ## Breaking
 

--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -74,7 +74,6 @@
   export let access_token: string = "";
 
   export let value: Message | void;
-  export let message_with_body: Message | void;
   export let to: ContactSearchCallback = [];
   export let from: ContactSearchCallback = [];
   export let cc: ContactSearchCallback = [];
@@ -221,16 +220,12 @@
   }
 
   let isAttachmentLoaded = false;
-  $: if (
-    message_with_body &&
-    message_with_body.files.length > 0 &&
-    !isAttachmentLoaded
-  ) {
-    for (const [fileIndex, file] of message_with_body.files.entries()) {
-      if (isFileAnAttachment(message_with_body, file)) {
+  $: if (value?.files?.length > 0 && !isAttachmentLoaded) {
+    for (const [fileIndex, file] of value.files.entries()) {
+      if (isFileAnAttachment(value, file)) {
         addAttachments({
-          account_id: message_with_body.account_id,
-          id: message_with_body.id,
+          account_id: value.account_id,
+          id: value.id,
           filename: file.filename,
           size: file.size,
           content_type: file.content_type,

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -313,7 +313,7 @@
   $: emailManuallyPassed = !!_this.thread;
 
   //#region Clean Conversation
-  // If a user sets message_with_body_type to "clean", expand their message to clean conversation.
+  // If a user sets message_body_type to "clean", expand their message to clean conversation.
   // This requires them to have access to the Nylas Neural API.
 
   const CONVERSATION_ENDPOINT_MAX_MESSAGES = 20;

--- a/components/mailbox/src/index.html
+++ b/components/mailbox/src/index.html
@@ -20,11 +20,16 @@
     </style>
     <script type="module">
       function toggleComposer(event, component) {
+        console.log(event.detail);
         component.removeAttribute("hidden");
         component.value = event.detail.value;
         component.focus_body_onload = event.detail.focus_body_onload;
         if (Object.keys(event.detail.message).length) {
-          component.message_with_body = event.detail.message;
+          component.value.body = event.detail.message.body ?? "";
+          component.value.files = event.detail.message.files ?? [];
+          component.value.account_id = event.detail.message.account_id ?? "";
+          component.value.id = event.detail.message.id ?? "";
+          component.value.cids = event.detail.message.cids ?? [];
         }
         component.open();
       }

--- a/components/mailbox/src/init.spec.js
+++ b/components/mailbox/src/init.spec.js
@@ -651,7 +651,7 @@ describe("Mailbox: updating 'to' field correctly for reply and reply-all", () =>
             composer.value = event.detail.value;
             composer.focus_body_onload = event.detail.focus_body_onload;
             if (Object.keys(event.detail.message).length) {
-              composer.message_with_body = event.detail.message;
+              composer.value.body = event.detail.message.body;
             }
             composer.open();
           });
@@ -716,7 +716,7 @@ describe("Mailbox: updating cc fields correctly for reply and reply-all", () => 
             composer.value = event.detail.value;
             composer.focus_body_onload = event.detail.focus_body_onload;
             if (Object.keys(event.detail.message).length) {
-              composer.message_with_body = event.detail.message;
+              composer.value.body = event.detail.message;
             }
             composer.open();
           });


### PR DESCRIPTION
# Code changes

- [x] Removed `message_with_body` prop

- [x] Updated `value` prop so it has the props from `message_with_body` that are necessary to include the body in a new email as well as include inline and attached files (`body`, `cids`, `account_id`, `id`)


# Readiness checklist

- [ ] Added changes to component `CHANGELOG.md`
- [ ] New property added? make sure to update `component/src/properties.json`
- [ ] Cypress tests passing?
- [ ] New cypress tests added?
- [ ] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
