### PR TITLE
[Email] Show and open existing draft when clicking on reply/forward of message

### DIFF
--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -153,6 +153,7 @@
 
   export const close = (): void => {
     const msg = $message;
+    msg.active = false;
     visible = false;
     if (_this.reset_after_send || _this.reset_after_close) {
       sendSuccess = false;

--- a/components/composer/src/components/HTMLEditor.svelte
+++ b/components/composer/src/components/HTMLEditor.svelte
@@ -14,6 +14,7 @@
   let toolbar: ToolbarItem[] = defaultActions;
 
   $: if (focus_body_onload && container) {
+    container.focus();
     handleHtmlBodyFocus();
   }
 

--- a/components/email/CHANGELOG.md
+++ b/components/email/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- [Email] Checks existing draft in thread when clicking on reply/forward, and opens composer with draft if exists. [#405](https://github.com/nylas/components/pull/405)
+- [Email] Highlights draft in thread when its opened with Composer. [#405](https://github.com/nylas/components/pull/405)
+
 ## Breaking
 
 ## New Features

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -613,7 +613,7 @@
   }
   //#endregion pagination
 
-  async function dispatchDraft(event) {
+  async function dispatchDraft(event: CustomEvent) {
     const { thread, focus_body_onload } = event.detail;
     const message = event.detail.message ?? thread.drafts[0];
 
@@ -621,6 +621,7 @@
       const inlineMessage = await getMessageWithInlineFiles(message);
       message.body = inlineMessage.body;
     }
+    draftMessageUpdate(message);
 
     const value = {
       to: message.to,

--- a/components/mailbox/src/index.html
+++ b/components/mailbox/src/index.html
@@ -19,8 +19,8 @@
       }
     </style>
     <script type="module">
-      function toggleComposer(event, component) {
-        console.log(event.detail);
+      function toggleComposer(event, component, type) {
+        console.log(type, event.detail);
         component.removeAttribute("hidden");
         component.value = event.detail.value;
         component.focus_body_onload = event.detail.focus_body_onload;

--- a/components/mailbox/src/init.spec.js
+++ b/components/mailbox/src/init.spec.js
@@ -1274,6 +1274,36 @@ describe("Mailbox Integration: Show draft message in Email thread", () => {
       .should("contain", "This is a new draft number one.");
   });
 
+  it("Click reply/forward to message in thread opens existing draft", () => {
+    cy.get("@mailbox").invoke("prop", "show_reply", true);
+    cy.get("@mailbox").invoke("prop", "show_forward", true);
+    cy.get("@mailbox").find(".email-row.condensed").should("have.length", 1);
+    cy.get("@mailbox").find(".email-row.condensed").click();
+
+    //Click on reply should open existing draft
+    cy.get("@email").find(".reply").should("exist");
+    cy.get("@email").find(".reply").click();
+    cy.get("@composer")
+      .find("header")
+      .should("contain", "Re: Test Draft Messages In Thread");
+    cy.get("@composer")
+      .find(".html-editor-content[role='textbox']")
+      .invoke("text")
+      .should("contain", "This is a new draft number one.");
+    cy.get("@composer").find("header .composer-btn .CloseIcon").click();
+
+    //Click on forward should open the same draft
+    cy.get("@email").find(".forward").should("exist");
+    cy.get("@email").find(".forward").click();
+    cy.get("@composer")
+      .find("header")
+      .should("contain", "Re: Test Draft Messages In Thread");
+    cy.get("@composer")
+      .find(".html-editor-content[role='textbox']")
+      .invoke("text")
+      .should("contain", "This is a new draft number one.");
+  });
+
   it("Click on draft loads draft body when multiple drafts under the same thread", () => {
     cy.get("@mailbox").find(".email-row.condensed").should("have.length", 1);
     cy.get("@mailbox").find(".email-row.condensed").click();

--- a/cypress/fixtures/mailbox/threads/draftMessage2.json
+++ b/cypress/fixtures/mailbox/threads/draftMessage2.json
@@ -48,7 +48,7 @@
         "name": "Test User"
       }
     ],
-    "reply_to_message_id": "message-id-1",
+    "reply_to_message_id": "message-id-2",
     "snippet": "Draft message number two",
     "starred": false,
     "subject": "Re: Test Draft Messages In Thread",

--- a/cypress/fixtures/mailbox/threads/threadWithDraft.json
+++ b/cypress/fixtures/mailbox/threads/threadWithDraft.json
@@ -91,7 +91,7 @@
               "name": "Test User"
             }
           ],
-          "reply_to_message_id": "message-id-1",
+          "reply_to_message_id": "message-id-2",
           "snippet": "Draft message number two",
           "starred": false,
           "subject": "Re: Test Draft Messages In Thread",


### PR DESCRIPTION
# Code changes

- [x] Checks existing draft in thread when clicking on reply/forward, and opens composer with draft if exists.
- [x] Highlights draft in thread when its opened with Composer
- [x]  Removed obsolete property `messageLoadStatus` to simplify `fetchIndividualMessage` function when loading messages and drafts

# Readiness checklist

- [x] Added changes to component `CHANGELOG.md`
- [x] Cypress tests passing?
- [x] New cypress tests added?

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
