### PR TITLE
Manually run prettier formatting across our components

### DIFF
--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -1144,8 +1144,7 @@
     --selected-color-lightened: {lightenHexColour(_this.selected_color, 60)}; 
     --free-color: {_this.free_color}; --busy-color: {_this.busy_color}; 
     --closed-color: {_this.closed_color}; --partial-color: {_this.partial_color};
-    --selected-color: {_this.selected_color};"
-  >
+    --selected-color: {_this.selected_color};">
     <header class:dated={_this.allow_date_change}>
       <h2 class="month">{showDateRange(days)}</h2>
       {#if _this.allow_date_change}
@@ -1198,14 +1197,12 @@
       class:timezone={_this.timezone}
       class:error={hasError}
       bind:this={dayContainer}
-      bind:clientWidth={dayContainerWidth}
-    >
+      bind:clientWidth={dayContainerWidth}>
       {#each days as day, dayIndex (day.timestamp.toISOString())}
         <div
           class="day"
           data-timestamp={day.timestamp.toISOString()}
-          bind:this={dayRef[dayIndex]}
-        >
+          bind:this={dayRef[dayIndex]}>
           <header>
             <h2>
               {#if _this.date_format === "date" || _this.date_format === "full"}
@@ -1232,14 +1229,12 @@
                   style="height: {epoch.height}%; top: {epoch.offset}%;"
                   data-available-calendars={epoch.available_calendars.toString()}
                   data-start-time={new Date(epoch.start_time).toLocaleString()}
-                  data-end-time={new Date(epoch.end_time).toLocaleString()}
-                >
+                  data-end-time={new Date(epoch.end_time).toLocaleString()}>
                   <div
                     class="inner"
                     style="background-color: {partialScale(
                       epoch.available_calendars.length,
-                    )}"
-                  />
+                    )}" />
                 </div>
               {/each}
             </div>
