### PR TITLE
[availability] Grey-out unavailable timeslots and prevent navigating to previous dates

### DIFF
--- a/commons/src/types/Availability.ts
+++ b/commons/src/types/Availability.ts
@@ -46,6 +46,7 @@ export interface Manifest extends NylasManifest {
   start_hour: number;
   view_as: "schedule" | "list";
   timezone: string;
+  unavailable_color: string;
   events: EventDefinition[];
 }
 

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -100,6 +100,7 @@
   export let start_hour: number;
   export let timezone: string;
   export let view_as: "schedule" | "list";
+  export let unavailable_color: string;
   export let events: EventDefinition[];
 
   const defaultValueMap: Partial<Manifest> = {
@@ -133,6 +134,7 @@
     start_hour: 0,
     timezone: "",
     view_as: "schedule",
+    unavailable_color: "#DDD",
     events: [],
   };
 
@@ -326,6 +328,17 @@
       : timeDay.floor(_this.start_date);
 
   $: endDay = dayRange[dayRange.length - 1];
+
+  let maxBookAheadOffset: string;
+  let minBookAheadOffset: string;
+
+  $: maxBookAheadOffset = timeDay
+    .offset(new Date(), _this.max_book_ahead_days)
+    .toLocaleDateString();
+
+  $: minBookAheadOffset = timeDay
+    .offset(new Date(), _this.min_book_ahead_days)
+    .toLocaleDateString();
 
   let ticks: Date[] = [];
 
@@ -1137,14 +1150,13 @@
     --selected-color-lightened: {lightenHexColour(_this.selected_color, 60)};
     --free-color: {_this.free_color}; --busy-color: {_this.busy_color};
     --closed-color: {_this.closed_color}; --partial-color: {_this.partial_color};
-    --selected-color: {_this.selected_color};">
+    --selected-color: {_this.selected_color};
+    --unavailable-color: {_this.unavailable_color}">
     <header class:dated={_this.allow_date_change}>
       <h2 class="month">{showDateRange(days)}</h2>
       {#if _this.allow_date_change}
         <div class="change-dates">
-          {#if !dayOrder.includes(timeDay
-              .offset(new Date(), _this.min_book_ahead_days)
-              .toLocaleDateString())}
+          {#if !dayOrder.includes(minBookAheadOffset)}
             <button on:click={goToPreviousDate} aria-label="Previous date">
               <BackIcon style="height:32px;width:32px;" />
             </button>
@@ -1152,9 +1164,7 @@
             <span />
           {/if}
 
-          {#if !dayOrder.includes(timeDay
-              .offset(new Date(), _this.max_book_ahead_days)
-              .toLocaleDateString())}
+          {#if !dayOrder.includes(maxBookAheadOffset)}
             <button on:click={goToNextDate} aria-label="Next date">
               <NextIcon style="height:32px;width:32px;" />
             </button>
@@ -1265,11 +1275,7 @@
                   class:outside-of-time-range={!slot.fallsWithinAllowedTimeRange}
                   title={slot.fallsWithinAllowedTimeRange
                     ? null
-                    : `You may only select timeslots in the future, between ${timeDay
-                        .offset(new Date(), _this.min_book_ahead_days)
-                        .toLocaleDateString()} and ${timeDay
-                        .offset(new Date(), _this.max_book_ahead_days)
-                        .toLocaleDateString()}`}
+                    : `You may only select timeslots in the future, between ${minBookAheadOffset} and ${maxBookAheadOffset}`}
                   on:click={() => {
                     handleSlotInteractionStart(slot);
                   }}

--- a/components/availability/src/Availability.svelte
+++ b/components/availability/src/Availability.svelte
@@ -9,7 +9,6 @@
   import {
     ManifestStore,
     AvailabilityStore,
-    CalendarStore,
     ErrorStore,
     ConsecutiveAvailabilityStore,
   } from "../../../commons/src";
