### PR TITLE
Fix Mailbox/Composer event dispatch problem

### DIFF
--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -564,7 +564,11 @@
       (draft) => draft.reply_to_message_id === message.id,
     );
     if (existingDraft) {
-      value.body = existingDraft.body;
+      if (!_this.thread && existingDraft.id) {
+        const res = await fetchIndividualMessage(existingDraft.id);
+        existingDraft.body = res.body;
+        value.body = res.body;
+      }
       dispatchEvent(event_identifier, {
         event,
         message: { ...existingDraft, subject, to, cc },
@@ -594,7 +598,11 @@
       body: message.body,
     };
     if (existingDraft) {
-      value.body = existingDraft.body;
+      if (!_this.thread && existingDraft.id) {
+        const res = await fetchIndividualMessage(existingDraft.id);
+        existingDraft.body = res.body;
+        value.body = res.body;
+      }
       dispatchEvent("forwardClicked", {
         event,
         message: { ...existingDraft, subject },
@@ -699,24 +707,24 @@
     }
   }
 
-  function dispatchDraftClickEvent(event: UIEvent, draft: Message) {
+  async function dispatchDraftClickEvent(event: UIEvent, draft: Message) {
     if (draft) {
       draft.draft_id = draft.id;
       activeThread?.drafts?.forEach(
         (threadDraft) => (threadDraft.active = threadDraft.id === draft.id),
       );
+
+      // Don't fetch message body when thread is being passed manually
+      if (!_this.thread && draft.id) {
+        const res = await fetchIndividualMessage(draft.id);
+        draft.body = res.body;
+      }
+
       dispatchEvent("draftClicked", {
         event,
         message: draft,
         thread: activeThread,
       });
-
-      // Don't fetch message body when thread is being passed manually
-      if (!_this.thread && draft.id) {
-        fetchIndividualMessage(draft.id).then((res) => {
-          draft.body = res.body;
-        });
-      }
     }
   }
 

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -537,6 +537,16 @@
     const subject = message.subject?.toLowerCase().startsWith("re:")
       ? message.subject
       : `Re: ${message.subject}`;
+    const value = {
+      reply_to_message_id: message.id,
+      from,
+      to,
+      reply_to: from,
+      cc,
+      bcc: message.bcc,
+      body: message.body,
+      subject: subject,
+    };
 
     let event_identifier;
     switch (type) {
@@ -554,30 +564,18 @@
       (draft) => draft.reply_to_message_id === message.id,
     );
     if (existingDraft) {
-      existingDraft.to = to;
-      existingDraft.cc = cc;
-      existingDraft.subject = subject;
+      value.body = existingDraft.body;
       dispatchEvent(event_identifier, {
         event,
-        message: existingDraft,
+        message: { ...existingDraft, subject, to, cc },
         thread: activeThread,
+        value,
       });
     } else {
       //Creating new reply message
-      const value = {
-        reply_to_message_id: message.id,
-        from,
-        to,
-        reply_to: from,
-        cc,
-        bcc: message.bcc,
-        body: message.body,
-        subject: subject,
-      };
-
       dispatchEvent(event_identifier, {
         event,
-        message: message,
+        message: { ...message, subject, to, cc },
         thread: activeThread,
         value,
       });
@@ -590,12 +588,18 @@
       (draft) => draft.reply_to_message_id === message.id,
     );
     const subject = `Fwd: ${message.subject}`;
+    const value = {
+      reply_to_message_id: message.id,
+      subject: subject,
+      body: message.body,
+    };
     if (existingDraft) {
-      existingDraft.subject = subject;
+      value.body = existingDraft.body;
       dispatchEvent("forwardClicked", {
         event,
-        message: existingDraft,
+        message: { ...existingDraft, subject },
         thread: activeThread,
+        value,
       });
     } else {
       //Create new message
@@ -603,6 +607,7 @@
         event,
         message: { ...message, subject },
         thread: activeThread,
+        value,
       });
     }
   }

--- a/components/mailbox/CHANGELOG.md
+++ b/components/mailbox/CHANGELOG.md
@@ -29,6 +29,8 @@
 - [Mailbox] Added new prop 'thread_click_action' that allows to specify the action on clicking an email thread [#369](https://github.com/nylas/components/pull/369)
 - View/save/send draft messages in email thread [#399](https://github.com/nylas/components/pull/399)
 - Added `draft` label an email thread [#403](https://github.com/nylas/components/pull/403)
+- Removed `event.detail.value` from custom events `draftThreadClicked`, `replyClicked`, `replyAllClicked`, `forwardClicked` and `draftClicked`, message value will be passed by `event.detail.message`. [#417](https://github.com/nylas/components/pull/417)
+- Deprecated `draftThreadEvent` event and renamed it to `draftThreadClicked`. [#417](https://github.com/nylas/components/pull/417)
 
 ## Bug Fixes
 

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -646,19 +646,32 @@
     }
     draftMessageUpdate(message);
 
+    const value = {
+      to: message.to,
+      cc: message.cc,
+      bcc: message.bcc,
+      from: message.from,
+      subject: message.subject,
+      body: message.body,
+    };
     dispatchEvent("draftThreadClicked", {
       event,
       message,
       thread,
+      value,
     });
 
     //Deprecated: DO NOT USE draftThreadEvent
+    console.warn(
+      "draftThreadEvent is Deprecated and will be removed in a future stable release; Please use draftThreadClicked instead",
+    );
     dispatchEvent("draftThreadEvent", {
       warning:
         "draftThreadEvent is Deprecated and will be removed in a future stable release; Please use draftThreadClicked instead.",
       event,
       message,
       thread,
+      value,
     });
   }
 </script>

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -261,7 +261,9 @@
   export async function draftMessageUpdate(message: Message): Promise<void> {
     threads = MailboxStore.hydrateDraftInThread(message, query, currentPage);
     const updatedThread = threads.find((t) => t.id === message.thread_id);
-    currentlySelectedThread.drafts = updatedThread.drafts;
+    if (currentlySelectedThread) {
+      currentlySelectedThread.drafts = updatedThread.drafts;
+    }
   }
 
   //#region actions

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -308,6 +308,7 @@
 
   async function handleEmailDraftOpened(event: CustomEvent) {
     let draft = event.detail.message;
+    const value = event.detail.value;
 
     //Fetch draft body for draft in email
     if (
@@ -320,6 +321,9 @@
       }
       if (FilesStore.hasInlineFiles(draft)) {
         draft = await getMessageWithInlineFiles(draft);
+      }
+      if (value) {
+        value.body = draft.body;
       }
       draftMessageUpdate(draft);
     }

--- a/components/mailbox/src/index.html
+++ b/components/mailbox/src/index.html
@@ -20,10 +20,9 @@
     </style>
     <script type="module">
       function toggleComposer(event, component, type) {
-        console.log(type, event.detail);
         component.removeAttribute("hidden");
         component.value = event.detail.value;
-        component.focus_body_onload = event.detail.focus_body_onload;
+        component.focus_body_onload = true;
         if (Object.keys(event.detail.message).length) {
           component.value = {
             ...event.detail.message,
@@ -67,21 +66,24 @@
           mailbox.sentMessageUpdate(message);
         });
 
-        const events = [
+        const mailboxEvents = [
           "replyClicked",
           "replyAllClicked",
           "forwardClicked",
-          "draftThreadEvent",
+          "draftThreadClicked",
+          "draftClicked",
         ];
-        events.forEach((eventType) =>
-          mailbox.addEventListener(eventType, (e) =>
-            toggleComposer(e, composer, eventType),
-          ),
+        mailboxEvents.forEach((eventType) =>
+          mailbox.addEventListener(eventType, (event) => {
+            console.log(eventType, { ...event.detail });
+            toggleComposer(event, composer, eventType);
+          }),
         );
 
-        const draftEvents = ["composerClosed", "draftUpdated", "draftSaved"];
-        draftEvents.forEach((eventType) =>
+        const composerEvents = ["composerClosed", "draftUpdated", "draftSaved"];
+        composerEvents.forEach((eventType) =>
           composer.addEventListener(eventType, (event) => {
+            console.log(eventType, { ...event.detail });
             const message = event.detail.message;
             if (message.object === "draft") {
               mailbox.draftMessageUpdate(message);

--- a/components/mailbox/src/index.html
+++ b/components/mailbox/src/index.html
@@ -25,8 +25,8 @@
         component.focus_body_onload = true;
         if (Object.keys(event.detail.message).length) {
           component.value = {
-            ...event.detail.message,
             ...component.value,
+            ...event.detail.message,
           };
         }
         component.open();

--- a/cypress/fixtures/mailbox/messages/messageForDraftThread.json
+++ b/cypress/fixtures/mailbox/messages/messageForDraftThread.json
@@ -19,7 +19,12 @@
     "date": 1634858431,
     "events": [],
     "files": [],
-    "from": [{ "email": "test-email@email.com", "name": "Test User" }],
+    "from": [
+      {
+        "email": "nylascypresstest+drafttest@gmail.com",
+        "name": "draft test"
+      }
+    ],
     "id": "message-id-1",
     "labels": [
       {
@@ -35,7 +40,14 @@
     "subject": "Test Draft Messages In Thread",
     "thread_id": "c6h7xdze9tod0p03v8wkb01nf",
     "to": [
-      { "email": "nylascypresstest+drafttest@gmail.com", "name": "draft test" }
+      {
+        "email": "test-email@email.com",
+        "name": "Test User"
+      },
+      {
+        "email": "nylascypresstest+drafttest2@gmail.com",
+        "name": "draft test2"
+      }
     ],
     "unread": false
   }

--- a/cypress/fixtures/mailbox/threads/threadWithDraft.json
+++ b/cypress/fixtures/mailbox/threads/threadWithDraft.json
@@ -144,8 +144,8 @@
           "files": [],
           "from": [
             {
-              "email": "test-email@email.com",
-              "name": "Test User"
+              "email": "nylascypresstest+drafttest@gmail.com",
+              "name": "draft test"
             }
           ],
           "id": "message-id-1",
@@ -164,8 +164,12 @@
           "thread_id": "c6h7xdze9tod0p03v8wkb01nf",
           "to": [
             {
-              "email": "nylascypresstest+drafttest@gmail.com",
-              "name": "draft test"
+              "email": "test-email@email.com",
+              "name": "Test User"
+            },
+            {
+              "email": "nylascypresstest+drafttest2@gmail.com",
+              "name": "draft test2"
             }
           ],
           "unread": false
@@ -180,6 +184,10 @@
         {
           "email": "test-email@email.com",
           "name": "Test User"
+        },
+        {
+          "email": "nylascypresstest+drafttest2@gmail.com",
+          "name": "draft test2"
         }
       ],
       "snippet": "This is the second message sent back to me.",


### PR DESCRIPTION
# Code changes

- [x] Fixed problem that when a draft message (within a thread) is clicked, the draftThreadEvent event is fired.
- [x] Fixed problem that the`replyClicked`, `replyAllClicked` and  `forwardClicked` event is not fired if a draft message is toggled open.
- [x] Deprecated `draftThreadEvent` and rename it to `draftThreadClicked`
- [x] Renamed several functions in Mailbox/Email to better suit their purposes.

# Readiness checklist
- [x] CHANGELOG.md updated?
- [x] Cypress tests passing?
- [x] New cypress tests added?

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
