### PR TITLE
Allow the files store to be re-populated if `prop.value.files` changes.

### DIFF
--- a/commons/src/types/Nylas.ts
+++ b/commons/src/types/Nylas.ts
@@ -128,6 +128,8 @@ export interface Message {
   reply_to_message_id?: string;
   folder_id?: string;
   label_ids?: string[];
+  account_id?: string;
+  [key: string]: unknown;
 }
 
 export interface RadialMessage extends Message {

--- a/components/composer/CHANGELOG.md
+++ b/components/composer/CHANGELOG.md
@@ -6,9 +6,10 @@
 
 ## Bug Fixes
 
-- [Composer] focus the HTML editor textbox when a formatting option is clicked [#342](https://github.com/nylas/components/pull/342)
-- [Composer] Header should reactively update with the change in the subject [#367](https://github.com/nylas/components/pull/367)
-- [Composer] Fix bug where unable to tab into contenteditable area in Firefox [#400](https://github.com/nylas/components/pull/400)
+- Focus the HTML editor textbox when a formatting option is clicked [#342](https://github.com/nylas/components/pull/342)
+- Header should reactively update with the change in the subject [#367](https://github.com/nylas/components/pull/367)
+- Fix bug where unable to tab into contenteditable area in Firefox [#400](https://github.com/nylas/components/pull/400)
+- Attachments were not being displayed or sent if the `value.files` property was set [#398](https://github.com/nylas/components/pull/398)
 
 # v1.1.6 (Unreleased)
 

--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -222,9 +222,10 @@
   $: if (value) {
     mergeMessage(value);
     if (value.files?.length > 0) {
-      mergeMessage({ file_ids: value.files.map(({ id }) => id) });
+      let file_ids = [];
       resetAttachments();
-      for (const [fileIndex, file] of value.files.entries()) {
+      for (const [_, file] of value.files.entries()) {
+        file_ids.push(file.id);
         if (isFileAnAttachment(value, file)) {
           addAttachments({
             account_id: value.account_id,
@@ -235,6 +236,7 @@
           });
         }
       }
+      mergeMessage({ file_ids });
     }
   }
 

--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -42,6 +42,7 @@
     removeAttachments,
     resetAfterSend,
     updateAttachment,
+    resetAttachments,
   } from "./lib/store";
   import { formatDate } from "./lib/format-date";
 
@@ -221,6 +222,8 @@
   $: if (value) {
     mergeMessage(value);
     if (value.files?.length > 0) {
+      mergeMessage({ file_ids: value.files.map(({ id }) => id) });
+      resetAttachments();
       for (const [fileIndex, file] of value.files.entries()) {
         if (isFileAnAttachment(value, file)) {
           addAttachments({
@@ -367,6 +370,7 @@
         });
     } else if (id) {
       // Middleware
+      console.log(JSON.stringify(msg, null, 2));
       sendMessage(id, msg, access_token)
         .then((res) => {
           if (afterSendSuccess) afterSendSuccess(res);
@@ -776,8 +780,7 @@
     rel="stylesheet"
     href={themeUrl}
     on:load={() => (themeLoaded = true)}
-    on:error={() => (themeLoaded = true)}
-  />
+    on:error={() => (themeLoaded = true)} />
 {/if}
 {#if visible && isLoading}
   <div class="nylas-composer nylas-composer__loader">
@@ -790,8 +793,7 @@
   <div
     class="nylas-composer"
     data-cy="nylas-composer"
-    class:minimized={_this.minimized}
-  >
+    class:minimized={_this.minimized}>
     {#if _this.show_header}
       <header class={_this.minimized ? "minimized" : undefined}>
         <span>{subject}</span>
@@ -800,16 +802,14 @@
             {#if _this.minimized}
               <button
                 class="composer-btn"
-                on:click={() => handleMinimize(false)}
-              >
+                on:click={() => handleMinimize(false)}>
                 <span class="sr-only">Expand Composer</span>
                 <ExpandIcon class="ExpandIcon" />
               </button>
             {:else}
               <button
                 class="composer-btn"
-                on:click={() => handleMinimize(true)}
-              >
+                on:click={() => handleMinimize(true)}>
                 <span class="sr-only">Collapse Composer</span>
                 <MinimizeIcon class="MinimizeIcon" />
               </button>
@@ -855,8 +855,7 @@
               placeholder="To:"
               change={handleContactsChange("to")}
               contacts={to}
-              value={$message.to}
-            />
+              value={$message.to} />
           {/if}
           <div class="addons">
             <button
@@ -867,8 +866,7 @@
               on:click={() => {
                 _this.show_cc = true;
                 previousProps = _this;
-              }}>CC</button
-            >
+              }}>CC</button>
 
             <button
               data-cy="toggle-bcc-field-btn"
@@ -880,8 +878,7 @@
               on:click={() => {
                 _this.show_bcc = true;
                 previousProps = _this;
-              }}>BCC</button
-            >
+              }}>BCC</button>
           </div>
         </div>
         {#if _this.show_cc}
@@ -891,8 +888,7 @@
               placeholder="CC:"
               contacts={cc}
               value={$message.cc}
-              change={handleContactsChange("cc")}
-            />
+              change={handleContactsChange("cc")} />
             <button
               type="button"
               class="composer-btn cc-btn"
@@ -901,8 +897,7 @@
                 _this.show_cc = false;
                 previousProps = _this;
               }}
-              aria-label="remove carbon copy field"
-            >
+              aria-label="remove carbon copy field">
               <CloseIcon class="CloseIcon" />
             </button>
           </div>
@@ -914,8 +909,7 @@
               placeholder="BCC:"
               contacts={bcc}
               value={$message.bcc}
-              change={handleContactsChange("bcc")}
-            />
+              change={handleContactsChange("bcc")} />
             <button
               type="button"
               class="composer-btn cc-btn"
@@ -924,8 +918,7 @@
                 _this.show_bcc = false;
                 previousProps = _this;
               }}
-              aria-label="remove blind carbon copy field"
-            >
+              aria-label="remove blind carbon copy field">
               <CloseIcon class="CloseIcon" />
             </button>
           </div>
@@ -941,8 +934,7 @@
               class="subject"
               value={subject}
               name="subject"
-              on:input={handleInputChange}
-            />
+              on:input={handleInputChange} />
           </label>
         {/if}
 
@@ -954,8 +946,7 @@
           focus_body_onload={_this.focus_body_onload}
           replace_fields={_this.replace_fields}
           show_editor_toolbar={_this.show_editor_toolbar}
-          on:keydown={handleKeyDown}
-        />
+          on:keydown={handleKeyDown} />
         {#if $attachments.length}
           <div class="nylas-attachments">
             <div class="attachments-wrapper">
@@ -964,8 +955,7 @@
               {#each $attachments as fileAttachment}
                 <nylas-composer-attachment
                   attachment={fileAttachment}
-                  remove={handleRemoveFile}
-                />
+                  remove={handleRemoveFile} />
               {/each}
             </div>
           </div>
@@ -982,8 +972,7 @@
             for="save-draft"
             class="composer-btn save-draft"
             title="Save Email As Draft"
-            on:click={handleSaveDraft}
-          >
+            on:click={handleSaveDraft}>
             <DraftIcon class="FooterIcon" />
             <span class="sr-only">Save Draft</span>
           </button>
@@ -993,8 +982,7 @@
             for="file-upload"
             class="composer-btn file-upload"
             title="Attach Files (up to {maxFileSize}MB)"
-            tabindex="0"
-          >
+            tabindex="0">
             <AttachmentIcon class="FooterIcon" />
             <span class="sr-only">Attach Files</span>
           </label>
@@ -1010,8 +998,7 @@
             hidden
             type="file"
             id="file-upload"
-            on:change={handleFilesChange}
-          />
+            on:change={handleFilesChange} />
         </form>
       </footer>
       <!-- Date Picker Component -->
@@ -1023,8 +1010,7 @@
         <nylas-composer-alert-bar
           type="info"
           dismissible={true}
-          ondismiss={removeSchedule}
-        >
+          ondismiss={removeSchedule}>
           Send scheduled for
           <span>{formatDate(new Date(datepickerTimestamp))}</span>
         </nylas-composer-alert-bar>

--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -51,7 +51,6 @@
   import DraftIcon from "./assets/drafts.svg";
   import ExpandIcon from "./assets/expand.svg";
   import type {
-    Message,
     SendCallback,
     FetchContactsCallback,
     Tracking,
@@ -60,6 +59,7 @@
     Attachment,
   } from "@commons/types/Composer";
   import type {
+    Message,
     ComposerProperties,
     Account,
     Participant,
@@ -157,7 +157,6 @@
     if (_this.reset_after_close) {
       resetAfterSend($message.from);
     }
-    isAttachmentLoaded = false;
     attachments.update(() => []);
     dispatchEvent("composerClosed", {});
   };
@@ -221,7 +220,21 @@
 
   $: if (value) {
     mergeMessage(value);
+    if (value.files?.length > 0) {
+      for (const [fileIndex, file] of value.files.entries()) {
+        if (isFileAnAttachment(value, file)) {
+          addAttachments({
+            account_id: value.account_id,
+            id: value.id,
+            filename: file.filename,
+            size: file.size,
+            content_type: file.content_type,
+          });
+        }
+      }
+    }
   }
+
   let maxFileSize: number;
   $: {
     if (!uploadFile) {
@@ -235,22 +248,6 @@
     } else {
       //Using custom uploadFile function
       maxFileSize = _this.max_file_size;
-    }
-  }
-
-  let isAttachmentLoaded = false;
-  $: if (value?.files?.length > 0 && !isAttachmentLoaded) {
-    for (const [fileIndex, file] of value.files.entries()) {
-      if (isFileAnAttachment(value, file)) {
-        addAttachments({
-          account_id: value.account_id,
-          id: value.id,
-          filename: file.filename,
-          size: file.size,
-          content_type: file.content_type,
-        });
-        isAttachmentLoaded = true;
-      }
     }
   }
 

--- a/components/composer/src/init.spec.js
+++ b/components/composer/src/init.spec.js
@@ -28,8 +28,8 @@ describe("Composer dispatches events", () => {
     }).as("getMiddlewareAccount");
 
     cy.intercept("GET", "/users", [
-      { name: "Test User", email: "tester@nylas.com" },
-      { name: "Secound Test User", email: "tester2@nylas.com" },
+      { name: "Test User", email: "tester@test.com" },
+      { name: "Secound Test User", email: "tester2@test.com" },
     ]).as("getUsers");
 
     cy.visit("/components/composer/src/cypress.html");
@@ -109,8 +109,8 @@ describe("Composer `to` prop", () => {
     }).as("getMiddlewareAccount");
 
     cy.intercept("GET", "/users", [
-      { name: "Test User", email: "tester@nylas.com" },
-      { name: "Secound Test User", email: "tester2@nylas.com" },
+      { name: "Test User", email: "tester@test.com" },
+      { name: "Secound Test User", email: "tester2@test.com" },
     ]).as("getUsers");
 
     cy.visit("/components/composer/src/cypress.html");
@@ -129,7 +129,7 @@ describe("Composer `to` prop", () => {
       })
       .wait(500);
 
-    cy.get("[data-cy=contacts-search-field]").first().click();
+    cy.get("[data-cy=contacts-search-field]").first().click().wait(500);
 
     cy.contains("test@test.com");
   });
@@ -164,8 +164,8 @@ describe("Composer interactions", () => {
     }).as("getMiddlewareAccount");
 
     cy.intercept("GET", "/users", [
-      { name: "Test User", email: "tester@nylas.com" },
-      { name: "Secound Test User", email: "tester2@nylas.com" },
+      { name: "Test User", email: "tester@test.com" },
+      { name: "Secound Test User", email: "tester2@test.com" },
     ]).as("getUsers");
 
     cy.visit("/components/composer/src/cypress.html");
@@ -227,7 +227,7 @@ describe("Composer interactions", () => {
         from: [
           {
             name: "Luka Test",
-            email: "luka.b@nylas.com",
+            email: "luka.b@test.com",
           },
         ],
         to: [],
@@ -278,8 +278,8 @@ describe("Composer customizations", () => {
     }).as("getMiddlewareAccount");
 
     cy.intercept("GET", "/users", [
-      { name: "Test User", email: "tester@nylas.com" },
-      { name: "Secound Test User", email: "tester2@nylas.com" },
+      { name: "Test User", email: "tester@test.com" },
+      { name: "Secound Test User", email: "tester2@test.com" },
     ]).as("getUsers");
 
     cy.visit("/components/composer/src/cypress.html");
@@ -333,13 +333,13 @@ describe("Composer customizations", () => {
         from: [
           {
             name: "Luka Test",
-            email: "luka.b@nylas.com",
+            email: "luka.b@test.com",
           },
         ],
         to: [
           {
             name: "Dan Test",
-            email: "dan.r@nylas.com",
+            email: "dan.r@test.com",
           },
         ],
       };
@@ -571,8 +571,8 @@ describe("Composer integration", () => {
     }).as("getMiddlewareAccount");
 
     cy.intercept("GET", "/users", [
-      { name: "Test User", email: "tester@nylas.com" },
-      { name: "Secound Test User", email: "tester2@nylas.com" },
+      { name: "Test User", email: "tester@test.com" },
+      { name: "Secound Test User", email: "tester2@test.com" },
     ]).as("getUsers");
 
     cy.visit("/components/composer/src/cypress.html");
@@ -586,7 +586,7 @@ describe("Composer integration", () => {
       component.to = [
         {
           name: "Test User",
-          email: "luka.b@nylas.com",
+          email: "luka.b@test.com",
         },
       ];
     });
@@ -605,13 +605,13 @@ describe("Composer integration", () => {
         from: [
           {
             name: "Luka Test",
-            email: "luka.b@nylas.com",
+            email: "luka.b@test.com",
           },
         ],
         to: [
           {
             name: "Dan Test",
-            email: "dan.r@nylas.com",
+            email: "dan.r@test.com",
           },
         ],
       };
@@ -635,13 +635,13 @@ describe("Composer integration", () => {
         from: [
           {
             name: "Luka Test",
-            email: "luka.b@nylas.com",
+            email: "luka.b@test.com",
           },
         ],
         to: [
           {
             name: "Dan Test",
-            email: "dan.r@nylas.com",
+            email: "dan.r@test.com",
           },
         ],
       };
@@ -702,8 +702,8 @@ describe("Composer callbacks and options", () => {
     }).as("getMiddlewareAccount");
 
     cy.intercept("GET", "/users", [
-      { name: "Test User", email: "tester@nylas.com" },
-      { name: "Secound Test User", email: "tester2@nylas.com" },
+      { name: "Test User", email: "tester@test.com" },
+      { name: "Secound Test User", email: "tester2@test.com" },
     ]).as("getUsers");
 
     cy.visit("/components/composer/src/cypress.html");
@@ -719,13 +719,13 @@ describe("Composer callbacks and options", () => {
         from: [
           {
             name: "Luka Test",
-            email: "luka.b@nylas.com",
+            email: "luka.b@test.com",
           },
         ],
         to: [
           {
             name: "Dan Test",
-            email: "dan.r@nylas.com",
+            email: "dan.r@test.com",
           },
         ],
       };
@@ -758,8 +758,8 @@ describe("Composer file upload", () => {
     }).as("getMiddlewareAccount");
 
     cy.intercept("GET", "/users", [
-      { name: "Test User", email: "tester@nylas.com" },
-      { name: "Secound Test User", email: "tester2@nylas.com" },
+      { name: "Test User", email: "tester@test.com" },
+      { name: "Secound Test User", email: "tester2@test.com" },
     ]).as("getUsers");
 
     cy.visit("/components/composer/src/cypress.html");
@@ -783,13 +783,13 @@ describe("Composer file upload", () => {
         from: [
           {
             name: "Luka Test",
-            email: "luka.b@nylas.com",
+            email: "luka.b@test.com",
           },
         ],
         to: [
           {
             name: "Dan Test",
-            email: "dan.r@nylas.com",
+            email: "dan.r@test.com",
           },
         ],
       };
@@ -819,13 +819,13 @@ describe("Composer file upload", () => {
         from: [
           {
             name: "Luka Test",
-            email: "luka.b@nylas.com",
+            email: "luka.b@test.com",
           },
         ],
         to: [
           {
             name: "Dan Test",
-            email: "dan.r@nylas.com",
+            email: "dan.r@test.com",
           },
         ],
       };
@@ -920,9 +920,11 @@ describe("Composer subject", () => {
   });
 
   it("Sets subject", () => {
-    cy.get("@testComponent").then((element) => {
-      element[0].value = { subject: "Test subject" };
-    });
+    cy.get("@testComponent")
+      .then((element) => {
+        element[0].value = { subject: "Test subject" };
+      })
+      .wait(500);
 
     cy.get("input[name=subject]").should("have.value", "Test subject");
     cy.get("header span:eq(0)").contains("Test subject").should("be.visible");
@@ -961,13 +963,13 @@ describe("Save composer message as draft", () => {
         from: [
           {
             name: "Luka Test",
-            email: "luka.b@nylas.com",
+            email: "luka.b@test.com",
           },
         ],
         to: [
           {
             name: "Dan Test",
-            email: "dan.r@nylas.com",
+            email: "dan.r@test.com",
           },
         ],
       };
@@ -997,13 +999,13 @@ describe("Save composer message as draft", () => {
         from: [
           {
             name: "Luka Test",
-            email: "luka.b@nylas.com",
+            email: "luka.b@test.com",
           },
         ],
         to: [
           {
             name: "Dan Test",
-            email: "dan.r@nylas.com",
+            email: "dan.r@test.com",
           },
         ],
       };
@@ -1036,8 +1038,8 @@ describe("Composer `value` prop", () => {
     }).as("getMiddlewareAccount");
 
     cy.intercept("GET", "/users", [
-      { name: "Test User", email: "tester@nylas.com" },
-      { name: "Secound Test User", email: "tester2@nylas.com" },
+      { name: "Test User", email: "tester@test.com" },
+      { name: "Secound Test User", email: "tester2@test.com" },
     ]).as("getUsers");
 
     cy.visit("/components/composer/src/cypress.html");
@@ -1139,5 +1141,61 @@ describe("Composer `value` prop", () => {
       const fileItem = cy.wrap(el[0]);
       fileItem.contains(files_two[0].filename);
     });
+  });
+
+  it("Set value.files and send with correct file ids", () => {
+    const filePath = "example.json";
+    const files = [
+      {
+        content_disposition: "attachment",
+        content_type: "text/calendar",
+        filename: null,
+        id: "file-id-1",
+        size: 636,
+      },
+      {
+        content_disposition: "attachment",
+        content_type: "application/ics",
+        filename: "invite.ics",
+        id: "file-id-2",
+        size: 636,
+      },
+    ];
+
+    const send = (data) => {
+      expect(data.file_ids).to.have.lengthOf(2);
+      expect(data.file_ids).to.contain(files[1].id);
+      return Promise.resolve({ success: true });
+    };
+    const uploadFile = (id, _file) => {
+      return Promise.resolve({ id });
+    };
+
+    cy.get("@composer").then((el) => {
+      const component = el[0];
+      component.value = {
+        files: files,
+        from: [
+          {
+            name: "Luka Test",
+            email: "luka@test.com",
+          },
+        ],
+        to: [
+          {
+            name: "Dan Test",
+            email: "dan@test.com",
+          },
+        ],
+      };
+      component.send = send;
+      component.uploadFile = uploadFile;
+    });
+
+    cy.get(".send-btn").contains("Send").click();
+    cy.get("nylas-composer-alert-bar").should(
+      "contain",
+      "Message sent successfully!",
+    );
   });
 });

--- a/components/composer/src/init.spec.js
+++ b/components/composer/src/init.spec.js
@@ -522,10 +522,14 @@ describe("Composer customizations", () => {
     });
     cy.get("@composer")
       .shadow()
+      .get(".nylas-composer__loader")
+      .should("not.exist");
+    cy.get("@composer")
+      .shadow()
       .get("nylas-html-editor")
       .shadow()
       .get(".html-editor-content[contenteditable]")
-      .should("have.focus");
+      .should("have.focus", { timeout: 1000 });
   });
 
   it("should not focus body on load", () => {
@@ -1050,33 +1054,41 @@ describe("Composer `value` prop", () => {
 
   it("Set value.body", () => {
     cy.wait(["@getMiddlewareManifest", "@getMiddlewareAccount"]);
-    cy.get("@composer")
-      .then((el) => {
-        const composer = el[0];
-        composer.value = {
-          ...composer.value,
-          body: "<b>HTML Body Test</b>",
-        };
-      })
-      .wait(500);
+    cy.get("@composer").then((el) => {
+      const composer = el[0];
+      composer.value = {
+        ...composer.value,
+        body: "<b>HTML Body Test</b>",
+      };
+    });
 
-    cy.get(".html-editor[contenteditable=true]")
+    cy.get("@composer")
+      .shadow()
+      .get(".nylas-composer__loader")
+      .should("not.exist");
+    cy.get("@composer")
+      .shadow()
+      .get("nylas-html-editor")
+      .shadow()
+      .get(".html-editor-content[contenteditable]")
       .invoke("prop", "innerHTML")
       .then((html) => {
         expect(html).to.equal(`<b>HTML Body Test</b>`);
       });
 
-    cy.get("@composer")
-      .then((el) => {
-        const composer = el[0];
-        composer.value = {
-          ...composer.value,
-          body: "<b>Updated HTML Body</b>",
-        };
-      })
-      .wait(500);
+    cy.get("@composer").then((el) => {
+      const composer = el[0];
+      composer.value = {
+        ...composer.value,
+        body: "<b>Updated HTML Body</b>",
+      };
+    });
 
-    cy.get(".html-editor[contenteditable=true]")
+    cy.get("@composer")
+      .shadow()
+      .get("nylas-html-editor")
+      .shadow()
+      .get(".html-editor-content[contenteditable]")
       .invoke("prop", "innerHTML")
       .then((html) => {
         expect(html).to.equal(`<b>Updated HTML Body</b>`);
@@ -1102,20 +1114,24 @@ describe("Composer `value` prop", () => {
       },
     ];
 
-    cy.get("@composer")
-      .then((el) => {
-        const composer = el[0];
-        composer.value = {
-          ...composer.value,
-          files: files_one,
-        };
-      })
-      .wait(500);
-
-    cy.get(".file-item").then((el) => {
-      const fileItem = cy.wrap(el[0]);
-      fileItem.contains(files_one[1].filename);
+    cy.get("@composer").then((el) => {
+      const composer = el[0];
+      composer.value = {
+        ...composer.value,
+        files: files_one,
+      };
     });
+    cy.get("@composer")
+      .shadow()
+      .get(".nylas-composer__loader")
+      .should("not.exist");
+    cy.get("@composer")
+      .shadow()
+      .get(".file-item")
+      .then((el) => {
+        const fileItem = cy.wrap(el[0]);
+        fileItem.contains(files_one[1].filename);
+      });
 
     const files_two = [
       {
@@ -1127,24 +1143,23 @@ describe("Composer `value` prop", () => {
         size: 26769,
       },
     ];
-    cy.get("@composer")
-      .then((el) => {
-        const composer = el[0];
-        composer.value = {
-          ...composer.value,
-          files: files_two,
-        };
-      })
-      .wait(500);
-
-    cy.get(".file-item").then((el) => {
-      const fileItem = cy.wrap(el[0]);
-      fileItem.contains(files_two[0].filename);
+    cy.get("@composer").then((el) => {
+      const composer = el[0];
+      composer.value = {
+        ...composer.value,
+        files: files_two,
+      };
     });
+    cy.get("@composer")
+      .shadow()
+      .get(".file-item")
+      .then((el) => {
+        const fileItem = cy.wrap(el[0]);
+        fileItem.contains(files_two[0].filename);
+      });
   });
 
   it("Set value.files and send with correct file ids", () => {
-    const filePath = "example.json";
     const files = [
       {
         content_disposition: "attachment",
@@ -1191,11 +1206,14 @@ describe("Composer `value` prop", () => {
       component.send = send;
       component.uploadFile = uploadFile;
     });
-
-    cy.get(".send-btn").contains("Send").click();
-    cy.get("nylas-composer-alert-bar").should(
-      "contain",
-      "Message sent successfully!",
-    );
+    cy.get("@composer")
+      .shadow()
+      .get(".nylas-composer__loader")
+      .should("not.exist");
+    cy.get("@composer").shadow().contains("Send").click();
+    cy.get("@composer")
+      .shadow()
+      .get("nylas-composer-alert-bar")
+      .should("contain", "Message sent successfully!");
   });
 });

--- a/components/composer/src/lib/store.ts
+++ b/components/composer/src/lib/store.ts
@@ -65,6 +65,10 @@ export const removeAttachments = (item: Attachment): void => {
   ]);
 };
 
+export const resetAttachments = (): void => {
+  attachments.set(JSON.parse(JSON.stringify(attachmentsInitialState)));
+};
+
 export const resetAfterSend = (from: string[]): void => {
   message.set(JSON.parse(JSON.stringify({ ...messageInitialState, from })));
   attachments.set(JSON.parse(JSON.stringify(attachmentsInitialState)));

--- a/components/mailbox/src/index.html
+++ b/components/mailbox/src/index.html
@@ -25,11 +25,14 @@
         component.value = event.detail.value;
         component.focus_body_onload = event.detail.focus_body_onload;
         if (Object.keys(event.detail.message).length) {
-          component.value.body = event.detail.message.body ?? "";
-          component.value.files = event.detail.message.files ?? [];
-          component.value.account_id = event.detail.message.account_id ?? "";
-          component.value.id = event.detail.message.id ?? "";
-          component.value.cids = event.detail.message.cids ?? [];
+          component.value = {
+            ...component.value,
+            body: event.detail.message.body ?? "",
+            files: event.detail.message.files ?? [],
+            account_id: event.detail.message.account_id ?? "",
+            id: event.detail.message.id ?? "",
+            cids: event.detail.message.cids ?? [],
+          };
         }
         component.open();
       }


### PR DESCRIPTION
# Code changes
- [x] Allowed the file attachments to be reactively loaded if/when `props.value.files` is set.
- [x] Added a new `resetAttachments` function to reset the attachments store _only_ when the `props.value.files` changes. 
- [x] Switched to using the Nylas `Message` type instead of the custom `Message` type defined by the Composer component.
- [x] Updated the demo site (index.html) to set the `composer.value` prop properties correctly. Previous way did not trigger any of our reactive code because we were assigning sub properties individually (and svelte doesn't like that).
- [x] All @nylas.com email address domains have been changed to @test.com in our cypress tests.

# Readiness checklist

- [x] Added changes to component `CHANGELOG.md`
- [x] Cypress tests passing
- [x] New cypress tests added

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
