### PR TITLE
[Schedule Editor] Allow for "hidden fields" for editable sections

### DIFF
--- a/commons/src/types/ScheduleEditor.ts
+++ b/commons/src/types/ScheduleEditor.ts
@@ -67,7 +67,7 @@ interface SectionOptions {
 }
 
 export enum SectionNames {
-  BASIC_DETAILS = "basic-details",
+  EVENT_DETAILS = "event-details",
   TIME_DATE_DETAILS = "time-date-details",
   STYLE_DETAILS = "style-details",
   BOOKING_DETAILS = "booking-details",

--- a/commons/src/types/ScheduleEditor.ts
+++ b/commons/src/types/ScheduleEditor.ts
@@ -63,7 +63,7 @@ interface HostRules {
 interface SectionOptions {
   expanded: boolean;
   editable: boolean;
-  hidden_fields?: string[];
+  hidden_fields: string[];
 }
 
 export enum SectionNames {

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -987,7 +987,7 @@
                 {/if}
               </div>
             {/if}
-            {#if fieldIsEditable(SectionNames.BOOKING_DETAILS, "capcity")}
+            {#if fieldIsEditable(SectionNames.BOOKING_DETAILS, "capacity")}
               <label>
                 <strong>Capacity</strong>
                 <input type="number" min={1} bind:value={_this.capacity} />

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -562,66 +562,79 @@
                     Remove this event
                   </button>
                 {/if}
-                <label>
-                  <strong>Event Title!</strong>
-                  <input type="text" bind:value={event.event_title} />
-                </label>
-                <label>
-                  <strong>Event Description</strong>
-                  <input type="text" bind:value={event.event_description} />
-                </label>
-                <label>
-                  <strong>Event Location</strong>
-                  <input type="text" bind:value={event.event_location} />
-                </label>
-                <label>
-                  <strong>Conferencing Link (Zoom, Teams, or Meet URL)</strong>
-                  <input type="url" bind:value={event.event_conferencing} />
-                </label>
-                <div role="radiogroup" aria-labelledby="slot_size">
-                  <strong id="slot_size">Meeting Length</strong>
+                {#if fieldIsEditable(SectionNames.BASIC_DETAILS, "event_title")}
                   <label>
-                    <input
-                      type="radio"
-                      value={15}
-                      bind:group={event.slot_size} />
-                    <span>15 minutes</span>
+                    <strong>Event Title</strong>
+                    <input type="text" bind:value={event.event_title} />
                   </label>
+                {/if}
+                {#if fieldIsEditable(SectionNames.BASIC_DETAILS, "event_description")}
                   <label>
-                    <input
-                      type="radio"
-                      value={30}
-                      bind:group={event.slot_size} />
-                    <span>30 minutes</span>
+                    <strong>Event Description</strong>
+                    <input type="text" bind:value={event.event_description} />
                   </label>
+                {/if}
+                {#if fieldIsEditable(SectionNames.BASIC_DETAILS, "event_location")}
                   <label>
-                    <input
-                      type="radio"
-                      value={60}
-                      bind:group={event.slot_size} />
-                    <span>60 minutes</span>
+                    <strong>Event Location</strong>
+                    <input type="text" bind:value={event.event_location} />
                   </label>
-                  {#if iter !== 0 && event.slot_size !== _this.events[0].slot_size}
-                    <!-- Temporary! Nylas' Consecutive Availabiilty API does not support variant time lengths between meetings -->
-                    <!-- https://app.shortcut.com/nylas/story/74514/consecutive-availability-allow-to-specify-duration-minutes-per-meeting -->
-                    <p class="warning">
-                      Note: different meeting lengths in a conecutive chain are
-                      not currently supported; all meetings in this chain will
-                      fall back to {_this.events[0].slot_size} minutes.
-                    </p>
-                  {/if}
-                </div>
-                <div>
-                  <strong id="participants">
-                    Email Ids to include for scheduling
-                  </strong>
+                {/if}
+                {#if fieldIsEditable(SectionNames.BASIC_DETAILS, "conferencing_link")}
                   <label>
-                    <textarea
-                      name="participants"
-                      on:input={(e) => debounceEmailInput(e, event)}
-                      value={event.participantEmails} />
+                    <strong
+                      >Conferencing Link (Zoom, Teams, or Meet URL)</strong>
+                    <input type="url" bind:value={event.event_conferencing} />
                   </label>
-                </div>
+                {/if}
+                {#if fieldIsEditable(SectionNames.BASIC_DETAILS, "meeting_length")}
+                  <div role="radiogroup" aria-labelledby="slot_size">
+                    <strong id="slot_size">Meeting Length</strong>
+                    <label>
+                      <input
+                        type="radio"
+                        value={15}
+                        bind:group={event.slot_size} />
+                      <span>15 minutes</span>
+                    </label>
+                    <label>
+                      <input
+                        type="radio"
+                        value={30}
+                        bind:group={event.slot_size} />
+                      <span>30 minutes</span>
+                    </label>
+                    <label>
+                      <input
+                        type="radio"
+                        value={60}
+                        bind:group={event.slot_size} />
+                      <span>60 minutes</span>
+                    </label>
+                    {#if iter !== 0 && event.slot_size !== _this.events[0].slot_size}
+                      <!-- Temporary! Nylas' Consecutive Availabiilty API does not support variant time lengths between meetings -->
+                      <!-- https://app.shortcut.com/nylas/story/74514/consecutive-availability-allow-to-specify-duration-minutes-per-meeting -->
+                      <p class="warning">
+                        Note: different meeting lengths in a conecutive chain
+                        are not currently supported; all meetings in this chain
+                        will fall back to {_this.events[0].slot_size} minutes.
+                      </p>
+                    {/if}
+                  </div>
+                {/if}
+                {#if fieldIsEditable(SectionNames.BASIC_DETAILS, "participants")}
+                  <div>
+                    <strong id="participants">
+                      Email Ids to include for scheduling
+                    </strong>
+                    <label>
+                      <textarea
+                        name="participants"
+                        on:input={(e) => debounceEmailInput(e, event)}
+                        value={event.participantEmails} />
+                    </label>
+                  </div>
+                {/if}
               </fieldset>
             {/each}
           </div>

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -523,7 +523,6 @@
   }
 
   function fieldIsHidden(sectionName: SectionNames, fieldName: string) {
-    // console.log("is field editable?", sectionName, fieldName);
     return _this.sections[sectionName].hidden_fields.includes(fieldName);
   }
   //#endregion initialize sections

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -543,16 +543,16 @@
     bind:clientWidth={mainElementWidth}
     bind:this={main}>
     <div class="settings">
-      {#if _this.sections[SectionNames.BASIC_DETAILS].editable}
+      {#if _this.sections[SectionNames.EVENT_DETAILS].editable}
         <nylas-schedule-editor-section
-          section_title={SectionNames.BASIC_DETAILS}
-          expanded={_this.sections[SectionNames.BASIC_DETAILS].expanded}>
+          section_title={SectionNames.EVENT_DETAILS}
+          expanded={_this.sections[SectionNames.EVENT_DETAILS].expanded}>
           <h1 slot="title">Event Details</h1>
           <p slot="intro" class="intro">
             Edit the details for your meeting. You can add consecutive meetings
             to allow users to book back-to-back events.
           </p>
-          <div slot="contents" class="contents basic-details">
+          <div slot="contents" class="contents event-details">
             {#each _this.events as event, iter}
               <fieldset>
                 {#if _this.events.length > 1}
@@ -562,32 +562,32 @@
                     Remove this event
                   </button>
                 {/if}
-                {#if fieldIsEditable(SectionNames.BASIC_DETAILS, "event_title")}
+                {#if fieldIsEditable(SectionNames.EVENT_DETAILS, "event_title")}
                   <label>
                     <strong>Event Title</strong>
                     <input type="text" bind:value={event.event_title} />
                   </label>
                 {/if}
-                {#if fieldIsEditable(SectionNames.BASIC_DETAILS, "event_description")}
+                {#if fieldIsEditable(SectionNames.EVENT_DETAILS, "event_description")}
                   <label>
                     <strong>Event Description</strong>
                     <input type="text" bind:value={event.event_description} />
                   </label>
                 {/if}
-                {#if fieldIsEditable(SectionNames.BASIC_DETAILS, "event_location")}
+                {#if fieldIsEditable(SectionNames.EVENT_DETAILS, "event_location")}
                   <label>
                     <strong>Event Location</strong>
                     <input type="text" bind:value={event.event_location} />
                   </label>
                 {/if}
-                {#if fieldIsEditable(SectionNames.BASIC_DETAILS, "conferencing_link")}
+                {#if fieldIsEditable(SectionNames.EVENT_DETAILS, "conferencing_link")}
                   <label>
                     <strong
                       >Conferencing Link (Zoom, Teams, or Meet URL)</strong>
                     <input type="url" bind:value={event.event_conferencing} />
                   </label>
                 {/if}
-                {#if fieldIsEditable(SectionNames.BASIC_DETAILS, "meeting_length")}
+                {#if fieldIsEditable(SectionNames.EVENT_DETAILS, "meeting_length")}
                   <div role="radiogroup" aria-labelledby="slot_size">
                     <strong id="slot_size">Meeting Length</strong>
                     <label>
@@ -622,7 +622,7 @@
                     {/if}
                   </div>
                 {/if}
-                {#if fieldIsEditable(SectionNames.BASIC_DETAILS, "participants")}
+                {#if fieldIsEditable(SectionNames.EVENT_DETAILS, "participants")}
                   <div>
                     <strong id="participants">
                       Email Ids to include for scheduling

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -860,134 +860,148 @@
           expanded={_this.sections[SectionNames.BOOKING_DETAILS].expanded}>
           <h1 slot="title">Booking Details</h1>
           <div slot="contents" class="contents">
-            <div role="checkbox" aria-labelledby="allow_booking">
-              <strong id="allow_booking">Allow booking</strong>
+            {#if fieldIsEditable(SectionNames.BOOKING_DETAILS, "allow_booking")}
+              <div role="checkbox" aria-labelledby="allow_booking">
+                <strong id="allow_booking">Allow booking</strong>
+                <label>
+                  <input
+                    type="checkbox"
+                    name="allow_booking"
+                    bind:checked={_this.allow_booking} />
+                  Allow bookings to be made
+                </label>
+              </div>
+            {/if}
+            {#if fieldIsEditable(SectionNames.BOOKING_DETAILS, "maximum_slots")}
               <label>
+                <strong>Maximum slots that can be booked at once</strong>
                 <input
-                  type="checkbox"
-                  name="allow_booking"
-                  bind:checked={_this.allow_booking} />
-                Allow bookings to be made
+                  type="number"
+                  min={1}
+                  max={20}
+                  bind:value={_this.max_bookable_slots} />
               </label>
-            </div>
-            <label>
-              <strong>Maximum slots that can be booked at once</strong>
-              <input
-                type="number"
-                min={1}
-                max={20}
-                bind:value={_this.max_bookable_slots} />
-            </label>
-            <div role="checkbox" aria-labelledby="screen_bookings">
-              <strong id="screen_bookings">
-                Scheduling on this calendar requires manual confirmation
-              </strong>
-              <label>
-                <input
-                  type="checkbox"
-                  name="screen_bookings"
-                  bind:checked={_this.screen_bookings} />
-                Let the meeting host screen bookings before they're made official
-              </label>
-            </div>
-            <label>
-              <strong>Participant Threshold / Partial bookable ratio</strong>
-              <input
-                type="range"
-                min={0}
-                max={1}
-                step={0.01}
-                bind:value={_this.partial_bookable_ratio} />
-              {Math.floor(_this.partial_bookable_ratio * 100)}%
-            </label>
-            <div role="radiogroup" aria-labelledby="recurrence">
-              <strong id="recurrence">
-                Allow, Disallow, or Mandate events to repeat?
-              </strong>
-              <label>
-                <input
-                  type="radio"
-                  name="recurrence"
-                  bind:group={_this.recurrence}
-                  value="none" />
-                <span>Don't Repeat Events</span>
-              </label>
-              <label>
-                <input
-                  type="radio"
-                  name="recurrence"
-                  bind:group={_this.recurrence}
-                  value="optional" />
-                <span>Users May Repeat Events</span>
-              </label>
-              <label>
-                <input
-                  type="radio"
-                  name="recurrence"
-                  bind:group={_this.recurrence}
-                  value="required" />
-                <span>Events Always Repeat</span>
-              </label>
-            </div>
-            <label>
-              <strong>Capacity</strong>
-              <input type="number" min={1} bind:value={_this.capacity} />
-            </label>
-            <div role="checkbox" aria-labelledby="allow_booking">
-              <strong>Top of the Hour Events</strong>
-              <label>
-                <input
-                  type="checkbox"
-                  name="mandate_top_of_hour"
-                  bind:checked={_this.mandate_top_of_hour} />
-                Only allow events to be booked at the Top of the Hour
-              </label>
-            </div>
-            {#if _this.recurrence === "required" || _this.recurrence === "optional"}
-              <div role="radiogroup" aria-labelledby="recurrence_cadence">
-                <strong id="recurrence_cadence">
-                  How often should events repeat{#if _this.recurrence === "optional"},
-                    if a user chooses to do so{/if}?
+            {/if}
+            {#if fieldIsEditable(SectionNames.BOOKING_DETAILS, "screen_bookings")}
+              <div role="checkbox" aria-labelledby="screen_bookings">
+                <strong id="screen_bookings">
+                  Scheduling on this calendar requires manual confirmation
                 </strong>
                 <label>
                   <input
                     type="checkbox"
-                    name="recurrence_cadence"
-                    bind:group={_this.recurrence_cadence}
-                    value="daily" />
-                  <span>Daily</span>
+                    name="screen_bookings"
+                    bind:checked={_this.screen_bookings} />
+                  Let the meeting host screen bookings before they're made official
+                </label>
+              </div>
+            {/if}
+            {#if fieldIsEditable(SectionNames.BOOKING_DETAILS, "bookable_ratio")}
+              <label>
+                <strong>Participant Threshold / Partial bookable ratio</strong>
+                <input
+                  type="range"
+                  min={0}
+                  max={1}
+                  step={0.01}
+                  bind:value={_this.partial_bookable_ratio} />
+                {Math.floor(_this.partial_bookable_ratio * 100)}%
+              </label>
+            {/if}
+            {#if fieldIsEditable(SectionNames.BOOKING_DETAILS, "recurrence")}
+              <div role="radiogroup" aria-labelledby="recurrence">
+                <strong id="recurrence">
+                  Allow, Disallow, or Mandate events to repeat?
+                </strong>
+                <label>
+                  <input
+                    type="radio"
+                    name="recurrence"
+                    bind:group={_this.recurrence}
+                    value="none" />
+                  <span>Don't Repeat Events</span>
                 </label>
                 <label>
                   <input
-                    type="checkbox"
-                    name="recurrence_cadence"
-                    bind:group={_this.recurrence_cadence}
-                    value="weekdays" />
-                  <span>Daily, only on weekdays</span>
+                    type="radio"
+                    name="recurrence"
+                    bind:group={_this.recurrence}
+                    value="optional" />
+                  <span>Users May Repeat Events</span>
                 </label>
                 <label>
                   <input
-                    type="checkbox"
-                    name="recurrence_cadence"
-                    bind:group={_this.recurrence_cadence}
-                    value="weekly" />
-                  <span>Weekly</span>
+                    type="radio"
+                    name="recurrence"
+                    bind:group={_this.recurrence}
+                    value="required" />
+                  <span>Events Always Repeat</span>
                 </label>
+                {#if _this.recurrence === "required" || _this.recurrence === "optional"}
+                  <div role="radiogroup" aria-labelledby="recurrence_cadence">
+                    <strong id="recurrence_cadence">
+                      How often should events repeat{#if _this.recurrence === "optional"},
+                        if a user chooses to do so{/if}?
+                    </strong>
+                    <label>
+                      <input
+                        type="checkbox"
+                        name="recurrence_cadence"
+                        bind:group={_this.recurrence_cadence}
+                        value="daily" />
+                      <span>Daily</span>
+                    </label>
+                    <label>
+                      <input
+                        type="checkbox"
+                        name="recurrence_cadence"
+                        bind:group={_this.recurrence_cadence}
+                        value="weekdays" />
+                      <span>Daily, only on weekdays</span>
+                    </label>
+                    <label>
+                      <input
+                        type="checkbox"
+                        name="recurrence_cadence"
+                        bind:group={_this.recurrence_cadence}
+                        value="weekly" />
+                      <span>Weekly</span>
+                    </label>
+                    <label>
+                      <input
+                        type="checkbox"
+                        name="recurrence_cadence"
+                        bind:group={_this.recurrence_cadence}
+                        value="biweekly" />
+                      <span>Biweekly</span>
+                    </label>
+                    <label>
+                      <input
+                        type="checkbox"
+                        name="recurrence_cadence"
+                        bind:group={_this.recurrence_cadence}
+                        value="monthly" />
+                      <span>Monthly</span>
+                    </label>
+                  </div>
+                {/if}
+              </div>
+            {/if}
+            {#if fieldIsEditable(SectionNames.BOOKING_DETAILS, "capcity")}
+              <label>
+                <strong>Capacity</strong>
+                <input type="number" min={1} bind:value={_this.capacity} />
+              </label>
+            {/if}
+            {#if fieldIsEditable(SectionNames.BOOKING_DETAILS, "mandate_top_of_hour")}
+              <div role="checkbox" aria-labelledby="mandate_top_of_hour">
+                <strong>Top of the Hour Events</strong>
                 <label>
                   <input
                     type="checkbox"
-                    name="recurrence_cadence"
-                    bind:group={_this.recurrence_cadence}
-                    value="biweekly" />
-                  <span>Biweekly</span>
-                </label>
-                <label>
-                  <input
-                    type="checkbox"
-                    name="recurrence_cadence"
-                    bind:group={_this.recurrence_cadence}
-                    value="monthly" />
-                  <span>Monthly</span>
+                    name="mandate_top_of_hour"
+                    bind:checked={_this.mandate_top_of_hour} />
+                  Only allow events to be booked at the Top of the Hour
                 </label>
               </div>
             {/if}
@@ -1227,34 +1241,40 @@
           expanded={_this.sections[SectionNames.NOTIFICATION_DETAILS].expanded}>
           <h1 slot="title">Notification Details</h1>
           <div slot="contents" class="contents">
-            <div role="radiogroup" aria-labelledby="notification_mode">
-              <strong id="notification_mode"
-                >How would you like to notify the customer on event creation?</strong>
+            {#if fieldIsEditable(SectionNames.NOTIFICATION_DETAILS, "notification_mode")}
+              <div role="radiogroup" aria-labelledby="notification_mode">
+                <strong id="notification_mode"
+                  >How would you like to notify the customer on event creation?</strong>
+                <label>
+                  <input
+                    type="radio"
+                    name="notification_mode"
+                    value={NotificationMode.SHOW_MESSAGE}
+                    bind:group={_this.notification_mode} />
+                  <span>Show Message on UI</span>
+                </label>
+                <label>
+                  <input
+                    type="radio"
+                    name="notification_mode"
+                    value={NotificationMode.SEND_MESSAGE}
+                    bind:group={_this.notification_mode} />
+                  <span>Send message via email</span>
+                </label>
+              </div>
+            {/if}
+            {#if fieldIsEditable(SectionNames.NOTIFICATION_DETAILS, "notification_message")}
               <label>
-                <input
-                  type="radio"
-                  name="notification_mode"
-                  value={NotificationMode.SHOW_MESSAGE}
-                  bind:group={_this.notification_mode} />
-                <span>Show Message on UI</span>
+                <strong>Notification message</strong>
+                <input type="text" bind:value={_this.notification_message} />
               </label>
+            {/if}
+            {#if fieldIsEditable(SectionNames.NOTIFICATION_DETAILS, "notification_subject")}
               <label>
-                <input
-                  type="radio"
-                  name="notification_mode"
-                  value={NotificationMode.SEND_MESSAGE}
-                  bind:group={_this.notification_mode} />
-                <span>Send message via email</span>
+                <strong>Notification Subject</strong>
+                <input type="text" bind:value={_this.notification_subject} />
               </label>
-            </div>
-            <label>
-              <strong>Notification message</strong>
-              <input type="text" bind:value={_this.notification_message} />
-            </label>
-            <label>
-              <strong>Notification Subject</strong>
-              <input type="text" bind:value={_this.notification_subject} />
-            </label>
+            {/if}
           </div>
           <footer slot="footer">
             <button on:click={saveProperties}>Save Editor Options</button>

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -495,6 +495,7 @@
         _this.sections[name] = {
           expanded: iter === 0,
           editable: true,
+          hidden_fields: [],
         };
       });
     } else {
@@ -505,15 +506,25 @@
           _this.sections[name] = {
             expanded: false,
             editable: false,
+            hidden_fields: [],
           };
         } else {
           // If the section is passed in but lacks an "editable" property, assume positive intent.
           if (!Object.keys(_this.sections[name]).includes("editable")) {
             _this.sections[name].editable = true;
           }
+          // Establish a default empty list for hidden fields
+          if (!Object.keys(_this.sections[name]).includes("hidden_fields")) {
+            _this.sections[name].hidden_fields = [];
+          }
         }
       });
     }
+  }
+
+  function fieldIsEditable(sectionName: SectionNames, fieldName: string) {
+    console.log("is field editable?", sectionName, fieldName);
+    return !_this.sections[sectionName].hidden_fields.includes(fieldName);
   }
   //#endregion initialize sections
 </script>
@@ -780,16 +791,18 @@
           expanded={_this.sections[SectionNames.STYLE_DETAILS].expanded}>
           <h1 slot="title">Style Details</h1>
           <div slot="contents" class="contents">
-            <div role="checkbox" aria-labelledby="show_ticks">
-              <strong id="show_ticks">Show ticks</strong>
-              <label>
-                <input
-                  type="checkbox"
-                  name="show_ticks"
-                  bind:checked={_this.show_ticks} />
-                Show tick marks on left side
-              </label>
-            </div>
+            {#if fieldIsEditable(SectionNames.STYLE_DETAILS, "show_ticks")}
+              <div role="checkbox" aria-labelledby="show_ticks">
+                <strong id="show_ticks">Show ticks</strong>
+                <label>
+                  <input
+                    type="checkbox"
+                    name="show_ticks"
+                    bind:checked={_this.show_ticks} />
+                  Show tick marks on left side
+                </label>
+              </div>
+            {/if}
             <div role="radiogroup" aria-labelledby="view_as">
               <strong id="view_as">View as a Schedule, or as a List?</strong>
               <label>

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -522,9 +522,9 @@
     }
   }
 
-  function fieldIsEditable(sectionName: SectionNames, fieldName: string) {
+  function fieldIsHidden(sectionName: SectionNames, fieldName: string) {
     // console.log("is field editable?", sectionName, fieldName);
-    return !_this.sections[sectionName].hidden_fields.includes(fieldName);
+    return _this.sections[sectionName].hidden_fields.includes(fieldName);
   }
   //#endregion initialize sections
 </script>
@@ -562,32 +562,32 @@
                     Remove this event
                   </button>
                 {/if}
-                {#if fieldIsEditable(SectionNames.EVENT_DETAILS, "event_title")}
+                {#if !fieldIsHidden(SectionNames.EVENT_DETAILS, "event_title")}
                   <label>
                     <strong>Event Title</strong>
                     <input type="text" bind:value={event.event_title} />
                   </label>
                 {/if}
-                {#if fieldIsEditable(SectionNames.EVENT_DETAILS, "event_description")}
+                {#if !fieldIsHidden(SectionNames.EVENT_DETAILS, "event_description")}
                   <label>
                     <strong>Event Description</strong>
                     <input type="text" bind:value={event.event_description} />
                   </label>
                 {/if}
-                {#if fieldIsEditable(SectionNames.EVENT_DETAILS, "event_location")}
+                {#if !fieldIsHidden(SectionNames.EVENT_DETAILS, "event_location")}
                   <label>
                     <strong>Event Location</strong>
                     <input type="text" bind:value={event.event_location} />
                   </label>
                 {/if}
-                {#if fieldIsEditable(SectionNames.EVENT_DETAILS, "conferencing_link")}
+                {#if !fieldIsHidden(SectionNames.EVENT_DETAILS, "conferencing_link")}
                   <label>
                     <strong
                       >Conferencing Link (Zoom, Teams, or Meet URL)</strong>
                     <input type="url" bind:value={event.event_conferencing} />
                   </label>
                 {/if}
-                {#if fieldIsEditable(SectionNames.EVENT_DETAILS, "meeting_length")}
+                {#if !fieldIsHidden(SectionNames.EVENT_DETAILS, "meeting_length")}
                   <div role="radiogroup" aria-labelledby="slot_size">
                     <strong id="slot_size">Meeting Length</strong>
                     <label>
@@ -622,7 +622,7 @@
                     {/if}
                   </div>
                 {/if}
-                {#if fieldIsEditable(SectionNames.EVENT_DETAILS, "participants")}
+                {#if !fieldIsHidden(SectionNames.EVENT_DETAILS, "participants")}
                   <div>
                     <strong id="participants">
                       Email Ids to include for scheduling
@@ -652,7 +652,7 @@
           expanded={_this.sections[SectionNames.TIME_DATE_DETAILS].expanded}>
           <h1 slot="title">Date/Time Details</h1>
           <div slot="contents" class="contents">
-            {#if fieldIsEditable(SectionNames.TIME_DATE_DETAILS, "start_hour")}
+            {#if !fieldIsHidden(SectionNames.TIME_DATE_DETAILS, "start_hour")}
               <label>
                 <strong>Start Hour</strong>
                 <input
@@ -664,7 +664,7 @@
                 {_this.start_hour}:00
               </label>
             {/if}
-            {#if fieldIsEditable(SectionNames.TIME_DATE_DETAILS, "end_hour")}
+            {#if !fieldIsHidden(SectionNames.TIME_DATE_DETAILS, "end_hour")}
               <label>
                 <strong>End Hour</strong>
                 <input
@@ -676,7 +676,7 @@
                 {_this.end_hour}:00
               </label>
             {/if}
-            {#if fieldIsEditable(SectionNames.TIME_DATE_DETAILS, "start_date")}
+            {#if !fieldIsHidden(SectionNames.TIME_DATE_DETAILS, "start_date")}
               <label>
                 <strong>Start Date</strong>
                 <strong>
@@ -700,7 +700,7 @@
                   disabled={!customStartDate} />
               </label>
             {/if}
-            {#if fieldIsEditable(SectionNames.TIME_DATE_DETAILS, "time_zone")}
+            {#if !fieldIsHidden(SectionNames.TIME_DATE_DETAILS, "time_zone")}
               <label>
                 <strong>Time Zone</strong>
                 <select bind:value={_this.timezone}>
@@ -710,7 +710,7 @@
                 </select>
               </label>
             {/if}
-            {#if fieldIsEditable(SectionNames.TIME_DATE_DETAILS, "days_to_show")}
+            {#if !fieldIsHidden(SectionNames.TIME_DATE_DETAILS, "days_to_show")}
               <label>
                 <strong>Days to show</strong>
                 <input
@@ -722,7 +722,7 @@
                 {_this.dates_to_show}
               </label>
             {/if}
-            {#if fieldIsEditable(SectionNames.TIME_DATE_DETAILS, "show_as_week")}
+            {#if !fieldIsHidden(SectionNames.TIME_DATE_DETAILS, "show_as_week")}
               <div role="checkbox" aria-labelledby="show_as_week">
                 <strong id="show_as_week">Show as week</strong>
                 <label>
@@ -734,7 +734,7 @@
                 </label>
               </div>
             {/if}
-            {#if fieldIsEditable(SectionNames.TIME_DATE_DETAILS, "show_weekends")}
+            {#if !fieldIsHidden(SectionNames.TIME_DATE_DETAILS, "show_weekends")}
               <div role="checkbox" aria-labelledby="show_weekends">
                 <strong id="show_weekends">Show weekends</strong>
                 <label>
@@ -746,7 +746,7 @@
                 </label>
               </div>
             {/if}
-            {#if fieldIsEditable(SectionNames.TIME_DATE_DETAILS, "available_hours")}
+            {#if !fieldIsHidden(SectionNames.TIME_DATE_DETAILS, "available_hours")}
               <div class="available-hours">
                 <strong>Available Hours</strong>
                 <p>
@@ -814,7 +814,7 @@
           expanded={_this.sections[SectionNames.STYLE_DETAILS].expanded}>
           <h1 slot="title">Style Details</h1>
           <div slot="contents" class="contents">
-            {#if fieldIsEditable(SectionNames.STYLE_DETAILS, "show_ticks")}
+            {#if !fieldIsHidden(SectionNames.STYLE_DETAILS, "show_ticks")}
               <div role="checkbox" aria-labelledby="show_ticks">
                 <strong id="show_ticks">Show ticks</strong>
                 <label>
@@ -826,7 +826,7 @@
                 </label>
               </div>
             {/if}
-            {#if fieldIsEditable(SectionNames.STYLE_DETAILS, "view_as_schedule")}
+            {#if !fieldIsHidden(SectionNames.STYLE_DETAILS, "view_as_schedule")}
               <div role="radiogroup" aria-labelledby="view_as">
                 <strong id="view_as">View as a Schedule, or as a List?</strong>
                 <label>
@@ -860,7 +860,7 @@
           expanded={_this.sections[SectionNames.BOOKING_DETAILS].expanded}>
           <h1 slot="title">Booking Details</h1>
           <div slot="contents" class="contents">
-            {#if fieldIsEditable(SectionNames.BOOKING_DETAILS, "allow_booking")}
+            {#if !fieldIsHidden(SectionNames.BOOKING_DETAILS, "allow_booking")}
               <div role="checkbox" aria-labelledby="allow_booking">
                 <strong id="allow_booking">Allow booking</strong>
                 <label>
@@ -872,7 +872,7 @@
                 </label>
               </div>
             {/if}
-            {#if fieldIsEditable(SectionNames.BOOKING_DETAILS, "maximum_slots")}
+            {#if !fieldIsHidden(SectionNames.BOOKING_DETAILS, "maximum_slots")}
               <label>
                 <strong>Maximum slots that can be booked at once</strong>
                 <input
@@ -882,7 +882,7 @@
                   bind:value={_this.max_bookable_slots} />
               </label>
             {/if}
-            {#if fieldIsEditable(SectionNames.BOOKING_DETAILS, "screen_bookings")}
+            {#if !fieldIsHidden(SectionNames.BOOKING_DETAILS, "screen_bookings")}
               <div role="checkbox" aria-labelledby="screen_bookings">
                 <strong id="screen_bookings">
                   Scheduling on this calendar requires manual confirmation
@@ -896,7 +896,7 @@
                 </label>
               </div>
             {/if}
-            {#if fieldIsEditable(SectionNames.BOOKING_DETAILS, "bookable_ratio")}
+            {#if !fieldIsHidden(SectionNames.BOOKING_DETAILS, "bookable_ratio")}
               <label>
                 <strong>Participant Threshold / Partial bookable ratio</strong>
                 <input
@@ -908,7 +908,7 @@
                 {Math.floor(_this.partial_bookable_ratio * 100)}%
               </label>
             {/if}
-            {#if fieldIsEditable(SectionNames.BOOKING_DETAILS, "recurrence")}
+            {#if !fieldIsHidden(SectionNames.BOOKING_DETAILS, "recurrence")}
               <div role="radiogroup" aria-labelledby="recurrence">
                 <strong id="recurrence">
                   Allow, Disallow, or Mandate events to repeat?
@@ -987,13 +987,13 @@
                 {/if}
               </div>
             {/if}
-            {#if fieldIsEditable(SectionNames.BOOKING_DETAILS, "capacity")}
+            {#if !fieldIsHidden(SectionNames.BOOKING_DETAILS, "capacity")}
               <label>
                 <strong>Capacity</strong>
                 <input type="number" min={1} bind:value={_this.capacity} />
               </label>
             {/if}
-            {#if fieldIsEditable(SectionNames.BOOKING_DETAILS, "mandate_top_of_hour")}
+            {#if !fieldIsHidden(SectionNames.BOOKING_DETAILS, "mandate_top_of_hour")}
               <div role="checkbox" aria-labelledby="mandate_top_of_hour">
                 <strong>Top of the Hour Events</strong>
                 <label>
@@ -1241,7 +1241,7 @@
           expanded={_this.sections[SectionNames.NOTIFICATION_DETAILS].expanded}>
           <h1 slot="title">Notification Details</h1>
           <div slot="contents" class="contents">
-            {#if fieldIsEditable(SectionNames.NOTIFICATION_DETAILS, "notification_mode")}
+            {#if !fieldIsHidden(SectionNames.NOTIFICATION_DETAILS, "notification_mode")}
               <div role="radiogroup" aria-labelledby="notification_mode">
                 <strong id="notification_mode"
                   >How would you like to notify the customer on event creation?</strong>
@@ -1263,13 +1263,13 @@
                 </label>
               </div>
             {/if}
-            {#if fieldIsEditable(SectionNames.NOTIFICATION_DETAILS, "notification_message")}
+            {#if !fieldIsHidden(SectionNames.NOTIFICATION_DETAILS, "notification_message")}
               <label>
                 <strong>Notification message</strong>
                 <input type="text" bind:value={_this.notification_message} />
               </label>
             {/if}
-            {#if fieldIsEditable(SectionNames.NOTIFICATION_DETAILS, "notification_subject")}
+            {#if !fieldIsHidden(SectionNames.NOTIFICATION_DETAILS, "notification_subject")}
               <label>
                 <strong>Notification Subject</strong>
                 <input type="text" bind:value={_this.notification_subject} />

--- a/components/schedule-editor/src/ScheduleEditor.svelte
+++ b/components/schedule-editor/src/ScheduleEditor.svelte
@@ -523,7 +523,7 @@
   }
 
   function fieldIsEditable(sectionName: SectionNames, fieldName: string) {
-    console.log("is field editable?", sectionName, fieldName);
+    // console.log("is field editable?", sectionName, fieldName);
     return !_this.sections[sectionName].hidden_fields.includes(fieldName);
   }
   //#endregion initialize sections
@@ -639,7 +639,7 @@
           expanded={_this.sections[SectionNames.TIME_DATE_DETAILS].expanded}>
           <h1 slot="title">Date/Time Details</h1>
           <div slot="contents" class="contents">
-            <div>
+            {#if fieldIsEditable(SectionNames.TIME_DATE_DETAILS, "start_hour")}
               <label>
                 <strong>Start Hour</strong>
                 <input
@@ -648,10 +648,10 @@
                   max={24}
                   step={1}
                   bind:value={_this.start_hour} />
+                {_this.start_hour}:00
               </label>
-              {_this.start_hour}:00
-            </div>
-            <div>
+            {/if}
+            {#if fieldIsEditable(SectionNames.TIME_DATE_DETAILS, "end_hour")}
               <label>
                 <strong>End Hour</strong>
                 <input
@@ -660,40 +660,44 @@
                   max={24}
                   step={1}
                   bind:value={_this.end_hour} />
+                {_this.end_hour}:00
               </label>
-              {_this.end_hour}:00
-            </div>
-            <label>
-              <strong>Start Date</strong>
-              <strong>
-                <input
-                  type="checkbox"
-                  name="custom_start_date"
-                  bind:checked={customStartDate}
-                  on:change={async () => {
-                    if (!customStartDate) {
-                      startDate = new Date().toLocaleDateString("en-CA");
-                      await tick();
-                      startDate = null;
-                    }
-                  }} />
-                Show a specific date
-              </strong>
+            {/if}
+            {#if fieldIsEditable(SectionNames.TIME_DATE_DETAILS, "start_date")}
+              <label>
+                <strong>Start Date</strong>
+                <strong>
+                  <input
+                    type="checkbox"
+                    name="custom_start_date"
+                    bind:checked={customStartDate}
+                    on:change={async () => {
+                      if (!customStartDate) {
+                        startDate = new Date().toLocaleDateString("en-CA");
+                        await tick();
+                        startDate = null;
+                      }
+                    }} />
+                  Show a specific date
+                </strong>
 
-              <input
-                type="date"
-                bind:value={startDate}
-                disabled={!customStartDate} />
-            </label>
-            <label>
-              <strong>Time Zone</strong>
-              <select bind:value={_this.timezone}>
-                {#each timezones.default as timezone}
-                  <option value={timezone.tzCode}>{timezone.name}</option>
-                {/each}
-              </select>
-            </label>
-            <div>
+                <input
+                  type="date"
+                  bind:value={startDate}
+                  disabled={!customStartDate} />
+              </label>
+            {/if}
+            {#if fieldIsEditable(SectionNames.TIME_DATE_DETAILS, "time_zone")}
+              <label>
+                <strong>Time Zone</strong>
+                <select bind:value={_this.timezone}>
+                  {#each timezones.default as timezone}
+                    <option value={timezone.tzCode}>{timezone.name}</option>
+                  {/each}
+                </select>
+              </label>
+            {/if}
+            {#if fieldIsEditable(SectionNames.TIME_DATE_DETAILS, "days_to_show")}
               <label>
                 <strong>Days to show</strong>
                 <input
@@ -702,82 +706,88 @@
                   max={7}
                   step={1}
                   bind:value={_this.dates_to_show} />
+                {_this.dates_to_show}
               </label>
-              {_this.dates_to_show}
-            </div>
-            <div role="checkbox" aria-labelledby="show_as_week">
-              <strong id="show_as_week">Show as week</strong>
-              <label>
-                <input
-                  type="checkbox"
-                  name="show_as_week"
-                  bind:checked={_this.show_as_week} />
-                Show whole week
-              </label>
-            </div>
-            <div role="checkbox" aria-labelledby="show_weekends">
-              <strong id="show_weekends">Show weekends</strong>
-              <label>
-                <input
-                  type="checkbox"
-                  name="show_weekends"
-                  bind:checked={_this.show_weekends} />
-                Keep weekends on
-              </label>
-            </div>
-            <div class="available-hours">
-              <strong>Available Hours</strong>
-              <p>
-                Drag over the hours want to be availble for booking. All other
-                hours will always show up as "busy" to your users.
-              </p>
+            {/if}
+            {#if fieldIsEditable(SectionNames.TIME_DATE_DETAILS, "show_as_week")}
               <div role="checkbox" aria-labelledby="show_as_week">
+                <strong id="show_as_week">Show as week</strong>
                 <label>
                   <input
                     type="checkbox"
-                    name="_this.show_as_week"
+                    name="show_as_week"
                     bind:checked={_this.show_as_week} />
-                  Customize each weekday
+                  Show whole week
                 </label>
               </div>
-              <div role="checkbox" aria-labelledby="show_as_week">
+            {/if}
+            {#if fieldIsEditable(SectionNames.TIME_DATE_DETAILS, "show_weekends")}
+              <div role="checkbox" aria-labelledby="show_weekends">
+                <strong id="show_weekends">Show weekends</strong>
                 <label>
                   <input
                     type="checkbox"
-                    name=" _this.show_weekends"
+                    name="show_weekends"
                     bind:checked={_this.show_weekends} />
-                  Allow booking on weekends
+                  Keep weekends on
                 </label>
               </div>
-              <div class="availability-container">
-                <nylas-availability
-                  allow_booking={true}
-                  show_as_week={_this.show_as_week || _this.show_weekends}
-                  show_weekends={_this.show_weekends}
-                  start_hour={_this.start_hour}
-                  end_hour={_this.end_hour}
-                  allow_date_change={false}
-                  partial_bookable_ratio="0"
-                  show_header={false}
-                  date_format={_this.show_as_week || _this.show_weekends
-                    ? "weekday"
-                    : "none"}
-                  busy_color="#000"
-                  closed_color="#999"
-                  selected_color="#095"
-                  slot_size="15"
-                  on:timeSlotChosen={availabilityChosen} />
+            {/if}
+            {#if fieldIsEditable(SectionNames.TIME_DATE_DETAILS, "available_hours")}
+              <div class="available-hours">
+                <strong>Available Hours</strong>
+                <p>
+                  Drag over the hours want to be availble for booking. All other
+                  hours will always show up as "busy" to your users.
+                </p>
+                <div role="checkbox" aria-labelledby="show_as_week">
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="_this.show_as_week"
+                      bind:checked={_this.show_as_week} />
+                    Customize each weekday
+                  </label>
+                </div>
+                <div role="checkbox" aria-labelledby="show_as_week">
+                  <label>
+                    <input
+                      type="checkbox"
+                      name=" _this.show_weekends"
+                      bind:checked={_this.show_weekends} />
+                    Allow booking on weekends
+                  </label>
+                </div>
+                <div class="availability-container">
+                  <nylas-availability
+                    allow_booking={true}
+                    show_as_week={_this.show_as_week || _this.show_weekends}
+                    show_weekends={_this.show_weekends}
+                    start_hour={_this.start_hour}
+                    end_hour={_this.end_hour}
+                    allow_date_change={false}
+                    partial_bookable_ratio="0"
+                    show_header={false}
+                    date_format={_this.show_as_week || _this.show_weekends
+                      ? "weekday"
+                      : "none"}
+                    busy_color="#000"
+                    closed_color="#999"
+                    selected_color="#095"
+                    slot_size="15"
+                    on:timeSlotChosen={availabilityChosen} />
+                </div>
+                <ul class="availability">
+                  {#each _this.open_hours || [] as availability}
+                    <li>
+                      <span class="date">
+                        {niceDate(availability)}
+                      </span>
+                    </li>
+                  {/each}
+                </ul>
               </div>
-              <ul class="availability">
-                {#each _this.open_hours || [] as availability}
-                  <li>
-                    <span class="date">
-                      {niceDate(availability)}
-                    </span>
-                  </li>
-                {/each}
-              </ul>
-            </div>
+            {/if}
           </div>
           <footer slot="footer">
             <button on:click={saveProperties}>Save Editor Options</button>
@@ -803,33 +813,27 @@
                 </label>
               </div>
             {/if}
-            <div role="radiogroup" aria-labelledby="view_as">
-              <strong id="view_as">View as a Schedule, or as a List?</strong>
-              <label>
-                <input
-                  type="radio"
-                  name="view_as"
-                  bind:group={_this.view_as}
-                  value="schedule" />
-                <span>Schedule</span>
-              </label>
-              <label>
-                <input
-                  type="radio"
-                  name="view_as"
-                  bind:group={_this.view_as}
-                  value="list" />
-                <span>List</span>
-              </label>
-            </div>
-            <label>
-              <strong>Attendees to show</strong>
-              <input
-                type="number"
-                min={1}
-                max={20}
-                bind:value={_this.attendees_to_show} />
-            </label>
+            {#if fieldIsEditable(SectionNames.STYLE_DETAILS, "view_as_schedule")}
+              <div role="radiogroup" aria-labelledby="view_as">
+                <strong id="view_as">View as a Schedule, or as a List?</strong>
+                <label>
+                  <input
+                    type="radio"
+                    name="view_as"
+                    bind:group={_this.view_as}
+                    value="schedule" />
+                  <span>Schedule</span>
+                </label>
+                <label>
+                  <input
+                    type="radio"
+                    name="view_as"
+                    bind:group={_this.view_as}
+                    value="list" />
+                  <span>List</span>
+                </label>
+              </div>
+            {/if}
           </div>
           <footer slot="footer">
             <button on:click={saveProperties}>Save Editor Options</button>

--- a/components/schedule-editor/src/index.html
+++ b/components/schedule-editor/src/index.html
@@ -21,34 +21,42 @@
         // which start as expanded by default, and which specific questions to hide.
         // <3, Nylas
 
-        // let sectionConfig = {
-        //   "basic-details": {
-        //     expanded: false,
-        //     editable: true,
-        //   },
-        //   "time-date-details": {
-        //     expanded: true,
-        //     editable: true,
-        //   },
-        //   "style-details": {
-        //     expanded: false,
-        //     editable: true,
-        //   },
-        //   "booking-details": {
-        //     expanded: true,
-        //     editable: true,
-        //   },
-        //   "custom-fields": {
-        //     expanded: false,
-        //     editable: true,
-        //   },
-        //   "notification-details": {
-        //     expanded: false,
-        //     editable: true,
-        //   }
-        // }
+        let sectionConfig = {
+          // "basic-details": {
+          //   expanded: false,
+          //   editable: true,
+          // },
+          "time-date-details": {
+            expanded: true,
+            editable: true,
+            hidden_fields: [
+              "available_hours",
+              "time_zone",
+              "days_to_show",
+              "show_weekends",
+              "show_as_week",
+            ],
+          },
+          "style-details": {
+            expanded: true,
+            editable: true,
+            hidden_fields: ["show_ticks"],
+          },
+          // "booking-details": {
+          //   expanded: true,
+          //   editable: true,
+          // },
+          // "custom-fields": {
+          //   expanded: false,
+          //   editable: true,
+          // },
+          // "notification-details": {
+          //   expanded: false,
+          //   editable: true,
+          // }
+        };
 
-        // component.sections = sectionConfig;
+        component.sections = sectionConfig;
       });
     </script>
   </head>

--- a/components/schedule-editor/src/index.html
+++ b/components/schedule-editor/src/index.html
@@ -21,48 +21,34 @@
         // which start as expanded by default, and which specific questions to hide.
         // <3, Nylas
 
-        let sectionConfig = {
-          "basic-details": {
-            expanded: true,
-            editable: true,
-            hidden_fields: [
-              "event_location",
-              "participants",
-              "meeting_length",
-              "conferencing_link",
-            ],
-          },
-          "time-date-details": {
-            expanded: true,
-            editable: true,
-            hidden_fields: [
-              "available_hours",
-              "time_zone",
-              "days_to_show",
-              "show_weekends",
-              "show_as_week",
-            ],
-          },
-          "style-details": {
-            expanded: true,
-            editable: true,
-            hidden_fields: ["show_ticks"],
-          },
-          // "booking-details": {
-          //   expanded: true,
-          //   editable: true,
-          // },
-          // "custom-fields": {
-          //   expanded: false,
-          //   editable: true,
-          // },
-          // "notification-details": {
-          //   expanded: false,
-          //   editable: true,
-          // }
-        };
+        // let sectionConfig = {
+        //   "event-details": {
+        //     expanded: false,
+        //     editable: true,
+        //   },
+        //   "time-date-details": {
+        //     expanded: true,
+        //     editable: true,
+        //   },
+        //   "style-details": {
+        //     expanded: false,
+        //     editable: true,
+        //   },
+        //   "booking-details": {
+        //     expanded: true,
+        //     editable: true,
+        //   },
+        //   "custom-fields": {
+        //     expanded: false,
+        //     editable: true,
+        //   },
+        //   "notification-details": {
+        //     expanded: false,
+        //     editable: true,
+        //   }
+        // }
 
-        component.sections = sectionConfig;
+        // component.sections = sectionConfig;
       });
     </script>
   </head>

--- a/components/schedule-editor/src/index.html
+++ b/components/schedule-editor/src/index.html
@@ -22,10 +22,16 @@
         // <3, Nylas
 
         let sectionConfig = {
-          // "basic-details": {
-          //   expanded: false,
-          //   editable: true,
-          // },
+          "basic-details": {
+            expanded: true,
+            editable: true,
+            hidden_fields: [
+              "event_location",
+              "participants",
+              "meeting_length",
+              "conferencing_link",
+            ],
+          },
           "time-date-details": {
             expanded: true,
             editable: true,

--- a/components/schedule-editor/src/init.spec.js
+++ b/components/schedule-editor/src/init.spec.js
@@ -139,4 +139,35 @@ describe("Editable Sections", () => {
         .should("have.length", 2);
     });
   });
+
+  it("Allows specific fields to be hidden", () => {
+    const sectionConfigWithHiddenFields = {
+      "style-details": {
+        expanded: true,
+        editable: true,
+        hidden_fields: ["show_ticks"],
+      },
+      "booking-details": {
+        expanded: false,
+        editable: true,
+      },
+    };
+
+    cy.get(testScheduleEditor).then((element) => {
+      const component = element[0];
+      component.sections = sectionConfigWithHiddenFields;
+      cy.get("nylas-schedule-editor-section")
+        .eq(0)
+        .shadow()
+        .get(".contents")
+        .children()
+        .should("contain", "View as a Schedule");
+      cy.get("nylas-schedule-editor-section")
+        .eq(0)
+        .shadow()
+        .get(".contents")
+        .children()
+        .should("not.contain", "Show ticks");
+    });
+  });
 });

--- a/components/schedule-editor/src/init.spec.js
+++ b/components/schedule-editor/src/init.spec.js
@@ -20,12 +20,12 @@ describe("schedule-editor component", () => {
   describe("Allows for multiple meetings", () => {
     it("Allows the user to add consecutive meetings", () => {
       cy.get("button.add-event").click();
-      cy.get(".basic-details fieldset").should("have.length", 3);
+      cy.get(".event-details fieldset").should("have.length", 3);
       cy.get("button.add-event").click();
-      cy.get(".basic-details fieldset").should("have.length", 4);
+      cy.get(".event-details fieldset").should("have.length", 4);
       cy.get("button.remove-event").eq(0).click();
       cy.get("button.remove-event").eq(0).click();
-      cy.get(".basic-details fieldset").should("have.length", 2);
+      cy.get(".event-details fieldset").should("have.length", 2);
     });
   });
 });
@@ -41,7 +41,7 @@ describe("Editable Sections", () => {
 
   it("Allows a custom section to be expanded", () => {
     const sectionConfig = {
-      "basic-details": {
+      "event-details": {
         expanded: false,
         editable: true,
       },

--- a/components/schedule-editor/src/styles/schedule-editor.scss
+++ b/components/schedule-editor/src/styles/schedule-editor.scss
@@ -56,10 +56,11 @@ main {
         table {
           border-bottom: 1px solid rgba(0, 0, 0, 0.25);
           grid-column: span 2;
-  
+
           tr.disabled {
             opacity: 0.6;
-            pointer-events: none;cursor: not-allowed;
+            pointer-events: none;
+            cursor: not-allowed;
           }
 
           th,
@@ -114,11 +115,11 @@ main {
                 align-items: center;
                 padding: 0.5rem;
                 background-color: transparent;
-              
+
                 &svg:nth-last-of-type(1) {
                   margin-left: 0.5rem;
                 }
-              
+
                 &:hover {
                   cursor: pointer;
                 }
@@ -129,7 +130,7 @@ main {
                 color: var(--blue);
                 font-size: 16px;
                 font-weight: normal;
-    
+
                 span {
                   margin-left: 0.5rem;
                 }
@@ -227,12 +228,16 @@ main {
               select {
                 -moz-appearance: none;
                 -webkit-appearance: none;
-    
+
                 &::-ms-expand {
                   display: none;
                 }
-    
-                background-image: linear-gradient(45deg, transparent 50%, black 50%),
+
+                background-image: linear-gradient(
+                    45deg,
+                    transparent 50%,
+                    black 50%
+                  ),
                   linear-gradient(135deg, black 50%, transparent 50%);
                 background-position: calc(100% - 20px) calc(1em + 4px),
                   calc(100% - 15px) calc(1em + 4px), calc(100% - 2.5em) 0.5em;
@@ -296,7 +301,7 @@ main {
           grid-column: -1 / 1;
         }
 
-        &.basic-details {
+        &.event-details {
           grid-template-columns: 1fr;
           & > fieldset {
             border: none;
@@ -351,7 +356,6 @@ main {
     cursor: col-resize;
   }
 }
-
 
 .warning {
   background-color: var(--red-lighter);


### PR DESCRIPTION
Allows a user to modify which questions within a `<nylas-schedule-editor>` section are editable/visible to a user setting up their booking component.

You can configure these in the same way that #409 introduces, so for example to disallow an a user from modifying the event notification subject/message, you could do the following:

```
      let sectionConfig = {
        "event-details": {
        },
        "time-date-details": {
        },
        "style-details": {
        },
        "booking-details": {
        },
        "custom-fields": {
        },
        "notification-details": {
          expanded: true,
          editable: true,
          hidden_fields: ["notification_message", "notification_subject"]
        }
      }

```
![image](https://user-images.githubusercontent.com/713991/157494012-7fe77a66-852d-4ab4-ba0f-992585cec780.png)

where if you didn't have those hidden fields,

```
      let sectionConfig = {
        "event-details": {
        },
        "time-date-details": {
        },
        "style-details": {
        },
        "booking-details": {
        },
        "custom-fields": {
        },
        "notification-details": {
          expanded: true,
          editable: true,
        }
      }
```

You'd see all 3 notification-related fields: 
![image](https://user-images.githubusercontent.com/713991/157494187-8c8f2daa-187b-4fc2-90c5-2a853d2b87ab.png)



## Current taxonomy of fields that can be hidden:

```
EVENT_DETAILS
  "event_title"
  "event_description"
  "event_location"
  "conferencing_link"
  "meeting_length"
  "participants"

TIME_DATE_DETAILS
  "start_hour"
  "end_hour"
  "start_date"
  "time_zone"
  "days_to_show"
  "show_as_week"
  "show_weekends"
  "available_hours"

STYLE_DETAILS
  "show_ticks"
  "view_as_schedule"

BOOKING_DETAILS
  "allow_booking"
  "maximum_slots"
  "screen_bookings"
  "bookable_ratio"
  "recurrence"
  "capacity"
  "mandate_top_of_hour"

NOTIFICATION_DETAILS
  "notification_mode"
  "notification_message"
  "notification_subject"
```


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
