### PR TITLE
View/save/send draft messages in thread of email

### DIFF
--- a/commons/src/store/mailbox.ts
+++ b/commons/src/store/mailbox.ts
@@ -242,27 +242,16 @@ function initializeThreads() {
                 messages.push(incomingMessage);
                 foundThread.messages = messages;
                 foundThread.snippet = incomingMessage.snippet;
+                //Remove draft with the same id as sent message
+                foundThread.drafts = foundThread.drafts.filter(
+                  (draft) => draft.id !== incomingMessage.id,
+                );
                 threadToUpdate = JSON.parse(JSON.stringify(foundThread));
               }
             }
             return { ...threads };
           });
         }
-
-        //Remove existing draft in thread if sent as draft
-        update((threads) => {
-          let threadToUpdate = threads[queryKey][currentPage].threads.find(
-            (thread) => thread.id === foundThread.id,
-          );
-          if (threadToUpdate) {
-            const filteredDrafts = foundThread.drafts.filter(
-              (draft) => draft.id !== incomingMessage.id,
-            );
-            foundThread.drafts = filteredDrafts;
-            threadToUpdate = JSON.parse(JSON.stringify(foundThread));
-          }
-          return { ...threads };
-        });
       }
 
       return threadsMap[queryKey][currentPage].threads;

