### PR TITLE
[agenda] inherit font-family from body

### DIFF
--- a/components/agenda/CHANGELOG.md
+++ b/components/agenda/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [Agenda] Add overrideable css vars to customize agenda appearance [#378](https://github.com/nylas/components/pull/378)
 - [Agenda] Dispatch `eventClicked` when event is clicked [#372](https://github.com/nylas/components/pull/372)
 - [Agenda] Added timezone prop support to Agenda [#368](https://github.com/nylas/components/pull/368)
+- [Agenda] All text will inherit `font-family` from `body` [#401](https://github.com/nylas/components/pull/401)
 
 ## Bug Fixes
 

--- a/components/agenda/src/styles/agenda.scss
+++ b/components/agenda/src/styles/agenda.scss
@@ -1,5 +1,5 @@
-@import "../../../theming/reset";
-@import "../../../theming/variables";
+@import "../../../theming/reset.scss";
+@import "../../../theming/variables.scss";
 
 @import "theme";
 @import "agenda-themes";
@@ -8,7 +8,7 @@ main {
   text-align: center;
   height: 100%;
   margin: 0 auto;
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: inherit;
   display: grid;
   grid-template-rows: 80px auto 1fr;
   grid-template-columns: 1fr;
@@ -134,7 +134,7 @@ header {
 }
 
 h2 {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: inherit;
   font-size: 12px;
   margin-bottom: 0px;
   font-weight: 600;


### PR DESCRIPTION
# Code changes

- [x] remove set fonts from Agenda so it can inherit from body.


https://user-images.githubusercontent.com/34139730/154761521-20eb47a8-c314-4194-b2d5-16ad6c8d29f3.mov


# Readiness checklist

- [x] Added changes to component `CHANGELOG.md`

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