@@ -1274,12 +1269,10 @@
                   }}
                   on:mouseenter={() => {
                     handleSlotHover(slot);
-                  }}
-                >
+                  }}>
                   {#if slot.selectionStatus === SelectionStatus.SELECTED || (event_to_hover && getBlockTimes(slot, day))}
                     <span class="selected-heading"
-                      >{getBlockTimes(slot, day)}</span
-                    >
+                      >{getBlockTimes(slot, day)}</span>
                   {/if}
                 </button>
               {/each}
@@ -1298,8 +1291,7 @@
                   class:pending={slot.selectionPending}
                   data-start-time={new Date(slot.start_time).toLocaleString()}
                   data-end-time={new Date(slot.end_time).toLocaleString()}
-                  on:click={() => toggleSlot(slot)}
-                >
+                  on:click={() => toggleSlot(slot)}>
                   {getTimeString(new Date(slot.start_time))}
                   {#if slot.availability === AvailabilityStatus.PARTIAL}
                     <span class="partial">

--- a/components/booking/src/Booking.svelte
+++ b/components/booking/src/Booking.svelte
@@ -289,37 +289,31 @@
               -
               {timeSlot.end_time.toLocaleTimeString([], {
                 timeStyle: "short",
-              })}</span
-            >
+              })}</span>
             <span class="date"
               >{timeSlot.start_time.toLocaleDateString("default", {
                 dateStyle: "full",
-              })}</span
-            >
+              })}</span>
             {#if _this.recurrence !== "none"}
               <footer>
                 {#if _this.recurrence === "optional"}
                   <strong>How often should this event repeat?</strong>
                   <div class="cadences">
                     <label
-                      class:checked={timeSlot.recurrence_cadence === "none"}
-                    >
+                      class:checked={timeSlot.recurrence_cadence === "none"}>
                       <input
                         type="radio"
                         value="none"
-                        bind:group={timeSlot.recurrence_cadence}
-                      />
+                        bind:group={timeSlot.recurrence_cadence} />
                       <span>never</span>
                     </label>
                     {#each _this.recurrence_cadence as cadence}
                       <label
-                        class:checked={timeSlot.recurrence_cadence === cadence}
-                      >
+                        class:checked={timeSlot.recurrence_cadence === cadence}>
                         <input
                           type="radio"
                           value={cadence}
-                          bind:group={timeSlot.recurrence_cadence}
-                        />
+                          bind:group={timeSlot.recurrence_cadence} />
                         <span>{cadence}</span>
                       </label>
                     {/each}
@@ -334,24 +328,21 @@
                       <input
                         type="radio"
                         value="none"
-                        bind:group={timeSlot.expirySelection}
-                      />
+                        bind:group={timeSlot.expirySelection} />
                       <span>never</span>
                     </label>
                     <label class:checked={timeSlot.expirySelection === "after"}>
                       <input
                         type="radio"
                         value="after"
-                        bind:group={timeSlot.expirySelection}
-                      />
+                        bind:group={timeSlot.expirySelection} />
                       <span>After</span>
                       {#if timeSlot.expirySelection === "after"}
                         <input
                           class="after"
                           type="number"
                           min="1"
-                          bind:value={timeSlot.recurrence_expiry}
-                        />
+                          bind:value={timeSlot.recurrence_expiry} />
                         <span>occurrences</span>
                       {/if}
                     </label>
@@ -359,8 +350,7 @@
                       <input
                         type="radio"
                         value="on"
-                        bind:group={timeSlot.expirySelection}
-                      />
+                        bind:group={timeSlot.expirySelection} />
                       <span>On</span>
                       {#if timeSlot.expirySelection === "on"}
                         <input
@@ -368,8 +358,7 @@
                           min={timeSlot.start_time
                             .toISOString()
                             .substring(0, 10)}
-                          bind:value={timeSlot.recurrence_expiry}
-                        />
+                          bind:value={timeSlot.recurrence_expiry} />
                       {/if}
                     </label>
                   </div>
@@ -388,16 +377,14 @@
                 <!-- TODO: see if we can make type="text" dynamic for email case. Svelte doesnt care for it as is. -->
                 <input
                   type="email"
-                  bind:value={customFieldResponses[field.title]}
-                />
+                  bind:value={customFieldResponses[field.title]} />
               </label>
             {:else}
               <label data-required={field.required}>
                 <strong>{field.title}</strong>
                 <input
                   type="text"
-                  bind:value={customFieldResponses[field.title]}
-                />
+                  bind:value={customFieldResponses[field.title]} />
               </label>
             {/if}
           {/each}
@@ -410,8 +397,7 @@
           : undefined}
         class="book"
         on:click={() => bookTimeSlots(slotsToBook)}
-        >{_this.booking_label}</button
-      >
+        >{_this.booking_label}</button>
     {:else if _this.event_options.length}
       <h2>Select an option</h2>
       <ul class="timeslots timeslot-options">
@@ -420,8 +406,7 @@
             aria-role="button"
             on:mouseenter={() => hoverOption(option)}
             on:mouseleave={() => blurOption()}
-            on:click={() => selectOption(option)}
-          >
+            on:click={() => selectOption(option)}>
             <span class="time"
               >{option[0].start_time.toLocaleString([], {
                 dateStyle: "medium",
@@ -431,8 +416,7 @@
               {option[option.length - 1].end_time.toLocaleString([], {
                 dateStyle: "medium",
                 timeStyle: "short",
-              })}</span
-            >
+              })}</span>
             <div class="sub-events">
               {#each option as subevent, iter}
                 <span class="sub-event">

--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -806,8 +806,7 @@
     rel="stylesheet"
     href={themeUrl}
     on:load={() => (themeLoaded = true)}
-    on:error={() => (themeLoaded = true)}
-  />
+    on:error={() => (themeLoaded = true)} />
 {/if}
 {#if visible && isLoading}
   <div class="nylas-composer nylas-composer__loader">
@@ -820,8 +819,7 @@
   <div
     class="nylas-composer"
     data-cy="nylas-composer"
-    class:minimized={_this.minimized}
-  >
+    class:minimized={_this.minimized}>
     {#if _this.show_header}
       <header class={_this.minimized ? "minimized" : undefined}>
         <span>{subject}</span>
@@ -830,16 +828,14 @@
             {#if _this.minimized}
               <button
                 class="composer-btn"
-                on:click={() => handleMinimize(false)}
-              >
+                on:click={() => handleMinimize(false)}>
                 <span class="sr-only">Expand Composer</span>
                 <ExpandIcon class="ExpandIcon" />
               </button>
             {:else}
               <button
                 class="composer-btn"
-                on:click={() => handleMinimize(true)}
-              >
+                on:click={() => handleMinimize(true)}>
                 <span class="sr-only">Collapse Composer</span>
                 <MinimizeIcon class="MinimizeIcon" />
               </button>
@@ -885,8 +881,7 @@
               placeholder="To:"
               change={handleContactsChange("to")}
               contacts={to}
-              value={$message.to}
-            />
+              value={$message.to} />
           {/if}
           <div class="addons">
             <button
@@ -897,8 +892,7 @@
               on:click={() => {
                 _this.show_cc = true;
                 previousProps = _this;
-              }}>CC</button
-            >
+              }}>CC</button>
 
             <button
               data-cy="toggle-bcc-field-btn"
@@ -910,8 +904,7 @@
               on:click={() => {
                 _this.show_bcc = true;
                 previousProps = _this;
-              }}>BCC</button
-            >
+              }}>BCC</button>
           </div>
         </div>
         {#if _this.show_cc}
@@ -921,8 +914,7 @@
               placeholder="CC:"
               contacts={cc}
               value={$message.cc}
-              change={handleContactsChange("cc")}
-            />
+              change={handleContactsChange("cc")} />
             <button
               type="button"
               class="composer-btn cc-btn"
@@ -931,8 +923,7 @@
                 _this.show_cc = false;
                 previousProps = _this;
               }}
-              aria-label="remove carbon copy field"
-            >
+              aria-label="remove carbon copy field">
               <CloseIcon class="CloseIcon" />
             </button>
           </div>
@@ -944,8 +935,7 @@
               placeholder="BCC:"
               contacts={bcc}
               value={$message.bcc}
-              change={handleContactsChange("bcc")}
-            />
+              change={handleContactsChange("bcc")} />
             <button
               type="button"
               class="composer-btn cc-btn"
@@ -954,8 +944,7 @@
                 _this.show_bcc = false;
                 previousProps = _this;
               }}
-              aria-label="remove blind carbon copy field"
-            >
+              aria-label="remove blind carbon copy field">
               <CloseIcon class="CloseIcon" />
             </button>
           </div>
@@ -971,8 +960,7 @@
               class="subject"
               value={subject}
               name="subject"
-              on:input={handleInputChange}
-            />
+              on:input={handleInputChange} />
           </label>
         {/if}
 
@@ -984,8 +972,7 @@
           focus_body_onload={_this.focus_body_onload}
           replace_fields={_this.replace_fields}
           show_editor_toolbar={_this.show_editor_toolbar}
-          on:keydown={handleKeyDown}
-        />
+          on:keydown={handleKeyDown} />
         {#if $attachments.length}
           <div class="nylas-attachments">
             <div class="attachments-wrapper">
@@ -994,8 +981,7 @@
               {#each $attachments as fileAttachment}
                 <nylas-composer-attachment
                   attachment={fileAttachment}
-                  remove={handleRemoveFile}
-                />
+                  remove={handleRemoveFile} />
               {/each}
             </div>
           </div>
@@ -1012,8 +998,7 @@
             for="save-draft"
             class="composer-btn save-draft"
             title="Save Email As Draft"
-            on:click={handleSaveDraft}
-          >
+            on:click={handleSaveDraft}>
             <DraftIcon class="FooterIcon" />
             <span class="sr-only">Save Draft</span>
           </button>
@@ -1023,8 +1008,7 @@
             for="file-upload"
             class="composer-btn file-upload"
             title="Attach Files (up to {maxFileSize}MB)"
-            tabindex="0"
-          >
+            tabindex="0">
             <AttachmentIcon class="FooterIcon" />
             <span class="sr-only">Attach Files</span>
           </label>
@@ -1040,8 +1024,7 @@
             hidden
             type="file"
             id="file-upload"
-            on:change={handleFilesChange}
-          />
+            on:change={handleFilesChange} />
         </form>
       </footer>
       <!-- Date Picker Component -->
@@ -1053,8 +1036,7 @@
         <nylas-composer-alert-bar
           type="info"
           dismissible={true}
-          ondismiss={removeSchedule}
-        >
+          ondismiss={removeSchedule}>
           Send scheduled for
           <span>{formatDate(new Date(datepickerTimestamp))}</span>
         </nylas-composer-alert-bar>

--- a/components/contact-list/src/ContactList.svelte
+++ b/components/contact-list/src/ContactList.svelte
@@ -492,8 +492,7 @@
   on:scroll={_this.contacts ? () => {} : debounceScroll}
   bind:clientHeight
   bind:clientWidth
-  class={!!themeUrl ? "custom" : _this.theme}
->
+  class={!!themeUrl ? "custom" : _this.theme}>
   {#if status === "loading" && hydratedContacts.length <= 0}
     <div class="loader" />
   {:else if hydratedContacts.length === 0}
@@ -506,8 +505,7 @@
       <p>
         See our <a
           href="https://docs.nylas.com/docs/contact-list-component"
-          target="_blank">Docs</a
-        >
+          target="_blank">Docs</a>
         for more details.
       </p>
     </div>
@@ -516,8 +514,7 @@
     {#if status === "loading" && results.length >= _this.contacts_to_load}
       <span
         class="loading"
-        style="--height: {clientHeight}px; --width: {clientWidth}px"
-      >
+        style="--height: {clientHeight}px; --width: {clientWidth}px">
         Loading More Contacts
       </span>
     {/if}
@@ -527,8 +524,7 @@
         Filter by email: <input
           id="show-filter-input"
           type="text"
-          bind:value={filterValue}
-        />
+          bind:value={filterValue} />
       </label>
     {/if}
 
@@ -546,20 +542,17 @@
           data-cy={i}
           data-last-contacted-date={contact.last_contacted_date || -1}
           class:selectable={_this.click_action === "select"}
-          class:selected={contact.selected}
-        >
+          class:selected={contact.selected}>
           <span class="checkbox">
             {#if _this.click_action === "select"}
               <input
                 type="checkbox"
                 bind:checked={contact.selected}
-                id="contact-{i}-checkbox"
-              />
+                id="contact-{i}-checkbox" />
               <label for="contact-{i}-checkbox"
                 >{contact.selected ? "Deselect" : "Select"}
                 {contact.given_name}
-                {contact.surname}</label
-              >
+                {contact.surname}</label>
             {/if}
           </span>
           <span class="image">
@@ -567,8 +560,7 @@
               {#if contact.picture !== "Loading"}
                 <img
                   alt={contact.emails[0].email}
-                  src="data:image/jpg;base64,{contact.picture}"
-                />
+                  src="data:image/jpg;base64,{contact.picture}" />
               {/if}
             {:else if contact.picture_url}
               {#if _this.contacts?.length}
@@ -582,8 +574,7 @@
               <img
                 src={contact.default_picture}
                 alt={contact.emails[0].email}
-                data-cy="default_set_by_user"
-              />
+                data-cy="default_set_by_user" />
             {:else if _this.default_photo}
               {(contact.default_picture = _this.default_photo)}
             {:else}
@@ -617,8 +608,7 @@
             <span
               class="recency"
               class:no-last-contact-data={!contact.last_contacted_date}
-              >{contact.time_ago}</span
-            >
+              >{contact.time_ago}</span>
           {/if}
         </li>
       {/each}

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -1637,8 +1637,7 @@
   bind:this={main}
   on:click={handleThreadClick}
   tabindex="0"
-  on:keypress={handleThreadKeypress}
->
+  on:keypress={handleThreadKeypress}>
   {#if _this.thread || _this.thread_id}
     {#await activeThread}
       Loading...
@@ -1649,19 +1648,16 @@
           <div
             class="email-row expanded {_this.click_action === 'mailbox'
               ? 'expanded-mailbox-thread'
-              : ''}"
-          >
+              : ''}">
             <header
               class="subject-title"
-              class:mailbox={_this.click_action === "mailbox"}
-            >
+              class:mailbox={_this.click_action === "mailbox"}>
               <div>
                 {#if _this.click_action === "mailbox"}
                   <button
                     title={"Return to Mailbox"}
                     aria-label={"Return to Mailbox"}
-                    on:click|stopPropagation={returnToMailbox}
-                  >
+                    on:click|stopPropagation={returnToMailbox}>
                     <LeftArrowLineIcon />
                   </button>
                 {/if}
@@ -1678,8 +1674,7 @@
                         : "Star thread"}
                       role="switch"
                       aria-checked={thread.starred}
-                      on:click|stopPropagation={handleThreadStarClick}
-                    />
+                      on:click|stopPropagation={handleThreadStarClick} />
                   </div>
                 {/if}
                 {#if _this.show_thread_actions}
@@ -1687,8 +1682,7 @@
                     <button
                       title="Delete thread / Move to trash"
                       aria-label="Delete thread (Move to trash)"
-                      on:click|stopPropagation={(e) => deleteEmail(e)}
-                    >
+                      on:click|stopPropagation={(e) => deleteEmail(e)}>
                       <TrashIcon />
                     </button>
                   </div>
@@ -1700,8 +1694,7 @@
                       aria-label={`Mark thread as ${
                         activeThread.unread ? "" : "un"
                       }read`}
-                      on:click|stopPropagation={toggleUnreadStatus}
-                    >
+                      on:click|stopPropagation={toggleUnreadStatus}>
                       {#if activeThread.unread}
                         <MarkReadIcon aria-hidden="true" />
                       {:else}
@@ -1726,8 +1719,7 @@
                   bind:this={messageRefs[msgIndex]}
                   on:click|stopPropagation={(e) =>
                     handleEmailClick(e, msgIndex)}
-                  on:keypress={(e) => handleEmailKeypress(e, msgIndex)}
-                >
+                  on:keypress={(e) => handleEmailKeypress(e, msgIndex)}>
                   {#if message.expanded || msgIndex === activeThread.messages.length - 1}
                     <div class="message-head">
                       <div class="message-from-to">
@@ -1736,8 +1728,7 @@
                             <div class="default-avatar">
                               <nylas-contact-image
                                 {contact_query}
-                                contact={contacts[message?.from[0].email]}
-                              />
+                                contact={contacts[message?.from[0].email]} />
                             </div>
                           {/if}
                           <div class="message-from">
@@ -1753,8 +1744,7 @@
                               id={message?.id.slice(0, 3)}
                               current_tooltip_id={currentTooltipId}
                               icon={DropdownSymbol}
-                              content={message?.from[0].email}
-                            />
+                              content={message?.from[0].email} />
                           </div>
                         </div>
                         <div class="message-to">
@@ -1796,8 +1786,7 @@
                                     } more`}
                                     content={`${aggregateRecipientsString(
                                       allRecipients,
-                                    )}`}
-                                  />
+                                    )}`} />
                                 </div>
                               {/if}
                             {/await}
@@ -1821,8 +1810,7 @@
                                 title={"Reply"}
                                 aria-label={"Reply"}
                                 on:click|stopPropagation={(e) =>
-                                  handleReplyClick(e, message, "reply")}
-                              >
+                                  handleReplyClick(e, message, "reply")}>
                                 <ReplyIcon aria-hidden="true" />
                               </button>
                             </div>
@@ -1833,8 +1821,7 @@
                                 title={"Reply all"}
                                 aria-label={"Reply all"}
                                 on:click|stopPropagation={(e) =>
-                                  handleReplyClick(e, message, "reply_all")}
-                              >
+                                  handleReplyClick(e, message, "reply_all")}>
                                 <ReplyAllIcon aria-hidden="true" />
                               </button>
                             </div>
@@ -1845,8 +1832,7 @@
                                 title="Forward"
                                 aria-label="Forward"
                                 on:click|stopPropagation={(e) =>
-                                  handleForwardClick(e, message)}
-                              >
+                                  handleForwardClick(e, message)}>
                                 <ForwardIcon aria-hidden="true" />
                               </button>
                             </div>
@@ -1861,8 +1847,7 @@
                         <nylas-message-body
                           {message}
                           body={message.body}
-                          on:downloadClicked={handleDownloadFromMessage}
-                        />
+                          on:downloadClicked={handleDownloadFromMessage} />
                         <!-- If a thread is being passed manually and there is no body, 
                           we will keep loading, so the below is our fallback -->
                       {:else if !!_this.thread && !_this.thread_id && click_action != "mailbox"}
@@ -1875,8 +1860,7 @@
                                   dispatchEvent("fileClicked", {
                                     event: e,
                                     file: file,
-                                  })}
-                              >
+                                  })}>
                                 {file.filename || file.id}
                               </button>
                             {/each}
@@ -1896,8 +1880,7 @@
                           <div class="default-avatar">
                             <nylas-contact-image
                               {contact_query}
-                              contact={contacts[message?.from[0].email]}
-                            />
+                              contact={contacts[message?.from[0].email]} />
                           </div>
                         {/if}
                         <div class="message-from">
@@ -1905,16 +1888,14 @@
                             >{userEmail && message?.from[0].email === userEmail
                               ? "me"
                               : message?.from[0].name ||
-                                message?.from[0].email}</span
-                          >
+                                message?.from[0].email}</span>
                           <!-- tooltip component -->
                           <nylas-tooltip
                             on:toggleTooltip={setTooltip}
                             id={message?.id.slice(0, 3)}
                             current_tooltip_id={currentTooltipId}
                             icon={DropdownSymbol}
-                            content={message?.from[0].email}
-                          />
+                            content={message?.from[0].email} />
                         </div>
                       </div>
                       <section>
@@ -1947,8 +1928,7 @@
                   class:active-draft={draft.active}
                   bind:this={messageRefs[draftIndex]}
                   on:click|stopPropagation={(e) => handleDraftClick(e, draft)}
-                  on:keypress={(e) => handleDraftKeypress(e, draft)}
-                >
+                  on:keypress={(e) => handleDraftKeypress(e, draft)}>
                   <div class="message-head draft">
                     <div class="avatar-info">
                       {#if _this.show_contact_avatar}
@@ -1995,8 +1975,7 @@
                                   } more`}
                                   content={`${aggregateRecipientsString(
                                     allRecipients,
-                                  )}`}
-                                />
+                                  )}`} />
                               </div>
                             {/if}
                           {/await}