--- a/commons/src/store/mailbox.ts
+++ b/commons/src/store/mailbox.ts
@@ -275,6 +275,7 @@ function initializeThreads() {
         );
 
         if (incomingDraft.thread_id) {
+          //Update the snippet showing on the condensed draft message
           incomingDraft.snippet = incomingDraft.body
             ?.replace(/<\/?[^>]+(>|$)/g, "")
             .substring(0, 75);

--- a/commons/src/store/mailbox.ts
+++ b/commons/src/store/mailbox.ts
@@ -281,8 +281,7 @@ function initializeThreads() {
             .substring(0, 75);
 
           if (foundDraft) {
-            foundDraft.body = incomingDraft.body;
-            foundDraft.snippet = incomingDraft.snippet;
+            Object.assign(foundDraft, incomingDraft);
           } else {
             const drafts = foundThread.drafts;
             drafts.push(incomingDraft);

--- a/commons/src/types/Nylas.ts
+++ b/commons/src/types/Nylas.ts
@@ -112,6 +112,7 @@ export interface Message {
   subject?: null | string;
   body: null | string;
   id: string;
+  object: string;
   snippet: string;
   from: Participant[];
   to: Participant[];

--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -64,6 +64,7 @@
     ComposerProperties,
     Account,
     Participant,
+    File,
   } from "@commons/types/Nylas";
   import type { FetchContactsCallback as ContactsSearchFetchContactsCallback } from "@commons/types/ContactsSearch";
 
@@ -233,7 +234,7 @@
         if (isFileAnAttachment(value, file)) {
           addAttachments({
             account_id: value.account_id,
-            id: value.id,
+            id: file.id,
             filename: file.filename,
             size: file.size,
             content_type: file.content_type,
@@ -307,9 +308,16 @@
         : id && (await nylasUploadFile(id, file, access_token));
 
       updateAttachment(file.name, { loading: false, id: result.id });
-      // Update the message object
       if (result.id)
-        mergeMessage({ file_ids: [...$message.file_ids, result.id] });
+        // Update message store with new file_id and file
+        // New added file is attachment, thus added content_disposition property
+        mergeMessage({
+          file_ids: [...$message.file_ids, result.id],
+          files: [
+            ...($message.files || []),
+            { ...result, content_disposition: "attachment" },
+          ],
+        });
       if (afterFileUploadSuccess) afterFileUploadSuccess(result);
     } catch (e) {
       updateAttachment(file.name, {
@@ -328,6 +336,9 @@
       mergeMessage({
         file_ids: $message.file_ids.filter(
           (id: string) => id !== attachment.id,
+        ),
+        files: $message.files?.filter(
+          (file: File) => file.id !== attachment.id,
         ),
       });
     }
@@ -794,7 +805,8 @@
     rel="stylesheet"
     href={themeUrl}
     on:load={() => (themeLoaded = true)}
-    on:error={() => (themeLoaded = true)} />
+    on:error={() => (themeLoaded = true)}
+  />
 {/if}
 {#if visible && isLoading}
   <div class="nylas-composer nylas-composer__loader">
@@ -807,7 +819,8 @@
   <div
     class="nylas-composer"
     data-cy="nylas-composer"
-    class:minimized={_this.minimized}>
+    class:minimized={_this.minimized}
+  >
     {#if _this.show_header}
       <header class={_this.minimized ? "minimized" : undefined}>
         <span>{subject}</span>
@@ -816,14 +829,16 @@
             {#if _this.minimized}
               <button
                 class="composer-btn"
-                on:click={() => handleMinimize(false)}>
+                on:click={() => handleMinimize(false)}
+              >
                 <span class="sr-only">Expand Composer</span>
                 <ExpandIcon class="ExpandIcon" />
               </button>
             {:else}
               <button
                 class="composer-btn"
-                on:click={() => handleMinimize(true)}>
+                on:click={() => handleMinimize(true)}
+              >
                 <span class="sr-only">Collapse Composer</span>
                 <MinimizeIcon class="MinimizeIcon" />
               </button>
@@ -869,7 +884,8 @@
               placeholder="To:"
               change={handleContactsChange("to")}
               contacts={to}
-              value={$message.to} />
+              value={$message.to}
+            />
           {/if}
           <div class="addons">
             <button
@@ -880,7 +896,8 @@
               on:click={() => {
                 _this.show_cc = true;
                 previousProps = _this;
-              }}>CC</button>
+              }}>CC</button
+            >
 
             <button
               data-cy="toggle-bcc-field-btn"
@@ -892,7 +909,8 @@
               on:click={() => {
                 _this.show_bcc = true;
                 previousProps = _this;
-              }}>BCC</button>
+              }}>BCC</button
+            >
           </div>
         </div>
         {#if _this.show_cc}
@@ -902,7 +920,8 @@
               placeholder="CC:"
               contacts={cc}
               value={$message.cc}
-              change={handleContactsChange("cc")} />
+              change={handleContactsChange("cc")}
+            />
             <button
               type="button"
               class="composer-btn cc-btn"
@@ -911,7 +930,8 @@
                 _this.show_cc = false;
                 previousProps = _this;
               }}
-              aria-label="remove carbon copy field">
+              aria-label="remove carbon copy field"
+            >
               <CloseIcon class="CloseIcon" />
             </button>
           </div>
@@ -923,7 +943,8 @@
               placeholder="BCC:"
               contacts={bcc}
               value={$message.bcc}
-              change={handleContactsChange("bcc")} />
+              change={handleContactsChange("bcc")}
+            />
             <button
               type="button"
               class="composer-btn cc-btn"
@@ -932,7 +953,8 @@
                 _this.show_bcc = false;
                 previousProps = _this;
               }}
-              aria-label="remove blind carbon copy field">
+              aria-label="remove blind carbon copy field"
+            >
               <CloseIcon class="CloseIcon" />
             </button>
           </div>
@@ -948,7 +970,8 @@
               class="subject"
               value={subject}
               name="subject"
-              on:input={handleInputChange} />
+              on:input={handleInputChange}
+            />
           </label>
         {/if}
 
@@ -960,7 +983,8 @@
           focus_body_onload={_this.focus_body_onload}
           replace_fields={_this.replace_fields}
           show_editor_toolbar={_this.show_editor_toolbar}
-          on:keydown={handleKeyDown} />
+          on:keydown={handleKeyDown}
+        />
         {#if $attachments.length}
           <div class="nylas-attachments">
             <div class="attachments-wrapper">
@@ -969,7 +993,8 @@
               {#each $attachments as fileAttachment}
                 <nylas-composer-attachment
                   attachment={fileAttachment}
-                  remove={handleRemoveFile} />
+                  remove={handleRemoveFile}
+                />
               {/each}
             </div>
           </div>
@@ -986,7 +1011,8 @@
             for="save-draft"
             class="composer-btn save-draft"
             title="Save Email As Draft"
-            on:click={handleSaveDraft}>
+            on:click={handleSaveDraft}
+          >
             <DraftIcon class="FooterIcon" />
             <span class="sr-only">Save Draft</span>
           </button>
@@ -996,7 +1022,8 @@
             for="file-upload"
             class="composer-btn file-upload"
             title="Attach Files (up to {maxFileSize}MB)"
-            tabindex="0">
+            tabindex="0"
+          >
             <AttachmentIcon class="FooterIcon" />
             <span class="sr-only">Attach Files</span>
           </label>
@@ -1012,7 +1039,8 @@
             hidden
             type="file"
             id="file-upload"
-            on:change={handleFilesChange} />
+            on:change={handleFilesChange}
+          />
         </form>
       </footer>
       <!-- Date Picker Component -->
@@ -1024,7 +1052,8 @@
         <nylas-composer-alert-bar
           type="info"
           dismissible={true}
-          ondismiss={removeSchedule}>
+          ondismiss={removeSchedule}
+        >
           Send scheduled for
           <span>{formatDate(new Date(datepickerTimestamp))}</span>
         </nylas-composer-alert-bar>

--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -151,15 +151,19 @@
   };
 
   export const close = (): void => {
+    const msg = $message;
     visible = false;
     if (_this.reset_after_send || _this.reset_after_close) {
       sendSuccess = false;
+      saveSuccess = false;
     }
     if (_this.reset_after_close) {
       resetAfterSend($message.from);
     }
     attachments.update(() => []);
-    dispatchEvent("composerClosed", {});
+    dispatchEvent("composerClosed", {
+      message: msg,
+    });
   };
 
   let isLoading = false;
@@ -371,6 +375,14 @@
           sendError = true;
         });
     } else if (id) {
+      //If message is an existing draft
+      if (msg.object === "draft") {
+        const res = await updateDraft(id, msg, access_token);
+        if (res.id) {
+          mergeMessage({ ...res });
+          msg = { draft_id: res.id, ...res };
+        }
+      }
       // Middleware
       console.log(JSON.stringify(msg, null, 2));
       sendMessage(id, msg, access_token)

--- a/components/composer/src/init.spec.js
+++ b/components/composer/src/init.spec.js
@@ -772,7 +772,7 @@ describe("Composer file upload", () => {
   });
 
   it("Successful upload", () => {
-    const filePath = "example.json";
+    const filePath = "composer/files/tiny_text_file.txt";
 
     const send = (data) => {
       expect(data.file_ids).to.have.lengthOf(1);
@@ -803,7 +803,7 @@ describe("Composer file upload", () => {
 
     cy.get("input[type=file]").attachFile(filePath);
     cy.get("nylas-composer-attachment")
-      .contains("example.json")
+      .contains("tiny_text_file.txt")
       .should("be.visible");
     cy.get(".send-btn").contains("Send").click();
     cy.get("nylas-composer-alert-bar").should(
@@ -988,7 +988,7 @@ describe("Save composer message as draft", () => {
   });
 
   it("Successful upload", () => {
-    const filePath = "example.json";
+    const filePath = "composer/files/tiny_text_file.txt";
 
     const save = (data) => {
       expect(data.file_ids).to.have.lengthOf(1);
@@ -1019,7 +1019,7 @@ describe("Save composer message as draft", () => {
 
     cy.get("input[type=file]").attachFile(filePath);
     cy.get("nylas-composer-attachment")
-      .contains("example.json")
+      .contains("tiny_text_file.txt")
       .should("be.visible");
     cy.get(".save-draft").click();
     cy.get("nylas-composer-alert-bar").should(

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -1562,6 +1562,12 @@
                 max-width: 95vw;
                 align-self: flex-start;
               }
+
+              div.message-head {
+                &.draft {
+                  flex-flow: row;
+                }
+              }
             }
 
             div.message-date {
@@ -1570,9 +1576,6 @@
             }
             &.expanded {
               div.message-head {
-                &.draft {
-                  flex-flow: row;
-                }
                 div.message-from-to {
                   margin: $spacing-xs 0;
                   div.message-to {

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -673,6 +673,37 @@
     });
   }
 
+  function handleDraftClick(event: MouseEvent, draftIndex: number) {
+    event.stopImmediatePropagation();
+    dispatchDraftEvent(event, draftIndex);
+  }
+
+  function handleDraftKeypress(event: KeyboardEvent, draftIndex: number) {
+    event.stopImmediatePropagation();
+    if (event.code === "Enter") {
+      dispatchDraftEvent(event, draftIndex);
+    }
+  }
+
+  function dispatchDraftEvent(event: UIEvent, draftIndex: number) {
+    if (activeThread.drafts[draftIndex]) {
+      dispatchEvent("draftClicked", {
+        event,
+        message: activeThread.drafts[draftIndex],
+        thread: activeThread,
+      });
+      // Don't fetch message when thread is being passed manually
+      if (!_this.thread) {
+        fetchIndividualMessage(
+          draftIndex,
+          activeThread.drafts[draftIndex].id,
+        ).then((res) => {
+          activeThread.drafts[draftIndex].body = res;
+        });
+      }
+    }
+  }
+
   const weekdays = [
     "Sunday",
     "Monday",
@@ -973,6 +1004,9 @@
         &.deleted {
           background: var(--red);
         }
+        &.draft {
+          background: var(--nylas-email-snippet-color, var(--grey-dark));
+        }
       }
       header {
         font-size: 1.2rem;
@@ -1185,10 +1219,14 @@
               margin-top: $spacing-xs;
             }
             div.message-head {
-              .avatar-from {
+              .avatar-info {
                 display: flex;
                 align-items: center;
                 gap: $spacing-s;
+
+                & .draft-to {
+                  color: var(--nylas-email-snippet-color, var(--grey-dark));
+                }
               }
             }
           }
@@ -1234,9 +1272,12 @@
         }
         &.expanded {
           div.message-head {
+            &.draft {
+              flex-flow: column;
+            }
             div.message-from-to {
               margin: 0.5rem 0;
-              .avatar-from {
+              .avatar-info {
                 display: flex;
                 align-items: center;
                 gap: $spacing-s;
@@ -1529,6 +1570,9 @@
             }
             &.expanded {
               div.message-head {
+                &.draft {
+                  flex-flow: row;
+                }
                 div.message-from-to {
                   margin: $spacing-xs 0;
                   div.message-to {
@@ -1577,6 +1621,7 @@
     {:then thread}
       {#if thread && activeThread}
         {#if activeThread.expanded}
+          <!-- Expanded thread row -->
           <div
             class="email-row expanded {_this.click_action === 'mailbox'
               ? 'expanded-mailbox-thread'
@@ -1662,7 +1707,7 @@
                   {#if message.expanded || msgIndex === activeThread.messages.length - 1}
                     <div class="message-head">
                       <div class="message-from-to">
-                        <div class="avatar-from">
+                        <div class="avatar-info">
                           {#if _this.show_contact_avatar}
                             <div class="default-avatar">
                               <nylas-contact-image
@@ -1822,7 +1867,7 @@
                     </div>
                   {:else}
                     <div class="message-head">
-                      <div class="avatar-from">
+                      <div class="avatar-info">
                         {#if _this.show_contact_avatar}
                           <div class="default-avatar">
                             <nylas-contact-image
@@ -1869,8 +1914,93 @@
             {:else}
               <span class="snippet">{thread.snippet}</span>
             {/if}
+            <!-- Draft messages -->
+            {#if activeThread.drafts.length}
+              {#each activeThread.drafts as draft, draftIndex}
+                <div
+                  tabindex="0"
+                  class={`individual-message condensed draft-message`}
+                  bind:this={messageRefs[draftIndex]}
+                  on:click|stopPropagation={(e) =>
+                    handleDraftClick(e, draftIndex)}
+                  on:keypress={(e) => handleDraftKeypress(e, draftIndex)}
+                >
+                  <div class="message-head draft">
+                    <div class="avatar-info">
+                      {#if _this.show_contact_avatar}
+                        <div class="default-avatar draft">
+                          <DraftIcon />
+                        </div>
+                      {/if}
+                      <div class="draft-to">
+                        {#if draft?.to}
+                          {#await getAllRecipients( { to: draft.to, cc: draft.cc, bcc: draft.bcc }, ) then allRecipients}
+                            {#each allRecipients.slice(0, PARTICIPANTS_TO_TRUNCATE) as recipient, i}
+                              <p>
+                                Draft
+                                {#if i === 0}
+                                  {`to ${
+                                    _this.you &&
+                                    recipient.email === _this.you.email_address
+                                      ? "Me"
+                                      : ""
+                                  }`}
+                                {:else if recipient._type === "cc" && i === draft.to.length}
+                                  cc:
+                                {:else if recipient._type === "bcc" && i === draft.to.length + draft.cc.length}
+                                  bcc:
+                                {/if}
+
+                                {#if recipient.email && recipient.name}
+                                  {recipient.name ?? _this.you.name} &lt;{recipient.email}&gt;
+                                {:else if recipient.email && !recipient.name}
+                                  {recipient.email}
+                                {/if}
+                              </p>
+                            {/each}
+                            {#if allRecipients.length > PARTICIPANTS_TO_TRUNCATE}
+                              <div>
+                                <nylas-tooltip
+                                  on:toggleTooltip={setTooltip}
+                                  id={`show-more-participants-${draft.id}`}
+                                  current_tooltip_id={currentTooltipId}
+                                  icon={DropdownSymbol}
+                                  text={`And ${
+                                    allRecipients.length -
+                                    PARTICIPANTS_TO_TRUNCATE
+                                  } more`}
+                                  content={`${aggregateRecipientsString(
+                                    allRecipients,
+                                  )}`}
+                                />
+                              </div>
+                            {/if}
+                          {/await}
+                        {/if}
+                      </div>
+                    </div>
+
+                    <section>
+                      {#if _this.show_received_timestamp}
+                        <div class="message-date">
+                          <span>
+                            Saved at: {formatExpandedDate(
+                              new Date(draft.date * 1000),
+                            )}
+                          </span>
+                        </div>
+                      {/if}
+                    </section>
+                  </div>
+                  <div class="snippet">
+                    {draft.snippet}
+                  </div>
+                </div>
+              {/each}
+            {/if}
           </div>
         {:else}
+          <!-- Condensed thread row -->
           <div
             class="email-row condensed"
             class:show_star={_this.show_star}
@@ -1901,17 +2031,17 @@
                       class:deleted={activeThread.messages.length <= 0 &&
                         !isDraft}
                     >
-                      {#if activeThread && activeThread.messages.length <= 0}
-                        {#if isDraft}
+                      {#if activeThread}
+                        {#if isDraft && activeThread.drafts.length > 0}
                           <DraftIcon />
-                        {:else}
+                        {:else if activeThread.messages.length <= 0}
                           <NoMessagesIcon />
+                        {:else}
+                          <nylas-contact-image
+                            {contact_query}
+                            contact={activeThreadContact}
+                          />
                         {/if}
-                      {:else}
-                        <nylas-contact-image
-                          {contact_query}
-                          contact={activeThreadContact}
-                        />
                       {/if}
                     </div>
                   {/if}
@@ -2055,7 +2185,7 @@
         <div class="individual-message expanded">
           <div class="message-head">
             <div class="message-from-to">
-              <div class="avatar-from">
+              <div class="avatar-info">
                 {#if _this.show_contact_avatar}
                   <div class="default-avatar">
                     <nylas-contact-image

--- a/components/mailbox/CHANGELOG.md
+++ b/components/mailbox/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Pass z-index css to confirmation pop up's modal & overlay using css variables `z-index-modal` & `z-index-overlay` respectively
 - Draft, reply, reply all and forwarded messages include inline images and attachments
 - [Mailbox] Added new prop 'thread_click_action' that allows to specify the action on clicking an email thread [#369](https://github.com/nylas/components/pull/369)
+- View/save/send draft messages in email thread [#399](https://github.com/nylas/components/pull/399)
 
 ## Bug Fixes
 

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -615,7 +615,7 @@
 
   async function dispatchDraft(event) {
     const { thread, focus_body_onload } = event.detail;
-    const message = thread.drafts[0];
+    const message = event.detail.message ?? thread.drafts[0];
 
     if (message.cids?.length) {
       const inlineMessage = await getMessageWithInlineFiles(message);

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -301,6 +301,19 @@
     }
   }
 
+  async function draftClicked(event: CustomEvent) {
+    let draft = event.detail.message;
+
+    if (!_this.all_threads && draft && currentlySelectedThread) {
+      draft = await fetchIndividualMessage(draft);
+      if (FilesStore.hasInlineFiles(draft)) {
+        draft = await getMessageWithInlineFiles(draft);
+      }
+      event.detail.focus_body_onload = true;
+      dispatchDraft(event);
+    }
+  }
+
   async function updateThreadStatus(updatedThread: any) {
     if (id && updatedThread && updatedThread.id) {
       await MailboxStore.updateThread(
@@ -595,7 +608,7 @@
   //#endregion pagination
 
   async function dispatchDraft(event) {
-    const { thread } = event.detail;
+    const { thread, focus_body_onload } = event.detail;
     const message = thread.drafts[0];
 
     if (message.cids?.length) {
@@ -611,7 +624,13 @@
       subject: message.subject,
       body: message.body,
     };
-    dispatchEvent("draftThreadEvent", { event, message, thread, value });
+    dispatchEvent("draftThreadEvent", {
+      event,
+      message,
+      thread,
+      value,
+      focus_body_onload,
+    });
   }
 </script>
 
@@ -901,6 +920,7 @@
           show_reply_all={_this.show_reply_all}
           show_forward={_this.show_forward}
           on:messageClicked={messageClicked}
+          on:draftClicked={draftClicked}
           on:threadStarred={threadStarred}
           on:returnToMailbox={returnToMailbox}
           on:toggleThreadUnreadStatus={toggleThreadUnreadStatus}
@@ -1041,6 +1061,7 @@
                     show_forward={_this.show_forward}
                     on:threadClicked={threadClicked}
                     on:messageClicked={messageClicked}
+                    on:draftClicked={draftClicked}
                     on:threadStarred={threadStarred}
                     on:returnToMailbox={returnToMailbox}
                     on:toggleThreadUnreadStatus={toggleThreadUnreadStatus}

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -258,6 +258,9 @@
   export async function sentMessageUpdate(message: Message): Promise<void> {
     threads = MailboxStore.hydrateMessageInThread(message, query, currentPage);
   }
+  export async function draftMessageUpdate(message: Message): Promise<void> {
+    threads = MailboxStore.hydrateDraftInThread(message, query, currentPage);
+  }
 
   //#region actions
   let areAllSelected = false;
@@ -305,10 +308,13 @@
     let draft = event.detail.message;
 
     if (!_this.all_threads && draft && currentlySelectedThread) {
-      draft = await fetchIndividualMessage(draft);
+      if (!draft?.body) {
+        draft = await fetchIndividualMessage(draft);
+      }
       if (FilesStore.hasInlineFiles(draft)) {
         draft = await getMessageWithInlineFiles(draft);
       }
+      draft.draft_id = draft.id;
       event.detail.focus_body_onload = true;
       dispatchDraft(event);
     }

--- a/components/mailbox/src/index.html
+++ b/components/mailbox/src/index.html
@@ -27,11 +27,7 @@
         if (Object.keys(event.detail.message).length) {
           component.value = {
             ...component.value,
-            body: event.detail.message.body ?? "",
-            files: event.detail.message.files ?? [],
-            account_id: event.detail.message.account_id ?? "",
-            id: event.detail.message.id ?? "",
-            cids: event.detail.message.cids ?? [],
+            ...event.detail.message,
           };
         }
         component.open();

--- a/components/mailbox/src/index.html
+++ b/components/mailbox/src/index.html
@@ -26,8 +26,8 @@
         component.focus_body_onload = event.detail.focus_body_onload;
         if (Object.keys(event.detail.message).length) {
           component.value = {
-            ...component.value,
             ...event.detail.message,
+            ...component.value,
           };
         }
         component.open();
@@ -77,6 +77,16 @@
           mailbox.addEventListener(eventType, (e) =>
             toggleComposer(e, composer, eventType),
           ),
+        );
+
+        const draftEvents = ["composerClosed", "draftUpdated", "draftSaved"];
+        draftEvents.forEach((eventType) =>
+          composer.addEventListener(eventType, (event) => {
+            const message = event.detail.message;
+            if (message.object === "draft") {
+              mailbox.draftMessageUpdate(message);
+            }
+          }),
         );
       });
     </script>

--- a/components/mailbox/src/index.html
+++ b/components/mailbox/src/index.html
@@ -42,6 +42,7 @@
 
         mailbox.addEventListener("returnToMailbox", (event) => {
           console.log("returnToMailbox", event.detail);
+          composer.close();
         });
         mailbox.actions_bar = ["selectall", "star", "delete", "unread"];
         mailbox.show_star = true;

--- a/components/mailbox/src/init.spec.js
+++ b/components/mailbox/src/init.spec.js
@@ -1211,7 +1211,7 @@ describe("Mailbox Integration: Show draft message in Email thread", () => {
       .find(".contacts-container")
       .should("contain", "nylascypresstest+drafttest@gmail.com");
     cy.get("@composer")
-      .find(".html-editor[role='textbox']")
+      .find(".html-editor-content[role='textbox']")
       .invoke("text")
       .should(
         "contain",
@@ -1233,7 +1233,7 @@ describe("Mailbox Integration: Show draft message in Email thread", () => {
       .find(".contacts-container")
       .should("contain", "nylascypresstest+drafttest@gmail.com");
     cy.get("@composer")
-      .find(".html-editor[role='textbox']")
+      .find(".html-editor-content[role='textbox']")
       .invoke("text")
       .should(
         "contain",

--- a/cypress/fixtures/composer/files/fileResponse.json
+++ b/cypress/fixtures/composer/files/fileResponse.json
@@ -1,0 +1,27 @@
+{
+  "component": {
+    "theming": {
+      "mode": "inline",
+      "show_header": true,
+      "show_close_button": true,
+      "show_editor_toolbar": true,
+      "visible": true,
+      "show_minimize_button": true,
+      "theme": "light",
+      "show_attachment_button": true,
+      "show_from": true,
+      "minimized": false,
+      "show_subject": true
+    }
+  },
+  "response": [
+    {
+      "account_id": "1xrddnl99frq3b7son9j32aba",
+      "content_type": "text/plain",
+      "filename": "tiny_text_file.txt",
+      "id": "text_file_id",
+      "object": "file",
+      "size": 14
+    }
+  ]
+}

--- a/cypress/fixtures/composer/files/tiny_text_file.txt
+++ b/cypress/fixtures/composer/files/tiny_text_file.txt
@@ -1,0 +1,1 @@
+Tiny text file

--- a/cypress/fixtures/mailbox/messages/messageForDraftThread.json
+++ b/cypress/fixtures/mailbox/messages/messageForDraftThread.json
@@ -1,0 +1,42 @@
+{
+  "component": {
+    "theming": {
+      "show_received_timestamp": true,
+      "thread_id": "c6h7xdze9tod0p03v8wkb01nf",
+      "clean_conversation": false,
+      "unread": false,
+      "show_star": false,
+      "show_contact_avatar": true,
+      "show_number_of_messages": true,
+      "click_action": "select"
+    }
+  },
+  "response": {
+    "account_id": "1xrddnl99frq3b7son9j32aba",
+    "bcc": [],
+    "body": "<div dir=\"ltr\">This is the first message sent by me.</div>",
+    "cc": [{ "email": "test@nylas.com", "name": "Real User" }],
+    "date": 1634858431,
+    "events": [],
+    "files": [],
+    "from": [{ "email": "nylascypresstest@gmail.com", "name": "Test User" }],
+    "id": "message-id-1",
+    "labels": [
+      {
+        "display_name": "SENT",
+        "id": "17ocjrnqb2w5m402t1lwswkkl",
+        "name": "sent"
+      }
+    ],
+    "object": "message",
+    "reply_to": [],
+    "snippet": "This is the first message sent by me.",
+    "starred": false,
+    "subject": "Test Draft Messages In Thread",
+    "thread_id": "c6h7xdze9tod0p03v8wkb01nf",
+    "to": [
+      { "email": "nylascypresstest+drafttest@gmail.com", "name": "draft test" }
+    ],
+    "unread": false
+  }
+}

--- a/cypress/fixtures/mailbox/threads/draftMessage1.json
+++ b/cypress/fixtures/mailbox/threads/draftMessage1.json
@@ -14,19 +14,11 @@
   "response": {
     "account_id": "1xrddnl99frq3b7son9j32aba",
     "bcc": [],
-    "body": "<div dir=\"ltr\">This is a new draft saved from composer in mailbox. This is testing in cypress.</div>",
+    "body": "<div dir=\"ltr\">This is a new draft number one.</div>",
     "cc": [],
     "date": 1645142972,
     "events": [],
-    "files": [
-      {
-        "content_disposition": "attachment",
-        "content_type": "text/plain",
-        "filename": "Tiny_text_file.txt",
-        "id": "27b1yxq5m61qdk47wz1xcix21",
-        "size": 14
-      }
-    ],
+    "files": [],
     "from": [
       {
         "email": "nylascypresstest@gmail.com",
@@ -49,7 +41,7 @@
       }
     ],
     "reply_to_message_id": "message-id-1",
-    "snippet": "This is a new draft saved from composer in mailbox. along with a text file attachment. This is the second message sent back to me. On Thu, Feb 17, 2022 at 5:47 PM Test User <nylascypresstest@",
+    "snippet": "This is a new draft number one.",
     "starred": false,
     "subject": "Re: Test Draft Messages In Thread",
     "thread_id": "c6h7xdze9tod0p03v8wkb01nf",

--- a/cypress/fixtures/mailbox/threads/draftMessage1.json
+++ b/cypress/fixtures/mailbox/threads/draftMessage1.json
@@ -14,7 +14,7 @@
   "response": {
     "account_id": "1xrddnl99frq3b7son9j32aba",
     "bcc": [],
-    "body": "<div dir=\"ltr\">This is a new draft saved from composer in mailbox. This is testing in cypress.</div><div dir=\"ltr\"><br></div><div dir=\"ltr\">This is the second message sent back to me.</div><br><div class=\"gmail_quote\"><div dir=\"ltr\" class=\"gmail_attr\">On Thu, Feb 17, 2022 at 5:47 PM Test User &lt;<a href=\"mailto:nylascypresstest@gmail.com\">nylascypresstest@gmail.com</a>&gt; wrote:<br></div><blockquote class=\"gmail_quote\" style=\"margin:0px 0px 0px 0.8ex;border-left:1px solid rgb(204,204,204);padding-left:1ex\"><div dir=\"ltr\">This is the first message sent by me.&nbsp;</div>\n</blockquote></div>",
+    "body": "<div dir=\"ltr\">This is a new draft saved from composer in mailbox. This is testing in cypress.</div>",
     "cc": [],
     "date": 1645142972,
     "events": [],
@@ -33,7 +33,7 @@
         "name": "Test User"
       }
     ],
-    "id": "7edfoygcc0232fffeqvf0db52",
+    "id": "draft_message_1",
     "labels": [
       {
         "display_name": "DRAFT",
@@ -48,7 +48,7 @@
         "name": "Test User"
       }
     ],
-    "reply_to_message_id": "5gvz6pav5vw467lagt40gfam4",
+    "reply_to_message_id": "message-id-1",
     "snippet": "This is a new draft saved from composer in mailbox. along with a text file attachment. This is the second message sent back to me. On Thu, Feb 17, 2022 at 5:47 PM Test User <nylascypresstest@",
     "starred": false,
     "subject": "Re: Test Draft Messages In Thread",

--- a/cypress/fixtures/mailbox/threads/draftMessage2.json
+++ b/cypress/fixtures/mailbox/threads/draftMessage2.json
@@ -1,0 +1,65 @@
+{
+  "component": {
+    "theming": {
+      "items_per_page": 13,
+      "show_thread_checkbox": true,
+      "actions_bar": ["selectall", "star", "delete", "unread"],
+      "show_star": false,
+      "header": "",
+      "unread_status": "default",
+      "keyword_to_search": "",
+      "query_string": "in=inbox"
+    }
+  },
+  "response": {
+    "account_id": "1xrddnl99frq3b7son9j32aba",
+    "bcc": [],
+    "body": "<div dir=\"ltr\">Draft message number two</div>",
+    "cc": [],
+    "date": 1645142972,
+    "events": [],
+    "files": [
+      {
+        "content_disposition": "attachment",
+        "content_type": "text/plain",
+        "filename": "Tiny_text_file.txt",
+        "id": "27b1yxq5m61qdk47wz1xcix21",
+        "size": 14
+      }
+    ],
+    "from": [
+      {
+        "email": "nylascypresstest@gmail.com",
+        "name": "Test User"
+      }
+    ],
+    "id": "draft_message_2",
+    "labels": [
+      {
+        "display_name": "DRAFT",
+        "id": "7yv75k10rd3rw4kghwm9rxmqz",
+        "name": "drafts"
+      }
+    ],
+    "object": "draft",
+    "reply_to": [
+      {
+        "email": "nylascypresstest@gmail.com",
+        "name": "Test User"
+      }
+    ],
+    "reply_to_message_id": "message-id-1",
+    "snippet": "Draft message number two",
+    "starred": false,
+    "subject": "Re: Test Draft Messages In Thread",
+    "thread_id": "c6h7xdze9tod0p03v8wkb01nf",
+    "to": [
+      {
+        "email": "nylascypresstest+drafttest@gmail.com",
+        "name": "draft test"
+      }
+    ],
+    "unread": false,
+    "version": 0
+  }
+}

--- a/cypress/fixtures/mailbox/threads/draftMessage2.json
+++ b/cypress/fixtures/mailbox/threads/draftMessage2.json
@@ -22,7 +22,7 @@
       {
         "content_disposition": "attachment",
         "content_type": "text/plain",
-        "filename": "Tiny_text_file.txt",
+        "filename": "tiny_text_file.txt",
         "id": "27b1yxq5m61qdk47wz1xcix21",
         "size": 14
       }

--- a/cypress/fixtures/mailbox/threads/threadDraftMessage.json
+++ b/cypress/fixtures/mailbox/threads/threadDraftMessage.json
@@ -1,0 +1,65 @@
+{
+  "component": {
+    "theming": {
+      "items_per_page": 13,
+      "show_thread_checkbox": true,
+      "actions_bar": ["selectall", "star", "delete", "unread"],
+      "show_star": false,
+      "header": "",
+      "unread_status": "default",
+      "keyword_to_search": "",
+      "query_string": "in=inbox"
+    }
+  },
+  "response": {
+    "account_id": "1xrddnl99frq3b7son9j32aba",
+    "bcc": [],
+    "body": "<div dir=\"ltr\">This is a new draft saved from composer in mailbox. This is testing in cypress.</div><div dir=\"ltr\"><br></div><div dir=\"ltr\">This is the second message sent back to me.</div><br><div class=\"gmail_quote\"><div dir=\"ltr\" class=\"gmail_attr\">On Thu, Feb 17, 2022 at 5:47 PM Test User &lt;<a href=\"mailto:nylascypresstest@gmail.com\">nylascypresstest@gmail.com</a>&gt; wrote:<br></div><blockquote class=\"gmail_quote\" style=\"margin:0px 0px 0px 0.8ex;border-left:1px solid rgb(204,204,204);padding-left:1ex\"><div dir=\"ltr\">This is the first message sent by me.&nbsp;</div>\n</blockquote></div>",
+    "cc": [],
+    "date": 1645142972,
+    "events": [],
+    "files": [
+      {
+        "content_disposition": "attachment",
+        "content_type": "text/plain",
+        "filename": "Tiny_text_file.txt",
+        "id": "27b1yxq5m61qdk47wz1xcix21",
+        "size": 14
+      }
+    ],
+    "from": [
+      {
+        "email": "nylascypresstest@gmail.com",
+        "name": "Test User"
+      }
+    ],
+    "id": "7edfoygcc0232fffeqvf0db52",
+    "labels": [
+      {
+        "display_name": "DRAFT",
+        "id": "7yv75k10rd3rw4kghwm9rxmqz",
+        "name": "drafts"
+      }
+    ],
+    "object": "draft",
+    "reply_to": [
+      {
+        "email": "nylascypresstest@gmail.com",
+        "name": "Test User"
+      }
+    ],
+    "reply_to_message_id": "5gvz6pav5vw467lagt40gfam4",
+    "snippet": "This is a new draft saved from composer in mailbox. along with a text file attachment. This is the second message sent back to me. On Thu, Feb 17, 2022 at 5:47 PM Test User <nylascypresstest@",
+    "starred": false,
+    "subject": "Re: Test Draft Messages In Thread",
+    "thread_id": "c6h7xdze9tod0p03v8wkb01nf",
+    "to": [
+      {
+        "email": "nylascypresstest+drafttest@gmail.com",
+        "name": "draft test"
+      }
+    ],
+    "unread": false,
+    "version": 0
+  }
+}

--- a/cypress/fixtures/mailbox/threads/threadWithDraft.json
+++ b/cypress/fixtures/mailbox/threads/threadWithDraft.json
@@ -35,7 +35,7 @@
               "name": "Test User"
             }
           ],
-          "id": "7edfoygcc0232fffeqvf0db52",
+          "id": "draft_message_1",
           "labels": [
             {
               "display_name": "DRAFT",
@@ -50,8 +50,49 @@
               "name": "Test User"
             }
           ],
-          "reply_to_message_id": "5gvz6pav5vw467lagt40gfam4",
-          "snippet": "This is a new draft saved from composer in mailbox. This is testing in cypress. This is the second message sent back to me. On Thu, Feb 17, 2022 at 5:47 PM Test User <nylascypresstest@",
+          "reply_to_message_id": "message-id-1",
+          "snippet": "This is a new draft saved from composer in mailbox. This is testing in cypress.",
+          "starred": false,
+          "subject": "Re: Test Draft Messages In Thread",
+          "thread_id": "c6h7xdze9tod0p03v8wkb01nf",
+          "to": [
+            {
+              "email": "nylascypresstest+drafttest@gmail.com",
+              "name": "draft test"
+            }
+          ],
+          "unread": false,
+          "version": 0
+        },
+        {
+          "account_id": "1xrddnl99frq3b7son9j32aba",
+          "bcc": [],
+          "cc": [],
+          "date": 1645142972,
+          "files": [],
+          "from": [
+            {
+              "email": "nylascypresstest@gmail.com",
+              "name": "Test User"
+            }
+          ],
+          "id": "draft_message_2",
+          "labels": [
+            {
+              "display_name": "DRAFT",
+              "id": "7yv75k10rd3rw4kghwm9rxmqz",
+              "name": "drafts"
+            }
+          ],
+          "object": "draft",
+          "reply_to": [
+            {
+              "email": "nylascypresstest@gmail.com",
+              "name": "Test User"
+            }
+          ],
+          "reply_to_message_id": "message-id-1",
+          "snippet": "Draft message number two",
           "starred": false,
           "subject": "Re: Test Draft Messages In Thread",
           "thread_id": "c6h7xdze9tod0p03v8wkb01nf",
@@ -107,7 +148,7 @@
               "name": "Test User"
             }
           ],
-          "id": "8g5sbsa7n8saez1ge23dnfjx0",
+          "id": "message-id-1",
           "labels": [
             {
               "display_name": "SENT",

--- a/cypress/fixtures/mailbox/threads/threadWithDraft.json
+++ b/cypress/fixtures/mailbox/threads/threadWithDraft.json
@@ -1,0 +1,151 @@
+{
+  "component": {
+    "theming": {
+      "items_per_page": 13,
+      "show_thread_checkbox": true,
+      "actions_bar": ["selectall", "star", "delete", "unread"],
+      "show_star": false,
+      "header": "",
+      "unread_status": "default",
+      "keyword_to_search": "",
+      "query_string": "in=inbox"
+    }
+  },
+  "response": [
+    {
+      "account_id": "1xrddnl99frq3b7son9j32aba",
+      "drafts": [
+        {
+          "account_id": "1xrddnl99frq3b7son9j32aba",
+          "bcc": [],
+          "cc": [],
+          "date": 1645142972,
+          "files": [
+            {
+              "content_disposition": "attachment",
+              "content_type": "text/plain",
+              "filename": "Tiny_text_file.txt",
+              "id": "27b1yxq5m61qdk47wz1xcix21",
+              "size": 14
+            }
+          ],
+          "from": [
+            {
+              "email": "nylascypresstest@gmail.com",
+              "name": "Test User"
+            }
+          ],
+          "id": "7edfoygcc0232fffeqvf0db52",
+          "labels": [
+            {
+              "display_name": "DRAFT",
+              "id": "7yv75k10rd3rw4kghwm9rxmqz",
+              "name": "drafts"
+            }
+          ],
+          "object": "draft",
+          "reply_to": [
+            {
+              "email": "nylascypresstest@gmail.com",
+              "name": "Test User"
+            }
+          ],
+          "reply_to_message_id": "5gvz6pav5vw467lagt40gfam4",
+          "snippet": "This is a new draft saved from composer in mailbox. This is testing in cypress. This is the second message sent back to me. On Thu, Feb 17, 2022 at 5:47 PM Test User <nylascypresstest@",
+          "starred": false,
+          "subject": "Re: Test Draft Messages In Thread",
+          "thread_id": "c6h7xdze9tod0p03v8wkb01nf",
+          "to": [
+            {
+              "email": "nylascypresstest+drafttest@gmail.com",
+              "name": "draft test"
+            }
+          ],
+          "unread": false,
+          "version": 0
+        }
+      ],
+      "first_message_timestamp": 1645138023,
+      "has_attachments": false,
+      "id": "c6h7xdze9tod0p03v8wkb01nf",
+      "labels": [
+        {
+          "display_name": "SENT",
+          "id": "17ocjrnqb2w5m402t1lwswkkl",
+          "name": "sent"
+        },
+        {
+          "display_name": "DRAFT",
+          "id": "7yv75k10rd3rw4kghwm9rxmqz",
+          "name": "drafts"
+        },
+        {
+          "display_name": "INBOX",
+          "id": "dx62wkpj57erbkargbr3zew3j",
+          "name": "inbox"
+        },
+        {
+          "display_name": "IMPORTANT",
+          "id": "5852fv5ompdk51g0ve17mvej9",
+          "name": "important"
+        }
+      ],
+      "last_message_received_timestamp": 1645138169,
+      "last_message_sent_timestamp": 1645138023,
+      "last_message_timestamp": 1645139358,
+      "last_updated_timestamp": 1645142972,
+      "messages": [
+        {
+          "account_id": "1xrddnl99frq3b7son9j32aba",
+          "bcc": [],
+          "cc": [],
+          "date": 1645138023,
+          "files": [],
+          "from": [
+            {
+              "email": "nylascypresstest@gmail.com",
+              "name": "Test User"
+            }
+          ],
+          "id": "8g5sbsa7n8saez1ge23dnfjx0",
+          "labels": [
+            {
+              "display_name": "SENT",
+              "id": "17ocjrnqb2w5m402t1lwswkkl",
+              "name": "sent"
+            }
+          ],
+          "object": "message",
+          "reply_to": [],
+          "snippet": "This is the first message sent by me.",
+          "starred": false,
+          "subject": "Test Draft Messages In Thread",
+          "thread_id": "c6h7xdze9tod0p03v8wkb01nf",
+          "to": [
+            {
+              "email": "nylascypresstest+drafttest@gmail.com",
+              "name": "draft test"
+            }
+          ],
+          "unread": false
+        }
+      ],
+      "object": "thread",
+      "participants": [
+        {
+          "email": "nylascypresstest+drafttest@gmail.com",
+          "name": "draft test"
+        },
+        {
+          "email": "nylascypresstest@gmail.com",
+          "name": "Test User"
+        }
+      ],
+      "snippet": "This is the second message sent back to me.",
+      "starred": false,
+      "subject": "Test Draft Messages In Thread",
+      "unread": false,
+      "version": 11
+    }
+  ]
+}

--- a/cypress/fixtures/mailbox/threads/threadWithDraft.json
+++ b/cypress/fixtures/mailbox/threads/threadWithDraft.json
@@ -20,15 +20,7 @@
           "bcc": [],
           "cc": [],
           "date": 1645142972,
-          "files": [
-            {
-              "content_disposition": "attachment",
-              "content_type": "text/plain",
-              "filename": "Tiny_text_file.txt",
-              "id": "27b1yxq5m61qdk47wz1xcix21",
-              "size": 14
-            }
-          ],
+          "files": [],
           "from": [
             {
               "email": "nylascypresstest@gmail.com",
@@ -51,7 +43,7 @@
             }
           ],
           "reply_to_message_id": "message-id-1",
-          "snippet": "This is a new draft saved from composer in mailbox. This is testing in cypress.",
+          "snippet": "This is a new draft number one.",
           "starred": false,
           "subject": "Re: Test Draft Messages In Thread",
           "thread_id": "c6h7xdze9tod0p03v8wkb01nf",
@@ -69,7 +61,15 @@
           "bcc": [],
           "cc": [],
           "date": 1645142972,
-          "files": [],
+          "files": [
+            {
+              "content_disposition": "attachment",
+              "content_type": "text/plain",
+              "filename": "tiny_text_file.txt",
+              "id": "27b1yxq5m61qdk47wz1xcix21",
+              "size": 14
+            }
+          ],
           "from": [
             {
               "email": "nylascypresstest@gmail.com",


### PR DESCRIPTION
# Code changes

- [x] If a thread has multiple messages and is expanded, then show a row for each draft message that may exist.
- [x] If a user clicks the row for a draft message, then fire an event saying that the draft message was clicked/opened
- [x] A developer should be able to launch a composer component when a draft message is clicked/opened in an expanded threaded message
- [x] As a user when I save a email (via composer) as draft, it should show up in my messages list


# Readiness checklist

- [x] Added changes to component `CHANGELOG.md`
- [x] Cypress tests passing?
- [x] New cypress tests added?
- [x] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
