### PR TITLE
[Composer] fix firefox bug tabbing into contenteditable area

### DIFF
--- a/components/composer/CHANGELOG.md
+++ b/components/composer/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [Composer] focus the HTML editor textbox when a formatting option is clicked [#342](https://github.com/nylas/components/pull/342)
 - [Composer] Header should reactively update with the change in the subject [#367](https://github.com/nylas/components/pull/367)
+- [Composer] Fix bug where unable to tab into contenteditable area in Firefox [#400](https://github.com/nylas/components/pull/400)
 
 # v1.1.6 (Unreleased)
 

--- a/components/composer/src/components/HTMLEditor.svelte
+++ b/components/composer/src/components/HTMLEditor.svelte
@@ -14,7 +14,7 @@
   let toolbar: ToolbarItem[] = defaultActions;
 
   $: if (focus_body_onload && container) {
-    container.focus();
+    handleHtmlBodyFocus();
   }
 
   $: if (html) {
@@ -102,6 +102,20 @@
       return item;
     });
   }
+
+  const handleHtmlBodyFocus = () => {
+    // if contenteditable area is empty we need to add something to add range
+    if (container.innerHTML === "") {
+      container.innerHTML = "\u00a0";
+    }
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(container);
+    range.collapse(false); // collapse range to the end
+
+    selection.removeAllRanges();
+    selection.addRange(range);
+  };
 </script>
 
 <style lang="scss">
@@ -111,6 +125,10 @@
     *:focus {
       outline: 5px auto var(--composer-primary-color, #5c77ff);
     }
+  }
+  .html-editor-content {
+    min-height: var(--composer-editor-min-height, 220px);
+    max-height: var(--composer-editor-max-height, 480px);
   }
   a {
     color: var(--composer-primary-color, #5c77ff);
@@ -201,9 +219,11 @@
   <div
     bind:this={container}
     bind:innerHTML={html}
+    on:focus={handleHtmlBodyFocus}
     contenteditable="true"
-    class="html-editor"
+    class="html-editor-content"
     role="textbox"
+    aria-label="HTML Editor"
     on:keyup={updateToolbarUI}
     on:mouseup={updateToolbarUI}
   />

--- a/components/composer/src/init.spec.js
+++ b/components/composer/src/init.spec.js
@@ -468,7 +468,7 @@ describe("Composer customizations", () => {
     cy.get(".nylas-composer").should("exist");
   });
 
-  it("Replaces merge fields as defined in replace_fields when passed as a strinigfied version", () => {
+  it("Replaces merge fields as defined in replace_fields when passed as a stringified version", () => {
     const value = {
       body: `[hi] what up!<br />
       <br />
@@ -481,10 +481,11 @@ describe("Composer customizations", () => {
     cy.get("@composer").invoke("prop", "replace_fields", [
       { from: "[hi]", to: "hello" },
     ]);
-    cy.get(".html-editor[contenteditable=true]").should("exist");
-    cy.get(".html-editor[contenteditable=true]")
+    cy.get(".html-editor-content[contenteditable]").should("exist");
+    cy.get(".html-editor-content[contenteditable]")
       .invoke("prop", "innerHTML")
       .then((html) => {
+        console.log("html:", html);
         expect(html).to.equal(
           `hello what up!<br>\n      <br>\n      <br>\n      Thanks,\n      -Phil`,
         );
@@ -505,7 +506,7 @@ describe("Composer customizations", () => {
       component.replace_fields = [{ from: "[hi]", to: "hello" }];
     });
 
-    cy.get(".html-editor[contenteditable=true]")
+    cy.get(".html-editor-content[contenteditable]")
       .invoke("prop", "innerHTML")
       .then((html) => {
         expect(html).to.include(
@@ -523,7 +524,7 @@ describe("Composer customizations", () => {
       .shadow()
       .get("nylas-html-editor")
       .shadow()
-      .get("div.html-editor[contenteditable]")
+      .get(".html-editor-content[contenteditable]")
       .should("have.focus");
   });
 
@@ -536,7 +537,7 @@ describe("Composer customizations", () => {
       .shadow()
       .get("nylas-html-editor")
       .shadow()
-      .get("div.html-editor[contenteditable]")
+      .get(".html-editor-content[contenteditable]")
       .should("not.have.focus");
   });
 
@@ -667,7 +668,7 @@ describe("Composer integration", () => {
       -Phil</div></div>`;
     });
 
-    cy.get(".html-editor[contenteditable=true]")
+    cy.get(".html-editor-content[contenteditable]")
       .invoke("prop", "innerHTML")
       .then((html) => {
         expect(html).to.include(
@@ -682,7 +683,7 @@ describe("Composer integration", () => {
       component.value = { body: "Test value body prop" };
     });
 
-    cy.get(".html-editor[contenteditable=true]")
+    cy.get(".html-editor-content[contenteditable=true]")
       .invoke("prop", "innerHTML")
       .should("include", "Test value body prop");
   });


### PR DESCRIPTION
# Code changes

- [x] add range functionality when div is focused to programmatically add blank space and add range when contenteditable area is empty.
- [x] when contenteditable area has content and put cursor at the end of the content.

# Readiness checklist

- [x] Added changes to component `CHANGELOG.md`

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