@@ -2031,8 +2010,7 @@
             class:unread={activeThread.unread}
             class:disable-click={activeThread &&
               activeThread.messages.length <= 0 &&
-              !activeThread.drafts.length}
-          >
+              !activeThread.drafts.length}>
             {#await isThreadADraftEmail(activeThread) then isDraft}
               <div class="from{_this.show_star ? '-star' : ''}">
                 {#if _this.show_star}
@@ -2044,8 +2022,7 @@
                       role="switch"
                       aria-checked={activeThread.starred}
                       on:click|preventDefault={handleThreadStarClick}
-                      aria-label={`Star button for thread ${_this.thread_id}`}
-                    />
+                      aria-label={`Star button for thread ${_this.thread_id}`} />
                   </div>
                 {/if}
                 <div class="from-message-count">
@@ -2059,8 +2036,7 @@
                         {:else}
                           <nylas-contact-image
                             {contact_query}
-                            contact={activeThreadContact}
-                          />
+                            contact={activeThreadContact} />
                         {/if}
                       {/if}
                     </div>
@@ -2078,14 +2054,12 @@
                         class:condensed={showSecondFromParticipant(
                           activeThread.messages,
                           activeThread.participants,
-                        )}
-                      >
+                        )}>
                         {#await getParticipants(activeThread) then participants}
                           {#each participants as name, idx}
                             <span
                               class="from-sub-section participant-label"
-                              class:draft-label={name === "Draft"}
-                            >
+                              class:draft-label={name === "Draft"}>
                               {name}
                             </span>
                             {#if idx < participants.length - 1}
@@ -2149,8 +2123,7 @@
                       {#each files as file}
                         <button
                           on:click={(event) =>
-                            downloadSelectedFile(event, file)}
-                        >
+                            downloadSelectedFile(event, file)}>
                           {file.filename || file.id}
                         </button>
                       {/each}
@@ -2160,8 +2133,7 @@
               </div>
               <div
                 class:date={_this.show_received_timestamp}
-                class:action-icons={_this.show_thread_actions}
-              >
+                class:action-icons={_this.show_thread_actions}>
                 {#if activeThread.has_attachments && Object.keys(attachedFiles).length > 0}
                   <span><AttachmentIcon /></span>
                 {/if}
@@ -2170,8 +2142,7 @@
                     <button
                       title="Delete thread"
                       aria-label="Delete thread"
-                      on:click|stopPropagation={deleteEmail}
-                    >
+                      on:click|stopPropagation={deleteEmail}>
                       <TrashIcon />
                     </button>
                   </div>
@@ -2183,8 +2154,7 @@
                       aria-label={`Mark thread as ${
                         activeThread.unread ? "" : "un"
                       }read`}
-                      on:click|stopPropagation={toggleUnreadStatus}
-                    >
+                      on:click|stopPropagation={toggleUnreadStatus}>
                       {#if activeThread.unread}
                         <MarkReadIcon aria-hidden="true" />
                       {:else}
@@ -2217,8 +2187,7 @@
                   <div class="default-avatar">
                     <nylas-contact-image
                       {contact_query}
-                      contact={activeMessageContact}
-                    />
+                      contact={activeMessageContact} />
                   </div>
                 {/if}
                 <div class="message-from">
@@ -2226,16 +2195,14 @@
                     >{userEmail && _this.message?.from[0].email === userEmail
                       ? "me"
                       : _this.message?.from[0]?.name ||
-                        _this.message?.from[0]?.email}</span
-                  >
+                        _this.message?.from[0]?.email}</span>
                   <!-- tooltip component -->
                   <nylas-tooltip
                     on:toggleTooltip={setTooltip}
                     id={_this.message?.id}
                     current_tooltip_id={currentTooltipId}
                     icon={DropdownSymbol}
-                    content={_this.message?.from[0].email}
-                  />
+                    content={_this.message?.from[0].email} />
                 </div>
               </div>
 
@@ -2273,8 +2240,9 @@
                         text={`And ${
                           allRecipients.length - PARTICIPANTS_TO_TRUNCATE
                         } more`}
-                        content={`${aggregateRecipientsString(allRecipients)}`}
-                      />
+                        content={`${aggregateRecipientsString(
+                          allRecipients,
+                        )}`} />
                     </div>
                   {/if}
                 {/await}
@@ -2295,8 +2263,7 @@
                       title={"Reply"}
                       aria-label={"Reply"}
                       on:click|stopPropagation={(e) =>
-                        handleReplyClick(e, _this.message, "reply")}
-                    >
+                        handleReplyClick(e, _this.message, "reply")}>
                       <ReplyIcon aria-hidden="true" />
                     </button>
                   </div>
@@ -2307,8 +2274,7 @@
                       title={"Reply all"}
                       aria-label={"Reply all"}
                       on:click|stopPropagation={(e) =>
-                        handleReplyClick(e, _this.message, "reply_all")}
-                    >
+                        handleReplyClick(e, _this.message, "reply_all")}>
                       <ReplyAllIcon aria-hidden="true" />
                     </button>
                   </div>
@@ -2323,8 +2289,7 @@
               <nylas-message-body
                 message={_this.message}
                 body={_this.message.body}
-                on:downloadClicked={handleDownloadFromMessage}
-              />
+                on:downloadClicked={handleDownloadFromMessage} />
             {/if}
           </div>
         </div>

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -912,8 +912,7 @@
 <main
   data-cy="nylas-mailbox"
   class:loading={!hasComponentLoaded}
-  class:empty={!threads?.length && hasComponentLoaded}
->
+  class:empty={!threads?.length && hasComponentLoaded}>
   {#if hasComponentLoaded}
     {#if currentlySelectedThread}
       <div class="email-container">
@@ -932,8 +931,7 @@
           on:returnToMailbox={returnToMailbox}
           on:toggleThreadUnreadStatus={toggleThreadUnreadStatus}
           on:threadDeleted={showConfirmDeleteModal}
-          on:downloadClicked={downloadSelectedFile}
-        />
+          on:downloadClicked={downloadSelectedFile} />
       </div>
     {:else}
       {#if _this.header}
@@ -943,11 +941,9 @@
               width="16"
               height="16"
               viewBox="0 0 16 16"
-              class:refreshing={loading}
-            >
+              class:refreshing={loading}>
               <path
-                d="M9.41757 0.780979L9.57471 0.00782773C12.9388 0.717887 15.4617 3.80648 15.4617 7.49954C15.4617 8.7935 15.1519 10.0136 14.6046 11.083L16 12.458L11.6994 13.7113L12.7846 9.28951L14.0208 10.5077C14.4473 9.60009 14.6869 8.5795 14.6869 7.49954C14.6869 4.17742 12.4188 1.41444 9.41757 0.780979ZM0 2.90469L4.24241 1.46013L3.3489 5.92625L2.06118 4.7644C1.71079 5.60175 1.51627 6.5265 1.51627 7.49954C1.51627 10.8217 3.7844 13.5847 6.78563 14.2182L6.62849 14.9913C3.26437 14.2812 0.741524 11.1926 0.741524 7.49954C0.741524 6.32506 0.996751 5.21133 1.45323 4.21587L0 2.90469Z"
-              />
+                d="M9.41757 0.780979L9.57471 0.00782773C12.9388 0.717887 15.4617 3.80648 15.4617 7.49954C15.4617 8.7935 15.1519 10.0136 14.6046 11.083L16 12.458L11.6994 13.7113L12.7846 9.28951L14.0208 10.5077C14.4473 9.60009 14.6869 8.5795 14.6869 7.49954C14.6869 4.17742 12.4188 1.41444 9.41757 0.780979ZM0 2.90469L4.24241 1.46013L3.3489 5.92625L2.06118 4.7644C1.71079 5.60175 1.51627 6.5265 1.51627 7.49954C1.51627 10.8217 3.7844 13.5847 6.78563 14.2182L6.62849 14.9913C3.26437 14.2812 0.741524 11.1926 0.741524 7.49954C0.741524 6.32506 0.996751 5.21133 1.45323 4.21587L0 2.90469Z" />
             </svg>
           </button>
           <h1>{header}</h1>
@@ -957,8 +953,7 @@
         <div
           role="toolbar"
           aria-label="Bulk actions"
-          aria-controls="mailboxlist"
-        >
+          aria-controls="mailboxlist">
           {#if _this.show_thread_checkbox && _this.actions_bar.includes(MailboxActions.SELECTALL)}
             <div class="thread-checkbox">
               {#each [areAllSelected ? "Deselect all" : "Select all"] as selectAllTitle}
@@ -967,8 +962,7 @@
                   aria-label={selectAllTitle}
                   type="checkbox"
                   checked={areAllSelected}
-                  on:click={onSelectAll}
-                />
+                  on:click={onSelectAll} />
               {/each}
             </div>
           {/if}
@@ -981,8 +975,7 @@
                   aria-label="Delete selected email(s)"
                   on:click={(e) => {
                     showConfirmDeleteModal(e, "selected");
-                  }}><TrashIcon /></button
-                >
+                  }}><TrashIcon /></button>
               </div>
             {/if}
             {#if _this.show_star && _this.actions_bar.includes(MailboxActions.STAR)}
@@ -996,8 +989,7 @@
                     disabled={!threads.filter((thread) => thread.selected)
                       .length}
                     aria-checked={areAllSelectedStarred}
-                    on:click={(e) => onStarSelected(e)}
-                  />
+                    on:click={(e) => onStarSelected(e)} />
                 {/each}
               </div>
             {/if}
@@ -1010,8 +1002,7 @@
                     disabled={!threads.filter((thread) => thread.selected)
                       .length}
                     aria-label="Mark selected email(s) as read"
-                    on:click={(e) => onChangeSelectedReadStatus(e)}
-                  >
+                    on:click={(e) => onChangeSelectedReadStatus(e)}>
                     <MarkReadIcon />
                   </button>
                 {:else}
@@ -1019,8 +1010,7 @@
                     data-cy="mark-unread"
                     title="Mark selected email(s) as unread"
                     aria-label="Mark selected email(s) as unread"
-                    on:click={(e) => onChangeSelectedReadStatus(e)}
-                  >
+                    on:click={(e) => onChangeSelectedReadStatus(e)}>
                     <MarkUnreadIcon />
                   </button>
                 {/if}
@@ -1038,8 +1028,7 @@
               class:no-messages={thread &&
                 thread?.messages &&
                 thread?.messages?.length <= 0 &&
-                !thread?.drafts?.length}
-            >
+                !thread?.drafts?.length}>
               <div class="checkbox-container thread-checkbox">
                 {#if _this.show_thread_checkbox}
                   <input
@@ -1051,8 +1040,7 @@
                       thread?.messages &&
                       thread?.messages?.length <= 0 &&
                       !thread?.drafts?.length}
-                    on:click={(e) => onSelectOne(e, thread)}
-                  />
+                    on:click={(e) => onSelectOne(e, thread)} />
                 {/if}
               </div>
               <div class="email-container">
@@ -1074,8 +1062,7 @@
                     on:toggleThreadUnreadStatus={toggleThreadUnreadStatus}
                     on:threadDeleted={showConfirmDeleteModal}
                     on:downloadClicked={downloadSelectedFile}
-                    show_thread_actions={thread.selected}
-                  />
+                    show_thread_actions={thread.selected} />
                 {/key}
               </div>
             </li>
@@ -1099,8 +1086,7 @@
             num_items={numThreads}
             visible={true}
             num_pages_visible={!_this.keyword_to_search}
-            on:changePage={changePage}
-          />
+            on:changePage={changePage} />
         {/if}
       </ul>
     {/if}
@@ -1108,8 +1094,7 @@
     <div class="mailbox-loader">
       <LoadingIcon
         class="spinner"
-        style="height:18px; animation: rotate 2s linear infinite; margin:10px;"
-      />
+        style="height:18px; animation: rotate 2s linear infinite; margin:10px;" />
       <p>Loading...</p>
     </div>
   {/if}
@@ -1137,8 +1122,7 @@
         </button>
         <button
           class="cancel"
-          on:click={() => (confirmDeleteModal.isOpen = false)}
-        >
+          on:click={() => (confirmDeleteModal.isOpen = false)}>
           Cancel
         </button>
       </div>

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -517,13 +517,11 @@
     on:mousemove={adjustColumns}
     on:mouseup={() => (adjustingPreviewPane = false)}
     bind:clientWidth={mainElementWidth}
-    bind:this={main}
-  >
+    bind:this={main}>
     <div class="settings">
       <nylas-schedule-editor-section
         section_title={SectionNames.BASIC_DETAILS}
-        expanded={true}
-      >
+        expanded={true}>
         <h1 slot="title">Event Details</h1>
         <p slot="intro" class="intro">
           Edit the details for your meeting. You can add consecutive meetings to
@@ -535,8 +533,7 @@
               {#if _this.events.length > 1}
                 <button
                   class="remove-event"
-                  on:click={() => removeConsecutiveEvent(event)}
-                >
+                  on:click={() => removeConsecutiveEvent(event)}>
                   Remove this event
                 </button>
               {/if}
@@ -588,8 +585,7 @@
                   <textarea
                     name="participants"
                     on:input={(e) => debounceEmailInput(e, event)}
-                    value={event.participantEmails}
-                  />
+                    value={event.participantEmails} />
                 </label>
               </div>
             </fieldset>
@@ -597,15 +593,13 @@
         </div>
         <footer slot="footer">
           <button class="add-event" on:click={addConsecutiveEvent}
-            >Add a follow-up event</button
-          >
+            >Add a follow-up event</button>
           <button on:click={saveProperties}>Save Editor Options</button>
         </footer>
       </nylas-schedule-editor-section>
 
       <nylas-schedule-editor-section
-        section_title={SectionNames.TIME_DATE_DETAILS}
-      >
+        section_title={SectionNames.TIME_DATE_DETAILS}>
         <h1 slot="title">Date/Time Details</h1>
         <div slot="contents" class="contents">
           <div>
@@ -616,8 +610,7 @@
                 min={0}
                 max={24}
                 step={1}
-                bind:value={_this.start_hour}
-              />
+                bind:value={_this.start_hour} />
             </label>
             {_this.start_hour}:00
           </div>
@@ -629,8 +622,7 @@
                 min={0}
                 max={24}
                 step={1}
-                bind:value={_this.end_hour}
-              />
+                bind:value={_this.end_hour} />
             </label>
             {_this.end_hour}:00
           </div>
@@ -647,16 +639,14 @@
                     await tick();
                     startDate = null;
                   }
-                }}
-              />
+                }} />
               Show a specific date
             </strong>
 
             <input
               type="date"
               bind:value={startDate}
-              disabled={!customStartDate}
-            />
+              disabled={!customStartDate} />
           </label>
           <label>
             <strong>Time Zone</strong>
@@ -674,8 +664,7 @@
                 min={1}
                 max={7}
                 step={1}
-                bind:value={_this.dates_to_show}
-              />
+                bind:value={_this.dates_to_show} />
             </label>
             {_this.dates_to_show}
           </div>
@@ -685,8 +674,7 @@
               <input
                 type="checkbox"
                 name="show_as_week"
-                bind:checked={_this.show_as_week}
-              />
+                bind:checked={_this.show_as_week} />
               Show whole week
             </label>
           </div>
@@ -696,8 +684,7 @@
               <input
                 type="checkbox"
                 name="show_weekends"
-                bind:checked={_this.show_weekends}
-              />
+                bind:checked={_this.show_weekends} />
               Keep weekends on
             </label>
           </div>
@@ -712,8 +699,7 @@
                 <input
                   type="checkbox"
                   name="_this.show_as_week"
-                  bind:checked={_this.show_as_week}
-                />
+                  bind:checked={_this.show_as_week} />
                 Customize each weekday
               </label>
             </div>
@@ -722,8 +708,7 @@
                 <input
                   type="checkbox"
                   name=" _this.show_weekends"
-                  bind:checked={_this.show_weekends}
-                />
+                  bind:checked={_this.show_weekends} />
                 Allow booking on weekends
               </label>
             </div>
@@ -744,8 +729,7 @@
                 closed_color="#999"
                 selected_color="#095"
                 slot_size="15"
-                on:timeSlotChosen={availabilityChosen}
-              />
+                on:timeSlotChosen={availabilityChosen} />
             </div>
             <ul class="availability">
               {#each _this.open_hours || [] as availability}
@@ -772,8 +756,7 @@
               <input
                 type="checkbox"
                 name="show_ticks"
-                bind:checked={_this.show_ticks}
-              />
+                bind:checked={_this.show_ticks} />
               Show tick marks on left side
             </label>
           </div>
@@ -784,8 +767,7 @@
                 type="radio"
                 name="view_as"
                 bind:group={_this.view_as}
-                value="schedule"
-              />
+                value="schedule" />
               <span>Schedule</span>
             </label>
             <label>
@@ -793,8 +775,7 @@
                 type="radio"
                 name="view_as"
                 bind:group={_this.view_as}
-                value="list"
-              />
+                value="list" />
               <span>List</span>
             </label>
           </div>
@@ -804,8 +785,7 @@
               type="number"
               min={1}
               max={20}
-              bind:value={_this.attendees_to_show}
-            />
+              bind:value={_this.attendees_to_show} />
           </label>
         </div>
         <footer slot="footer">
@@ -814,8 +794,7 @@
       </nylas-schedule-editor-section>
 
       <nylas-schedule-editor-section
-        section_title={SectionNames.BOOKING_DETAILS}
-      >
+        section_title={SectionNames.BOOKING_DETAILS}>
         <h1 slot="title">Booking Details</h1>
         <div slot="contents" class="contents">
           <div role="checkbox" aria-labelledby="allow_booking">
@@ -824,8 +803,7 @@
               <input
                 type="checkbox"
                 name="allow_booking"
-                bind:checked={_this.allow_booking}
-              />
+                bind:checked={_this.allow_booking} />
               Allow bookings to be made
             </label>
           </div>
@@ -835,8 +813,7 @@
               type="number"
               min={1}
               max={20}
-              bind:value={_this.max_bookable_slots}
-            />
+              bind:value={_this.max_bookable_slots} />
           </label>
           <div role="checkbox" aria-labelledby="screen_bookings">
             <strong id="screen_bookings">
@@ -846,8 +823,7 @@
               <input
                 type="checkbox"
                 name="screen_bookings"
-                bind:checked={_this.screen_bookings}
-              />
+                bind:checked={_this.screen_bookings} />
               Let the meeting host screen bookings before they're made official
             </label>
           </div>
@@ -858,8 +834,7 @@
               min={0}
               max={1}
               step={0.01}
-              bind:value={_this.partial_bookable_ratio}
-            />
+              bind:value={_this.partial_bookable_ratio} />
             {Math.floor(_this.partial_bookable_ratio * 100)}%
           </label>
           <div role="radiogroup" aria-labelledby="recurrence">
@@ -871,8 +846,7 @@
                 type="radio"
                 name="recurrence"
                 bind:group={_this.recurrence}
-                value="none"
-              />
+                value="none" />
               <span>Don't Repeat Events</span>
             </label>
             <label>
@@ -880,8 +854,7 @@
                 type="radio"
                 name="recurrence"
                 bind:group={_this.recurrence}
-                value="optional"
-              />
+                value="optional" />
               <span>Users May Repeat Events</span>
             </label>
             <label>
@@ -889,8 +862,7 @@
                 type="radio"
                 name="recurrence"
                 bind:group={_this.recurrence}
-                value="required"
-              />
+                value="required" />
               <span>Events Always Repeat</span>
             </label>
           </div>
@@ -904,8 +876,7 @@
               <input
                 type="checkbox"
                 name="mandate_top_of_hour"
-                bind:checked={_this.mandate_top_of_hour}
-              />
+                bind:checked={_this.mandate_top_of_hour} />
               Only allow events to be booked at the Top of the Hour
             </label>
           </div>
@@ -920,8 +891,7 @@
                   type="checkbox"
                   name="recurrence_cadence"
                   bind:group={_this.recurrence_cadence}
-                  value="daily"
-                />
+                  value="daily" />
                 <span>Daily</span>
               </label>
               <label>
@@ -929,8 +899,7 @@
                   type="checkbox"
                   name="recurrence_cadence"
                   bind:group={_this.recurrence_cadence}
-                  value="weekdays"
-                />
+                  value="weekdays" />
                 <span>Daily, only on weekdays</span>
               </label>
               <label>
@@ -938,8 +907,7 @@
                   type="checkbox"
                   name="recurrence_cadence"
                   bind:group={_this.recurrence_cadence}
-                  value="weekly"
-                />
+                  value="weekly" />
                 <span>Weekly</span>
               </label>
               <label>
@@ -947,8 +915,7 @@
                   type="checkbox"
                   name="recurrence_cadence"
                   bind:group={_this.recurrence_cadence}
-                  value="biweekly"
-                />
+                  value="biweekly" />
                 <span>Biweekly</span>
               </label>
               <label>
@@ -956,8 +923,7 @@
                   type="checkbox"
                   name="recurrence_cadence"
                   bind:group={_this.recurrence_cadence}
-                  value="monthly"
-                />
+                  value="monthly" />
                 <span>Monthly</span>
               </label>
             </div>
@@ -994,23 +960,20 @@
                         swapDraggedWithHovered(i);
                       }
                     }}
