### PR TITLE
Pinning svelte to 3.44.2 to resolve a max call stack exceeded issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "rollup-plugin-terser": "^7.0.0",
     "sass": "1.32.8",
     "sirv-cli": "1.0.11",
-    "svelte": "^3.35.0",
+    "svelte": "3.44.2",
     "svelte-check": "1.1.19",
     "svelte-jester": "^1.3.2",
     "svelte-loader": "2.13.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2009,25 +2009,25 @@
     fastq "^1.6.0"
 
 "@nylas/components-agenda@file:components/agenda":
-  version "1.1.7-canary.3"
+  version "1.1.7-canary.5"
   dependencies:
     dompurify "^2.3.3"
 
 "@nylas/components-availability@file:components/availability":
-  version "1.1.5-canary.6"
+  version "1.1.5-canary.10"
   dependencies:
     d3-scale "^4.0.0"
     d3-time "^3.0.0"
     just-throttle "2.3.1"
 
 "@nylas/components-booking@file:components/booking":
-  version "1.0.0-canary.0"
+  version "1.0.0-canary.3"
 
 "@nylas/components-composer@file:components/composer":
-  version "1.1.6-canary.10"
+  version "1.1.6-canary.15"
 
 "@nylas/components-contact-list@file:components/contact-list":
-  version "1.1.4-canary.5"
+  version "1.1.4-canary.6"
 
 "@nylas/components-conversation@file:components/conversation":
   version "1.1.6-canary.3"
@@ -2038,17 +2038,17 @@
   version "1.1.4-canary.0"
 
 "@nylas/components-email@file:components/email":
-  version "1.1.7-canary.18"
+  version "1.1.7-canary.22"
   dependencies:
     dompurify "^2.3.3"
 
 "@nylas/components-mailbox@file:components/mailbox":
-  version "1.1.6-canary.16"
+  version "1.1.6-canary.22"
   dependencies:
     dompurify "^2.3.3"
 
 "@nylas/components-schedule-editor@file:components/schedule-editor":
-  version "1.1.4-canary.5"
+  version "1.1.4-canary.8"
 
 "@nylas/components-theming@file:components/theming":
   version "1.0.0"
@@ -11136,10 +11136,10 @@ svelte-preprocess@^4.0.0:
     sorcery "^0.10.0"
     strip-indent "^3.0.0"
 
-svelte@^3.35.0:
-  version "3.46.4"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.46.4.tgz#0c46bc4a3e20a2617a1b7dc43a722f9d6c084a38"
-  integrity sha512-qKJzw6DpA33CIa+C/rGp4AUdSfii0DOTCzj/2YpSKKayw5WGSS624Et9L1nU1k2OVRS9vaENQXp2CVZNU+xvIg==
+svelte@3.44.2:
+  version "3.44.2"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.44.2.tgz#3e69be2598308dfc8354ba584cec54e648a50f7f"
+  integrity sha512-jrZhZtmH3ZMweXg1Q15onb8QlWD+a5T5Oca4C1jYvSURp2oD35h4A5TV6t6MEa93K4LlX6BkafZPdQoFjw/ylA==
 
 svgo@^1.0.0:
   version "1.3.2"


### PR DESCRIPTION
# Background
Related to the following reported issue https://github.com/sveltejs/svelte/issues/7032

# Code changes
- [x] Pinned svelte to 3.44.2 

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
