### PR TITLE
Fix Email/Composer does not properly strip HTML body for message snippet preview 

### DIFF
--- a/commons/src/store/mailbox.ts
+++ b/commons/src/store/mailbox.ts
@@ -275,11 +275,6 @@ function initializeThreads() {
         );
 
         if (incomingDraft.thread_id) {
-          //Update the snippet showing on the condensed draft message
-          incomingDraft.snippet = incomingDraft.body
-            ?.replace(/<\/?[^>]+(>|$)/g, "")
-            .substring(0, 75);
-
           if (foundDraft) {
             Object.assign(foundDraft, incomingDraft);
           } else {

--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -8,6 +8,7 @@
   import "./components/ContactsSearch.svelte";
   import LoadingIcon from "./assets/loading.svg";
   import { isFileAnAttachment } from "@commons/methods/isFileAnAttachment";
+  import { calculateMessageTempSnippet } from "./lib/utils";
 
   import {
     ErrorStore,
@@ -162,6 +163,8 @@
     if (_this.reset_after_close) {
       resetAfterSend($message.from);
     }
+    // Update the snippet showing on the condensed draft message
+    msg.snippet = calculateMessageTempSnippet(msg.body);
     attachments.update(() => []);
     dispatchEvent("composerClosed", {
       message: msg,

--- a/components/composer/src/Composer.svelte
+++ b/components/composer/src/Composer.svelte
@@ -8,7 +8,7 @@
   import "./components/ContactsSearch.svelte";
   import LoadingIcon from "./assets/loading.svg";
   import { isFileAnAttachment } from "@commons/methods/isFileAnAttachment";
-  import { calculateMessageTempSnippet } from "./lib/utils";
+  import { cleanMessageForSnippet } from "./lib/utils";
 
   import {
     ErrorStore,
@@ -164,7 +164,7 @@
       resetAfterSend($message.from);
     }
     // Update the snippet showing on the condensed draft message
-    msg.snippet = calculateMessageTempSnippet(msg.body);
+    msg.snippet = cleanMessageForSnippet(msg.body);
     attachments.update(() => []);
     dispatchEvent("composerClosed", {
       message: msg,

--- a/components/composer/src/lib/utils.ts
+++ b/components/composer/src/lib/utils.ts
@@ -16,6 +16,24 @@ export const debounce = (
     timeout = setTimeout(later, wait);
   };
 };
+
 export const isValidEmail = (email: string): boolean => {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+};
+
+export const calculateMessageTempSnippet = (body: string): string => {
+  if (!body) return "";
+  return (
+    body
+      // Remove style and script tag and content
+      .replace(/<style|script([\S\s]*?)>([\S\s]*?)<\/style|script>/g, "")
+      // Remove all tags and keep content / Remove all HTML entities
+      ?.replace(/<\/?[^>]+(>|$)|(&.+?;)/g, "")
+      // Remove extra spaces
+      ?.replace(/\s+/g, " ")
+      // Remove leading and trailing space
+      ?.trim()
+      // Add ... for longer message
+      ?.substring(0, 190) + (body.length > 190 ? "..." : "")
+  );
 };

--- a/components/composer/src/lib/utils.ts
+++ b/components/composer/src/lib/utils.ts
@@ -1,4 +1,5 @@
 import type { CallbackDebounceFunction } from "@commons/types/ContactsSearch";
+import * as DOMPurify from "dompurify";
 
 export const debounce = (
   func: CallbackDebounceFunction,
@@ -21,14 +22,15 @@ export const isValidEmail = (email: string): boolean => {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 };
 
-export const calculateMessageTempSnippet = (body: string): string => {
+export const cleanMessageForSnippet = (body: string): string => {
   if (!body) return "";
   return (
-    body
-      // Remove style and script tag and content
-      .replace(/<style|script([\S\s]*?)>([\S\s]*?)<\/style|script>/g, "")
-      // Remove all tags and keep content / Remove all HTML entities
-      ?.replace(/<\/?[^>]+(>|$)|(&.+?;)/g, "")
+    DOMPurify.sanitize(body, {
+      ALLOWED_TAGS: [],
+      KEEP_CONTENT: true,
+    })
+      //Remove all HTML entities
+      ?.replace(/(&.+?;)/g, "")
       // Remove extra spaces
       ?.replace(/\s+/g, " ")
       // Remove leading and trailing space


### PR DESCRIPTION
# Code changes

- [x] Updated the HTML stripping function within composer component
- [x] Extract the stripping function into `utils.ts`
- [x] Remove the stripping from `hydrateDraftInThread` function in MailboxStore because we only need to generate snippet when user closes the composer.

# Readiness checklist

- [x] Cypress tests passing?
- [ ] New cypress tests added?

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