-                    use:storeRef={{ id: field.id }}
-                  >
+                    use:storeRef={{ id: field.id }}>
                     <td class="cta">
                       <button
                         class="drag"
                         on:mousedown={(event) => {
                           handleCustomFieldDrag(event, field, i);
-                        }}
-                      >
+                        }}>
                         <span class="sr-only">Reorder custom field</span>
                         <DragIcon />
                       </button>
                     </td>
                     <td
                       class:multi-line={field.description}
-                      class={"title-and-description"}
-                    >
+                      class={"title-and-description"}>
                       <span>{field.title ?? "—"}</span>
                       {#if field.description}
                         <span class="description">{field.description}</span>
@@ -1026,8 +989,7 @@
                       <button
                         class="edit"
                         aria-label="Edit"
-                        on:click={() => editCustomField(field)}
-                      >
+                        on:click={() => editCustomField(field)}>
                         <PencilIcon />
                         <span>Edit</span>
                       </button>
@@ -1041,8 +1003,7 @@
                           <button
                             class="delete"
                             aria-label="Delete"
-                            on:click={() => removeCustomField(field)}
-                          >
+                            on:click={() => removeCustomField(field)}>
                             <TrashIcon />
                             <span>Delete</span>
                           </button>
@@ -1053,8 +1014,7 @@
                             <input
                               type="text"
                               aria-label="Title"
-                              bind:value={editableCustomField.title}
-                            />
+                              bind:value={editableCustomField.title} />
                           </label>
                         </div>
                         <div class="input-field">
@@ -1063,8 +1023,7 @@
                             <input
                               type="text"
                               aria-label="Description"
-                              bind:value={editableCustomField.description}
-                            />
+                              bind:value={editableCustomField.description} />
                           </label>
                         </div>
                         <div class="input-field">
@@ -1072,8 +1031,7 @@
                             <div>Type *</div>
                             <select
                               bind:value={editableCustomField.type}
-                              aria-label="Input Type"
-                            >
+                              aria-label="Input Type">
                               <option value="text">Text</option>
                               <option value="checkbox">Checkbox</option>
                             </select>
@@ -1084,8 +1042,7 @@
                             <input
                               type="checkbox"
                               aria-label="Required field?"
-                              bind:checked={editableCustomField.required}
-                            />
+                              bind:checked={editableCustomField.required} />
                             <span>Required</span>
                           </label>
                         </div>
@@ -1095,8 +1052,7 @@
                             on:click={() => {
                               currentlyEditedField = null;
                               editableCustomField = { ...emptyCustomField };
-                            }}
-                          >
+                            }}>
                             <span>Cancel</span>
                           </button>
 
