### PR TITLE
Fixed draft deleting in Gmail with Label id

### DIFF
--- a/commons/src/connections/messages.ts
+++ b/commons/src/connections/messages.ts
@@ -43,7 +43,7 @@ export async function updateMessage(
     method: "PUT",
     component_id,
     access_token,
-    body: { folder_id: message.folder_id },
+    body: { folder_id: message.folder_id, label_ids: message.label_ids },
   });
   return await fetch(url, fetchConfig)
     .then((response) =>

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -534,6 +534,7 @@
         const existingLabelIds =
           thread.labels?.map((label: any) => label.id) || [];
         thread.label_ids = [...existingLabelIds, trashLabelID];
+        await updateThreadStatus(thread);
 
         /**
          * Nylas thread update API does not update label of the drafts in thread currently
@@ -541,16 +542,15 @@
          **/
         const allDrafts = [...thread.drafts];
         for (let draft of allDrafts) {
+          const draftLabels = draft.labels?.map((label: any) => label.id) || [];
           await updateMessage(
             query.component_id,
-            { ...draft, label_ids: [...existingLabelIds, trashLabelID] },
+            { ...draft, label_ids: [...draftLabels, trashLabelID] },
             access_token,
           ).catch((err) => {
             silence(err);
           });
         }
-
-        await updateThreadStatus(thread);
       } else if (trashFolderID) {
         thread.folder_id = trashFolderID;
         /**

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -534,6 +534,22 @@
         const existingLabelIds =
           thread.labels?.map((label: any) => label.id) || [];
         thread.label_ids = [...existingLabelIds, trashLabelID];
+
+        /**
+         * Nylas thread update API does not update label of the drafts in thread currently
+         * As a workaround, any drafts in thread needs to be deleted individually
+         **/
+        const allDrafts = [...thread.drafts];
+        for (let draft of allDrafts) {
+          await updateMessage(
+            query.component_id,
+            { ...draft, label_ids: [...existingLabelIds, trashLabelID] },
+            access_token,
+          ).catch((err) => {
+            silence(err);
+          });
+        }
+
         await updateThreadStatus(thread);
       } else if (trashFolderID) {
         thread.folder_id = trashFolderID;

--- a/components/mailbox/src/index.html
+++ b/components/mailbox/src/index.html
@@ -93,17 +93,13 @@
   </head>
 
   <body>
-    <nylas-mailbox
-      id="demo-mailbox"
-      header="Mailbox"
-      show_star="true"
-    ></nylas-mailbox>
+    <nylas-mailbox id="demo-mailbox" header="Mailbox" show_star="true">
+    </nylas-mailbox>
     <nylas-composer
       id="demo-composer"
       show_header="true"
       show_subject="true"
-      hidden=""
-    >
+      hidden="">
     </nylas-composer>
   </body>
 </html>


### PR DESCRIPTION
# Code changes
- Nylas thread update API does not update label of the drafts in thread currently
- [x] As a workaround, any drafts in thread needs to be deleted individually

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
