### PR TITLE
[availability] Removed redundant calls to /consecutive endpoint

### DIFF
--- a/commons/src/types/Availability.ts
+++ b/commons/src/types/Availability.ts
@@ -14,7 +14,7 @@ export interface Manifest extends NylasManifest {
   allow_booking: boolean;
   allow_date_change: boolean;
   attendees_to_show: number;
-  availability: Availability;
+  availability: AvailabilityResponse;
   booking_options: ConsecutiveEvent[][];
   booking_user_email: string;
   booking_user_token: string;
@@ -105,12 +105,12 @@ export interface BookableSlot extends TimeSlot {
   expirySelection: string;
   participantEmails: string[];
   recurrence_cadence?:
-    | "none"
-    | "daily"
-    | "weekdays"
-    | "biweekly"
-    | "weekly"
-    | "monthly";
+  | "none"
+  | "daily"
+  | "weekdays"
+  | "biweekly"
+  | "weekly"
+  | "monthly";
   recurrence_expiry?: Date | string;
 }
 

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -41,6 +41,7 @@
     Day,
     PreDatedTimeSlot,
     OpenHours,
+    AvailabilityResponse,
   } from "@commons/types/Availability";
   import "@commons/components/ContactImage/ContactImage.svelte";
   import "@commons/components/ErrorMessage.svelte";
@@ -70,7 +71,7 @@
   export let allow_booking: boolean;
   export let allow_date_change: boolean;
   export let attendees_to_show: number;
-  export let availability: Availability;
+  export let availability: AvailabilityResponse;
   export let booking_options: ConsecutiveEvent[][];
   export let booking_user_email: string;
   export let booking_user_token: string;
@@ -234,7 +235,7 @@
     // TODO - Use a library to calculate the diff between props so that
     // only updated props are reassigned instead of rebuilding the whole object.
     if (
-      (!$$props.event_to_hover ||
+      ($$props.event_to_hover === undefined ||
         previousProps.event_to_hover === $$props.event_to_hover) &&
       JSON.stringify(previousProps) !== JSON.stringify($$props)
     ) {
@@ -269,7 +270,12 @@
   $: (async () => {
     if (_this.booking_options) {
       consecutiveOptions = _this.booking_options;
-    } else if (id && Array.isArray(_this.events) && dayRange.length > 0) {
+    } else if (
+      !loading &&
+      id &&
+      Array.isArray(_this.events) &&
+      dayRange.length > 0
+    ) {
       await buildConsecutiveOptions();
     }
     buildDailyConsecutiveOptions();
@@ -711,7 +717,7 @@
     }
   }
 
-  function mapTimeslotsToCalendars(calendarList: Calendar[]) {
+  function mapTimeslotsToCalendars(calendarList: AvailabilityResponse) {
     const freeBusyCalendars: any = [];
 
     const timeSlotMap: Record<string, PreDatedTimeSlot[]> = {};


### PR DESCRIPTION
# Code changes

- Removed redundant calls to /consecutive endpoint that would happen before the component was loaded
- Removed extra call that would happen when `events_to_hover` was set to null

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