@@ -1108,8 +1064,7 @@
                               currentlyEditedField = null;
                               field = { ...editableCustomField };
                               editableCustomField = { ...emptyCustomField };
-                            }}
-                          >
+                            }}>
                             <span>Save changes</span>
                           </button>
                         </div>
@@ -1123,8 +1078,7 @@
               {#if !isAddingCustomField}
                 <button
                   aria-label="Add a custom field"
-                  on:click={() => (isAddingCustomField = true)}
-                >
+                  on:click={() => (isAddingCustomField = true)}>
                   <PlusIcon />
                   <span>Add a custom field</span>
                 </button>
@@ -1139,8 +1093,7 @@
                       <input
                         type="text"
                         aria-label="Title"
-                        bind:value={newCustomField.title}
-                      />
+                        bind:value={newCustomField.title} />
                     </label>
                   </div>
                   <div class="input-field">
@@ -1149,8 +1102,7 @@
                       <input
                         type="text"
                         aria-label="Description"
-                        bind:value={newCustomField.description}
-                      />
+                        bind:value={newCustomField.description} />
                     </label>
                   </div>
                   <div class="input-field">
@@ -1158,8 +1110,7 @@
                       <div>Type</div>
                       <select
                         bind:value={newCustomField.type}
-                        aria-label="Input Type"
-                      >
+                        aria-label="Input Type">
                         <option value="text">Text</option>
                         <option value="checkbox">Checkbox</option>
                       </select>
@@ -1170,8 +1121,7 @@
                       <input
                         type="checkbox"
                         aria-label="Required Field?"
-                        bind:checked={newCustomField.required}
-                      />
+                        bind:checked={newCustomField.required} />
                       <span>Required</span>
                     </label>
                   </div>
@@ -1181,16 +1131,14 @@
                       on:click={() => {
                         newCustomField = { ...emptyCustomField };
                         isAddingCustomField = false;
-                      }}
-                    >
+                      }}>
                       <span>Cancel</span>
                     </button>
                     <button
                       class="save"
                       disabled={newCustomField.title?.length === 0 ||
                         !newCustomField.type}
