### PR TITLE
Update draft icon on thread when saving new draft

### DIFF
--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -898,10 +898,7 @@
   }
 
   function isThreadADraftEmail(currentThread: Thread): boolean {
-    return (
-      currentThread &&
-      currentThread.labels?.some((label) => label.name === MessageType.DRAFTS)
-    );
+    return currentThread && currentThread.drafts?.length > 0;
   }
 
   let latestMessageNode: HTMLElement | null = null;
@@ -2027,9 +2024,12 @@
                 {/if}
                 <div class="from-message-count">
                   {#if _this.show_contact_avatar}
-                    <div class="default-avatar" class:deleted={isDeleted}>
+                    <div
+                      class="default-avatar"
+                      class:deleted={isDeleted}
+                      class:draft-icon={isDraft}>
                       {#if activeThread}
-                        {#if isDraft && activeThread.drafts.length > 0}
+                        {#if isDraft}
                           <DraftIcon />
                         {:else if activeThread.messages.length <= 0}
                           <NoMessagesIcon />

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -260,6 +260,8 @@
   }
   export async function draftMessageUpdate(message: Message): Promise<void> {
     threads = MailboxStore.hydrateDraftInThread(message, query, currentPage);
+    const updatedThread = threads.find((t) => t.id === message.thread_id);
+    currentlySelectedThread.drafts = updatedThread.drafts;
   }
 
   //#region actions

--- a/cypress/fixtures/mailbox/threads/threadRegular.json
+++ b/cypress/fixtures/mailbox/threads/threadRegular.json
@@ -1,0 +1,96 @@
+{
+  "component": {
+    "theming": {
+      "items_per_page": 13,
+      "show_thread_checkbox": true,
+      "actions_bar": ["selectall", "star", "delete", "unread"],
+      "show_star": false,
+      "header": "",
+      "unread_status": "default",
+      "keyword_to_search": "",
+      "query_string": "in=inbox"
+    }
+  },
+  "response": [
+    {
+      "account_id": "1xrddnl99frq3b7son9j32aba",
+      "drafts": [],
+      "first_message_timestamp": 1645138023,
+      "has_attachments": false,
+      "id": "c6h7xdze9tod0p03v8wkb01nf",
+      "labels": [
+        {
+          "display_name": "INBOX",
+          "id": "dx62wkpj57erbkargbr3zew3j",
+          "name": "inbox"
+        },
+        {
+          "display_name": "IMPORTANT",
+          "id": "5852fv5ompdk51g0ve17mvej9",
+          "name": "important"
+        }
+      ],
+      "last_message_received_timestamp": 1645138169,
+      "last_message_sent_timestamp": 1645138023,
+      "last_message_timestamp": 1645139358,
+      "last_updated_timestamp": 1645142972,
+      "messages": [
+        {
+          "account_id": "1xrddnl99frq3b7son9j32aba",
+          "bcc": [],
+          "cc": [],
+          "date": 1645138023,
+          "files": [],
+          "from": [
+            {
+              "email": "nylascypresstest+test@gmail.com",
+              "name": "Test Email"
+            }
+          ],
+          "id": "message-id-1",
+          "labels": [
+            {
+              "display_name": "INBOX",
+              "id": "dx62wkpj57erbkargbr3zew3j",
+              "name": "inbox"
+            },
+            {
+              "display_name": "IMPORTANT",
+              "id": "5852fv5ompdk51g0ve17mvej9",
+              "name": "important"
+            }
+          ],
+          "object": "message",
+          "reply_to": [],
+          "snippet": "This is the first message sent by me.",
+          "starred": false,
+          "subject": "Regular Thread Test Subject",
+          "thread_id": "c6h7xdze9tod0p03v8wkb01nf",
+          "to": [
+            {
+              "email": "test-email@email.com",
+              "name": "Test User"
+            }
+          ],
+          "unread": false
+        }
+      ],
+      "object": "thread",
+      "participants": [
+        {
+          "email": "nylascypresstest+test@gmail.com",
+          "name": "Test Email"
+        },
+        {
+          "email": "test-email@email.com",
+          "name": "Test User"
+        }
+      ],
+      "snippet": "This is the first message sent by me.",
+      "starred": false,
+      "subject": "Regular Thread Test Subject",
+      "unread": false,
+      "version": 0
+    }
+  ]
+}


### PR DESCRIPTION
# Code changes

- [x] Updates logic of how Email component detect if a thread is draft
- [x] Fetch updated thread when draft is saved in the thread

# Screen record
https://user-images.githubusercontent.com/14408339/159306237-27848f51-6986-412f-a4eb-fdbdddd48a3b.mov

# Readiness checklist

- [x] Cypress tests passing?
- [x] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
