### PR TITLE
[Schedule Editor] Sections as a prop: allow for editability and default expansion states

### DIFF
--- a/commons/src/types/ScheduleEditor.ts
+++ b/commons/src/types/ScheduleEditor.ts
@@ -42,6 +42,7 @@ export interface Manifest extends NylasManifest {
   min_book_ahead_days: number;
   custom_fields: CustomField[];
   events: EventDefinition[];
+  sections: Sections;
 }
 
 export interface EventDefinition {
@@ -62,6 +63,7 @@ interface HostRules {
 interface SectionOptions {
   expanded: boolean;
   editable: boolean;
+  hidden_fields?: string[];
 }
 
 export enum SectionNames {
@@ -74,5 +76,5 @@ export enum SectionNames {
 }
 
 export type Sections = {
-  [key in SectionNames]: SectionOptions;
+  [key in SectionNames]?: SectionOptions;
 };

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -487,9 +487,7 @@
 
   //#endregion consecutive events
 
-  //#region expand/collapse
-
-  // let sections: Partial<Sections> = {};
+  //#region initialize sections
 
   function establishSections() {
     if (!Object.entries(_this.sections).length) {
@@ -517,13 +515,7 @@
       });
     }
   }
-  $: console.log({ sections });
-
-  // function toggleCollapse(name: SectionNames) {
-  //   _this.sections[name].expanded = !_this.sections[name].expanded;
-  //   _this.sections = { ..._this.sections };
-  // }
-  //#endregion expand/collapse
+  //#endregion initialize sections
 </script>
 
 <style lang="scss">

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -493,7 +493,7 @@
     if (!Object.entries(_this.sections).length) {
       Object.values(SectionNames).forEach((name, iter) => {
         _this.sections[name] = {
-          expanded: iter === 0 ? true : false,
+          expanded: iter === 0,
           editable: true,
         };
       });

--- a/components/schedule-editor/src/index.html
+++ b/components/schedule-editor/src/index.html
@@ -16,7 +16,39 @@
     <script>
       document.addEventListener("DOMContentLoaded", function () {
         const component = document.querySelector("nylas-schedule-editor");
-        // component.participants = ["nylascypresstest@gmail.com"];
+
+        // Hey you! Uncomment the below in your own <nylas-schedule-editor> to control which sections get shown,
+        // which start as expanded by default, and which specific questions to hide.
+        // <3, Nylas
+
+        // let sectionConfig = {
+        //   "basic-details": {
+        //     expanded: false,
+        //     editable: true,
+        //   },
+        //   "time-date-details": {
+        //     expanded: true,
+        //     editable: true,
+        //   },
+        //   "style-details": {
+        //     expanded: false,
+        //     editable: true,
+        //   },
+        //   "booking-details": {
+        //     expanded: true,
+        //     editable: true,
+        //   },
+        //   "custom-fields": {
+        //     expanded: false,
+        //     editable: true,
+        //   },
+        //   "notification-details": {
+        //     expanded: false,
+        //     editable: true,
+        //   }
+        // }
+
+        // component.sections = sectionConfig;
       });
     </script>
   </head>

--- a/components/schedule-editor/src/init.spec.js
+++ b/components/schedule-editor/src/init.spec.js
@@ -29,3 +29,114 @@ describe("schedule-editor component", () => {
     });
   });
 });
+
+describe("Editable Sections", () => {
+  it("Expands the first section by default", () => {
+    cy.get(testScheduleEditor)
+      .get("nylas-schedule-editor-section")
+      .should("have.length", 6);
+    cy.get(testScheduleEditor).get("details[open]").should("have.length", 1);
+    cy.get(testScheduleEditor).get("details").eq(0).should("have.attr", "open");
+  });
+
+  it("Allows a custom section to be expanded", () => {
+    const sectionConfig = {
+      "basic-details": {
+        expanded: false,
+        editable: true,
+      },
+      "time-date-details": {
+        expanded: true,
+        editable: true,
+      },
+      "style-details": {
+        expanded: false,
+        editable: true,
+      },
+      "booking-details": {
+        expanded: true,
+        editable: true,
+      },
+      "custom-fields": {
+        expanded: false,
+        editable: true,
+      },
+      "notification-details": {
+        expanded: false,
+        editable: true,
+      },
+    };
+
+    cy.get(testScheduleEditor).then((element) => {
+      const component = element[0];
+      component.sections = sectionConfig;
+
+      cy.get(testScheduleEditor).get("details[open]").should("have.length", 2);
+      cy.get(testScheduleEditor)
+        .get("details")
+        .eq(0)
+        .should("not.have.attr", "open");
+      cy.get(testScheduleEditor)
+        .get("details")
+        .eq(1)
+        .should("have.attr", "open");
+      cy.get(testScheduleEditor)
+        .get("details")
+        .eq(3)
+        .should("have.attr", "open");
+
+      cy.get(testScheduleEditor)
+        .get("nylas-schedule-editor-section:eq(1) h1")
+        .click();
+      cy.get(testScheduleEditor).get("details[open]").should("have.length", 1);
+      cy.get(testScheduleEditor)
+        .get("nylas-schedule-editor-section:eq(3) h1")
+        .click();
+      cy.get(testScheduleEditor).get("details[open]").should("have.length", 0);
+      cy.get(testScheduleEditor)
+        .get("nylas-schedule-editor-section:eq(5) h1")
+        .click();
+      cy.get(testScheduleEditor).get("details[open]").should("have.length", 1);
+    });
+  });
+
+  it("Doesn't show sections not included in passed prop", () => {
+    const sectionConfig = {
+      "custom-fields": {
+        expanded: true,
+        editable: true,
+      },
+      "notification-details": {
+        expanded: false,
+        editable: true,
+      },
+    };
+
+    cy.get(testScheduleEditor).then((element) => {
+      const component = element[0];
+      component.sections = sectionConfig;
+      cy.get(testScheduleEditor)
+        .get("nylas-schedule-editor-section")
+        .should("have.length", 2);
+    });
+  });
+
+  it("Is pretty chill about editable property not being there", () => {
+    const sectionConfig = {
+      "custom-fields": {
+        expanded: true,
+      },
+      "notification-details": {
+        expanded: false,
+      },
+    };
+
+    cy.get(testScheduleEditor).then((element) => {
+      const component = element[0];
+      component.sections = sectionConfig;
+      cy.get(testScheduleEditor)
+        .get("nylas-schedule-editor-section")
+        .should("have.length", 2);
+    });
+  });
+});


### PR DESCRIPTION
Establishes `sections` as a passable property for `<nylas-schedule-editor>`;
- `editable` (defaults to true) dictates whether the section should show up at all
- `expanded` (defaults to false, except in the case of the first section) dictates whether the section is expanded or collapsed at initial load

### TODO:
- Logic to apply `hidden_fields` prop among sections

![image](https://user-images.githubusercontent.com/713991/157116226-2c4cbe13-8948-4aed-9a1d-8dfe5d1107d8.png)


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