-                      on:click={() => addNewField()}
-                    >
+                      on:click={() => addNewField()}>
                       <span>Add field</span>
                     </button>
                   </div>
@@ -1205,21 +1153,18 @@
       </nylas-schedule-editor-section>
 
       <nylas-schedule-editor-section
-        section_title={SectionNames.NOTIFICATION_DETAILS}
-      >
+        section_title={SectionNames.NOTIFICATION_DETAILS}>
         <h1 slot="title">Notification Details</h1>
         <div slot="contents" class="contents">
           <div role="radiogroup" aria-labelledby="notification_mode">
             <strong id="notification_mode"
-              >How would you like to notify the customer on event creation?</strong
-            >
+              >How would you like to notify the customer on event creation?</strong>
             <label>
               <input
                 type="radio"
                 name="notification_mode"
                 value={NotificationMode.SHOW_MESSAGE}
-                bind:group={_this.notification_mode}
-              />
+                bind:group={_this.notification_mode} />
               <span>Show Message on UI</span>
             </label>
             <label>
@@ -1227,8 +1172,7 @@
                 type="radio"
                 name="notification_mode"
                 value={NotificationMode.SEND_MESSAGE}
-                bind:group={_this.notification_mode}
-              />
+                bind:group={_this.notification_mode} />
               <span>Send message via email</span>
             </label>
           </div>
@@ -1265,8 +1209,7 @@
                 },
               ]
             : []}
-          {id}
-        />
+          {id} />
         <nylas-booking
           {slots_to_book}
           {..._this}
@@ -1279,8 +1222,7 @@
                 },
               ]
             : []}
-          {id}
-        />
+          {id} />
       </aside>
     {/if}
 
@@ -1290,14 +1232,12 @@
         top={dragPlaceholder.top}
         height={tablerowRect.height}
         width={tablerowRect.width}
-        visible={!!draggedField}
-      >
+        visible={!!draggedField}>
         {#each customFieldKeys as key, i}
           <div
             class="drag-preview-cell"
             style="width: {tablecellRect[i].width}px; height: {tablecellRect[i]
-              .height}px;"
-          >
+              .height}px;">
             {(draggedField && draggedField[key]) || "—"}
           </div>
         {/each}


### PR DESCRIPTION
Our same-line-bracket and other rules hadn't been applied across our components; this fixes that.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