@@ -32,7 +31,6 @@
   } from "@commons/enums/Availability";
 
   import type {
-    Calendar,
     Manifest,
     TimeSlot,
     SelectableSlot,
@@ -1136,20 +1134,33 @@
     style="
     --busy-color-lightened: {lightenHexColour(_this.busy_color, 90)};
     --closed-color-lightened: {lightenHexColour(_this.closed_color, 90)};
-    --selected-color-lightened: {lightenHexColour(_this.selected_color, 60)}; 
-    --free-color: {_this.free_color}; --busy-color: {_this.busy_color}; 
+    --selected-color-lightened: {lightenHexColour(_this.selected_color, 60)};
+    --free-color: {_this.free_color}; --busy-color: {_this.busy_color};
     --closed-color: {_this.closed_color}; --partial-color: {_this.partial_color};
     --selected-color: {_this.selected_color};">
     <header class:dated={_this.allow_date_change}>
       <h2 class="month">{showDateRange(days)}</h2>
       {#if _this.allow_date_change}
         <div class="change-dates">
-          <button on:click={goToPreviousDate} aria-label="Previous date">
-            <BackIcon style="height:32px;width:32px;" />
-          </button>
-          <button on:click={goToNextDate} aria-label="Next date">
-            <NextIcon style="height:32px;width:32px;" />
-          </button>
+          {#if !dayOrder.includes(timeDay
+              .offset(new Date(), _this.min_book_ahead_days)
+              .toLocaleDateString())}
+            <button on:click={goToPreviousDate} aria-label="Previous date">
+              <BackIcon style="height:32px;width:32px;" />
+            </button>
+          {:else}
+            <span />
+          {/if}
+
+          {#if !dayOrder.includes(timeDay
+              .offset(new Date(), _this.max_book_ahead_days)
+              .toLocaleDateString())}
+            <button on:click={goToNextDate} aria-label="Next date">
+              <NextIcon style="height:32px;width:32px;" />
+            </button>
+          {:else}
+            <span />
+          {/if}
         </div>
       {/if}
       <div class="legend">

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -27,9 +27,6 @@
         // component.availability = availability;
         // component.booking_options = booking_options;
 
-        component.max_book_ahead_days = 0;
-        setTimeout(() => (component.max_book_ahead_days = 1), 5000);
-
         component.addEventListener("dateChange", (event) => {
           console.log("date change", event.detail.dates);
         });
@@ -430,13 +427,6 @@
         <label>
           <input type="radio" name="show-header" value="false" />
           False
-        </label>
-      </fieldset>
-
-      <fieldset>
-        <label>
-          Max Bookable Slots
-          <input type="number" name="max-slots" min="1" value="1" />
         </label>
       </fieldset>
 

--- a/components/availability/src/index.html
+++ b/components/availability/src/index.html
@@ -558,6 +558,14 @@
             value="#EE3248" />
           Closed color
         </label>
+        <label>
+          <input
+            type="color"
+            name="color-unavailable"
+            data-type="unavailable_color"
+            value="#DDDDDD" />
+          Unavailable color
+        </label>
       </fieldset>
       <fieldset>
         <legend>View As</legend>

--- a/components/availability/src/styles/availability.scss
+++ b/components/availability/src/styles/availability.scss
@@ -305,8 +305,6 @@ main {
       list-style-type: none;
       margin: 0;
       padding: 0;
-      border: 1px solid rgba(0, 0, 0, 0.1);
-      border-bottom: none;
 
       .slot {
         border: none;
@@ -343,11 +341,14 @@ main {
         &.busy:not(.pending),
         &.closed:not(.pending) {
           cursor: not-allowed;
-          margin-left: 8px;
         }
 
-        &.outside-of-time-range:hover {
-          cursor: not-allowed;
+        &.outside-of-time-range {
+          background-color: #ddd;
+
+          &:hover {
+            cursor: not-allowed;
+          }
         }
 
         .selected-heading {

--- a/components/availability/src/styles/availability.scss
+++ b/components/availability/src/styles/availability.scss
@@ -344,7 +344,7 @@ main {
         }
 
         &.outside-of-time-range {
-          background-color: #ddd;
+          background-color: var(--unavailable-color, #ddd);
 
           &:hover {
             cursor: not-allowed;


### PR DESCRIPTION
# Code changes

- Grey-out unavailable timeslots (timeslots before the current time, and slots before / after the min / max book ahead)
- Prevent navigating to previous dates and dates past the max book ahead date

![greyout](https://user-images.githubusercontent.com/8049234/159559400-c49c5693-00f3-4db1-9542-adcd65b737c1.gif)


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
