### PR TITLE
[Email|Mailbox] Show .ics files as attachments

### DIFF
--- a/commons/src/constants/attachment-content-types.ts
+++ b/commons/src/constants/attachment-content-types.ts
@@ -1,7 +1,6 @@
 export const DisallowedContentTypes = [
   "message/delivery-status",
   "message/rfc822",
-  "text/calendar",
 ];
 
 export const InlineImageTypes = [

--- a/commons/src/methods/isFileAnAttachment.ts
+++ b/commons/src/methods/isFileAnAttachment.ts
@@ -6,6 +6,7 @@ import {
 
 export const isFileAnAttachment = (message: Message, file: File): boolean =>
   file.content_disposition === "attachment" &&
+  file.filename &&
   !(
     file.content_id &&
     message.cids?.includes(file.content_id) &&

--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -537,7 +537,7 @@ describe("Booking time slots", () => {
 
           // Change to next date
           cy.get("div.change-dates").should("exist");
-          cy.get(".change-dates button:eq(1)").click();
+          cy.get(".change-dates button").should("not.exist");
 
           expect(selectedTimeslots).to.have.lengthOf(0);
           cy.get(".slot.free")
@@ -803,23 +803,26 @@ describe("Booking time slots", () => {
       cy.get("@testComponent").invoke("attr", "show_as_week", false);
       cy.get("div.day:eq(0) header h2").invoke("text").should("eq", "15 Wed");
       cy.get("div.day:eq(2) header h2").invoke("text").should("eq", "17 Fri");
-      cy.get(".change-dates button:eq(1)").click();
+      cy.get(".change-dates button[aria-label='Next date']").click();
       cy.get("div.day:eq(0) header h2").invoke("text").should("eq", "18 Sat");
       cy.get("div.day:eq(2) header h2").invoke("text").should("eq", "20 Mon");
     });
 
     it("Handles moving forward show_as_week gracefully when squashed", () => {
       cy.viewport(800, 550);
-      cy.get(".change-dates button:eq(1)").click();
+      cy.get(".change-dates button[aria-label='Next date']").click();
       cy.get("div.day:eq(0) header h2").invoke("text").should("eq", "18 Sat");
       cy.get("div.day:eq(2) header h2").invoke("text").should("eq", "20 Mon");
     });
 
     it("Handles moving backward show_as_week gracefully when squashed", () => {
       cy.viewport(800, 550);
-      cy.get(".change-dates button:eq(0)").click();
-      cy.get("div.day:eq(0) header h2").invoke("text").should("eq", "12 Sun");
-      cy.get("div.day:eq(2) header h2").invoke("text").should("eq", "14 Tue");
+      cy.get(".change-dates button[aria-label='Next date']").click(); // Move forward 1 day
+      cy.get(".change-dates button[aria-label='Next date']").click(); // Move forward 1 more day
+      cy.get("div.day:eq(0) header h2").invoke("text").should("eq", "21 Tue");
+      cy.get(".change-dates button[aria-label='Previous date']").click(); // Move backward 1 day
+      cy.get("div.day:eq(0) header h2").invoke("text").should("eq", "18 Sat");
+      cy.get("div.day:eq(2) header h2").invoke("text").should("eq", "20 Mon");
     });
   });
 

--- a/components/availability/src/styles/availability.scss
+++ b/components/availability/src/styles/availability.scss
@@ -120,6 +120,9 @@ main {
         var(--blue),
         var(--blue-lighter)
       );
+      &::before {
+        z-index: 3;
+      }
     }
     &.timezone.loading {
       &::before,
@@ -130,6 +133,9 @@ main {
     &.loading.error {
       @include progress-bar(top, 36px, left, 0, var(--red), var(--red));
       animation: none;
+      &::before {
+        z-index: 3;
+      }
     }
 
     &.schedule {

--- a/components/email/CHANGELOG.md
+++ b/components/email/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [Email] UI tweaks that improve design [#270](https://github.com/nylas/components/pull/270)
 - [Email] Added new loading indicator [#270](https://github.com/nylas/components/pull/270)
 - [Email] Updated border style + variables [#270](https://github.com/nylas/components/pull/270)
+- Fixed double clicking a thread caused the component to become unresponsive [#425](https://github.com/nylas/components/pull/425)
 
 # v1.1.7 (2021-12-22)
 

--- a/components/email/CHANGELOG.md
+++ b/components/email/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [Email] Added customizable css variables for attachment button [#379](https://github.com/nylas/components/pull/379)
 
 ```
+  -  --nylas-email-font-family
   -  --nylas-email-attachment-border-style
   -  --nylas-email-attachment-button-color
   -  --nylas-email-attachment-button-bg

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -387,12 +387,18 @@
     }
   }
 
+  let loading: boolean = false;
   async function handleThread(event: MouseEvent | KeyboardEvent) {
+    if (loading) {
+      return;
+    }
+
     const messageType = getMessageType(activeThread);
 
     if (activeThread[messageType].length <= 0) {
       return;
     }
+    loading = true;
     if (_this.click_action === "default" || _this.click_action === "mailbox") {
       //#region read/unread
       if (
@@ -420,6 +426,7 @@
     } else if (messageType !== MessageType.DRAFTS && !activeThread.expanded) {
       activeThread.expanded = !activeThread.expanded;
     }
+    loading = false;
 
     dispatchEvent("threadClicked", {
       event,
@@ -927,7 +934,9 @@
     }
   }
 
-  function getMessageType(currentThread: Thread): string {
+  function getMessageType(
+    currentThread: Thread,
+  ): keyof Pick<Conversation, "messages" | "drafts"> {
     return currentThread[MessageType.DRAFTS].length &&
       !currentThread[MessageType.MESSAGES].length
       ? MessageType.DRAFTS

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -1017,7 +1017,12 @@
     width: 100%;
     position: relative;
     display: grid;
-    font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+    font-family: var(
+      --nylas-email-font-family,
+      -apple-system,
+      BlinkMacSystemFont,
+      sans-serif
+    );
     .email-row {
       background: var(--nylas-email-background, var(--grey-lightest));
       border: var(--email-border-style, 1px solid var(--grey-lighter));

--- a/components/email/src/init.spec.js
+++ b/components/email/src/init.spec.js
@@ -38,6 +38,19 @@ const SAMPLE_THREAD = {
           id: "d1fop1j6savk2dqex9uvwvclt",
           size: 27174,
         },
+        {
+          content_disposition: "attachment",
+          content_type: "text/calendar",
+          filename: null,
+          id: "32yf13av2aiq6is5t1jov7ofd",
+          size: 1005,
+        },
+        {
+          content_disposition: "attachment",
+          content_type: "application/ics",
+          filename: "invite.ics",
+          id: "cvmampvjwqvunwmey4b5fp84f",
+        },
       ],
       from: [
         {
@@ -950,6 +963,7 @@ describe("Email: Images and Files", () => {
     cy.get("@email").find(".email-row.condensed .attachment").should("exist");
     cy.get("@email")
       .find(".email-row.condensed .attachment button")
+      .first()
       .should("have.text", "invoice_2062.pdf ");
   });
 });

--- a/components/email/src/init.spec.js
+++ b/components/email/src/init.spec.js
@@ -50,6 +50,14 @@ const SAMPLE_THREAD = {
           content_type: "application/ics",
           filename: "invite.ics",
           id: "cvmampvjwqvunwmey4b5fp84f",
+          size: 1005,
+        },
+        {
+          content_disposition: "attachment",
+          content_type: "text/calendar",
+          filename: "US_Holidays.ics",
+          id: "64qp23bc3asd6ih7t47ofd",
+          size: 4321,
         },
       ],
       from: [
@@ -965,6 +973,30 @@ describe("Email: Images and Files", () => {
       .find(".email-row.condensed .attachment button")
       .first()
       .should("have.text", "invoice_2062.pdf ");
+  });
+
+  it("Shows .ics attachments when condensed", () => {
+    cy.get("@email").invoke("prop", "show_expanded_email_view_onload", false);
+    cy.get("@email").invoke("prop", "thread", SAMPLE_THREAD);
+
+    cy.get("@email").find(".email-row.condensed .attachment").should("exist");
+    cy.get("@email")
+      .find(".email-row.condensed .attachment button")
+      .first()
+      .nextAll()
+      .should("have.text", "invite.ics US_Holidays.ics ");
+  });
+
+  it("Does not show ghost/unnamed .ics attachments included in calendar invites", () => {
+    cy.get("@email").invoke("prop", "show_expanded_email_view_onload", false);
+    cy.get("@email").invoke("prop", "thread", SAMPLE_THREAD);
+
+    cy.get("@email").find(".email-row.condensed .attachment").should("exist");
+    cy.get("@email")
+      .find(".email-row.condensed .attachment button")
+      .first()
+      .nextAll()
+      .should("not.include.text", "32yf13av2aiq6is5t1jov7ofd");
   });
 });
 

--- a/components/mailbox/CHANGELOG.md
+++ b/components/mailbox/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Fixed TypeError was being thrown if all_threads prop was used and user clicked a message to expand it's body [315](https://github.com/nylas/components/pull/315)
 - Fixed dispatched event `threadClicked` being dispatched multiple times on a single click [315](https://github.com/nylas/components/pull/315)
 - Fixed the issue where deleting a sent thread by self using non-gmail account was not working [#374](https://github.com/nylas/components/pull/374)
+- Fixed double clicking a thread caused the component to become unresponsive [#425](https://github.com/nylas/components/pull/425)
 
 # v1.1.5 (2021-12-15)
 

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -348,9 +348,14 @@
     }
   }
 
+  let loading = false;
   async function threadClicked(event: CustomEvent) {
     const { thread, messageType } = event.detail;
     const messages = thread[messageType];
+    if (loading) {
+      return;
+    }
+    loading = true;
     if (_this.thread_click_action === MailboxThreadClickAction.DEFAULT) {
       let message = await fetchIndividualMessage(messages[messages.length - 1]);
 
@@ -391,6 +396,7 @@
         }
       }
     }
+    loading = false;
   }
 
   async function getMessageWithInlineFiles(message: Message): Promise<Message> {
@@ -409,7 +415,6 @@
     return message;
   }
 
-  let loading = false;
   async function refreshClicked(event: MouseEvent) {
     loading = true;
     dispatchEvent("refreshClicked", { event });

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -361,6 +361,7 @@
 
       if (messageType === MessageType.DRAFTS) {
         await dispatchDraftThreadClicked(event);
+        loading = false;
         return;
       }
 

--- a/components/mailbox/src/init.spec.js
+++ b/components/mailbox/src/init.spec.js
@@ -108,6 +108,7 @@ describe("Mailbox Display", () => {
   let thread1;
   let thread2;
   let THREAD_WITH_MESSAGE_THAT_DOES_NOT_HAVE_FROM_OR_TO_FIELDS;
+  let THREAD_WITH_CALENDAR_ATTACHMENTS;
 
   beforeEach(() => {
     cy.intercept(
@@ -153,6 +154,12 @@ describe("Mailbox Display", () => {
       THREAD_WITH_MESSAGE_THAT_DOES_NOT_HAVE_FROM_OR_TO_FIELDS = f.response;
     });
 
+    cy.fixture("mailbox/threads/threadWithCalendarAttachments.json").then(
+      (f) => {
+        THREAD_WITH_CALENDAR_ATTACHMENTS = f.response;
+      },
+    );
+
     cy.fixture("mailbox/threads/SAMPLE_1.json").then((f) => {
       thread1 = f;
     });
@@ -191,6 +198,32 @@ describe("Mailbox Display", () => {
     cy.get("@email")
       .find(".snippet")
       .contains("Sorry, looks like this thread is currently unavailable");
+  });
+
+  it("Shows both .ics files and calendar invites as attachments", () => {
+    cy.get("@mailbox").invoke(
+      "prop",
+      "all_threads",
+      THREAD_WITH_CALENDAR_ATTACHMENTS,
+    );
+
+    cy.get("@email").find(".email-row.condensed .attachment").should("exist");
+    cy.get("@email")
+      .find(".email-row.condensed .attachment button")
+      .should("have.text", "invite.ics US_Holidays.ics ");
+  });
+
+  it.only("Does not show attachment button for unnamed .ics files attached with invites", () => {
+    cy.get("@mailbox").invoke(
+      "prop",
+      "all_threads",
+      THREAD_WITH_CALENDAR_ATTACHMENTS,
+    );
+
+    cy.get("@email").find(".email-row.condensed .attachment").should("exist");
+    cy.get("@email")
+      .find(".email-row.condensed .attachment button")
+      .should("not.include.text", "32yf13av2aiq6is5t1jov7ofd");
   });
 });
 

--- a/components/mailbox/src/init.spec.js
+++ b/components/mailbox/src/init.spec.js
@@ -491,6 +491,22 @@ describe("Mailbox Interactions", () => {
     cy.get("@mailbox").find("nylas-email").as("email");
   });
 
+  it("Should expand a thread when clicked once", () => {
+    cy.get("@mailbox").find(".email-row.condensed").as("emailRow");
+    cy.get("@mailbox").find(".email-row.expanded").should("not.exist");
+
+    cy.get("@emailRow").first().click();
+    cy.get("@mailbox").find(".email-row.expanded").should("have.length", 1);
+  });
+
+  it.only("Should expand a thread when clicked twice", () => {
+    cy.get("@mailbox").find(".email-row.condensed").as("emailRow");
+    cy.get("@mailbox").find(".email-row.expanded").should("not.exist");
+
+    cy.get("@emailRow").first().dblclick();
+    cy.get("@mailbox").find(".email-row.expanded").should("have.length", 1);
+  });
+
   it("Refresh button works", () => {
     let refreshed = false;
     cy.get("@mailbox").invoke("prop", "header", "Test");

--- a/components/theming/animation.scss
+++ b/components/theming/animation.scss
@@ -50,7 +50,6 @@
   &::before {
     animation: progress 2s ease-in-out infinite;
     background-color: $backgroundColor;
-    z-index: 3;
   }
   &::before,
   &::after {

--- a/cypress/fixtures/mailbox/threads/threadWithCalendarAttachments copy.json
+++ b/cypress/fixtures/mailbox/threads/threadWithCalendarAttachments copy.json
@@ -1,0 +1,82 @@
+{
+  "account_id": "1xrddnl99frq3b7son9j32aba",
+  "drafts": [],
+  "first_message_timestamp": 1629832405,
+  "has_attachments": true,
+  "id": "dlrwnv5oc3v3apxc2j0ht8vop",
+  "labels": [
+    {
+      "display_name": "Inbox",
+      "id": "dx62wkpj57erbkargbr3zew3j",
+      "name": "inbox"
+    }
+  ],
+  "last_message_received_timestamp": 1629832405,
+  "last_message_sent_timestamp": null,
+  "last_message_timestamp": 1629832405,
+  "messages": [
+    {
+      "account_id": "1xrddnl99frq3b7son9j32aba",
+      "bcc": [],
+      "cc": [],
+      "date": 1629832405,
+      "files": [
+        {
+          "content_disposition": "attachment",
+          "content_type": "application/pdf",
+          "filename": "invoice_2062.pdf",
+          "id": "d1fop1j6savk2dqex9uvwvclt",
+          "size": 27174
+        },
+        {
+          "content_disposition": "attachment",
+          "content_type": "text/calendar",
+          "filename": null,
+          "id": "32yf13av2aiq6is5t1jov7ofd",
+          "size": 1005
+        },
+        {
+          "content_disposition": "attachment",
+          "content_type": "application/ics",
+          "filename": "invite.ics",
+          "id": "cvmampvjwqvunwmey4b5fp84f",
+          "size": 1005
+        },
+        {
+          "content_disposition": "attachment",
+          "content_type": "text/calendar",
+          "filename": "US_Holidays.ics",
+          "id": "64qp23bc3asd6ih7t47ofd",
+          "size": 4321
+        }
+      ],
+      "from": [{ "email": "tips@nylas.com", "name": "J Valdivia" }],
+      "id": "3ozrqu3obfwzmsltxj72ll86m",
+      "labels": [
+        {
+          "display_name": "Inbox",
+          "id": "dx62wkpj57erbkargbr3zew3j",
+          "name": "inbox"
+        }
+      ],
+      "object": "message",
+      "reply_to": [{ "email": "tips@nylas.com", "name": "" }],
+      "snippet": "Set yourself up for an integration that scales by avoiding common roadblocks and pitfalls. Learn how to boost revenue, accelerate your roadmap, and meet & exceed your customers’ needs with these assets.",
+      "starred": false,
+      "subject": "API Integration Pitfalls and How to Avoid Them",
+      "thread_id": "dlrwnv5oc3v3apxc2j0ht8vop",
+      "to": [{ "email": "nylascypresstest+trialuser2@gmail.com", "name": "" }],
+      "unread": true
+    }
+  ],
+  "object": "thread",
+  "participants": [
+    { "email": "tips@nylas.com", "name": "J Valdivia" },
+    { "email": "nylascypresstest+trialuser2@gmail.com", "name": "" }
+  ],
+  "snippet": "Set yourself up for an integration that scales by avoiding common roadblocks and pitfalls. Learn how to boost revenue, accelerate your roadmap, and meet & exceed your customers’ needs with these assets.",
+  "starred": false,
+  "subject": "API Integration Pitfalls and How to Avoid Them",
+  "unread": true,
+  "version": 2
+}

--- a/cypress/fixtures/mailbox/threads/threadWithCalendarAttachments.json
+++ b/cypress/fixtures/mailbox/threads/threadWithCalendarAttachments.json
@@ -1,0 +1,84 @@
+{
+  "component": {
+    "theming": {}
+  },
+  "response": [
+    {
+      "account_id": "1xrddnl99frq3b7son9j32aba",
+      "drafts": [],
+      "first_message_timestamp": 1629832405,
+      "has_attachments": true,
+      "id": "dlrwnv5oc3v3apxc2j0ht8vop",
+      "labels": [
+        {
+          "display_name": "Inbox",
+          "id": "dx62wkpj57erbkargbr3zew3j",
+          "name": "inbox"
+        }
+      ],
+      "last_message_received_timestamp": 1629832405,
+      "last_message_sent_timestamp": null,
+      "last_message_timestamp": 1629832405,
+      "messages": [
+        {
+          "account_id": "1xrddnl99frq3b7son9j32aba",
+          "bcc": [],
+          "cc": [],
+          "date": 1629832405,
+          "files": [
+            {
+              "content_disposition": "attachment",
+              "content_type": "text/calendar",
+              "filename": null,
+              "id": "32yf13av2aiq6is5t1jov7ofd",
+              "size": 1005
+            },
+            {
+              "content_disposition": "attachment",
+              "content_type": "application/ics",
+              "filename": "invite.ics",
+              "id": "cvmampvjwqvunwmey4b5fp84f",
+              "size": 1005
+            },
+            {
+              "content_disposition": "attachment",
+              "content_type": "text/calendar",
+              "filename": "US_Holidays.ics",
+              "id": "64qp23bc3asd6ih7t47ofd",
+              "size": 4321
+            }
+          ],
+          "from": [{ "email": "tips@nylas.com", "name": "J Valdivia" }],
+          "id": "3ozrqu3obfwzmsltxj72ll86m",
+          "labels": [
+            {
+              "display_name": "Inbox",
+              "id": "dx62wkpj57erbkargbr3zew3j",
+              "name": "inbox"
+            }
+          ],
+          "object": "message",
+          "reply_to": [{ "email": "tips@nylas.com", "name": "" }],
+          "snippet": "Set yourself up for an integration that scales by avoiding common roadblocks and pitfalls. Learn how to boost revenue, accelerate your roadmap, and meet & exceed your customers’ needs with these assets.",
+          "starred": false,
+          "subject": "API Integration Pitfalls and How to Avoid Them",
+          "thread_id": "dlrwnv5oc3v3apxc2j0ht8vop",
+          "to": [
+            { "email": "nylascypresstest+trialuser2@gmail.com", "name": "" }
+          ],
+          "unread": true
+        }
+      ],
+      "object": "thread",
+      "participants": [
+        { "email": "tips@nylas.com", "name": "J Valdivia" },
+        { "email": "nylascypresstest+trialuser2@gmail.com", "name": "" }
+      ],
+      "snippet": "Set yourself up for an integration that scales by avoiding common roadblocks and pitfalls. Learn how to boost revenue, accelerate your roadmap, and meet & exceed your customers’ needs with these assets.",
+      "starred": false,
+      "subject": "API Integration Pitfalls and How to Avoid Them",
+      "unread": true,
+      "version": 2
+    }
+  ]
+}

--- a/tests/methods/convertDateTimeZone.spec.ts
+++ b/tests/methods/convertDateTimeZone.spec.ts
@@ -8,7 +8,12 @@ const date = new Date("2041-11-01T17:00:00.000Z");
 const simpleTimeString = "5:00 pm";
 const atlanticZone = "Atlantic/South_Georgia";
 
-Settings.defaultLocale = "en-CA";
+const defaults = () => {
+  Settings.defaultLocale = "en-CA";
+  Settings.defaultZone = "system";
+};
+
+beforeEach(defaults);
 
 describe("Format a time slot", () => {
   it("should convert a JS Date object to simple time string", () => {
@@ -29,6 +34,7 @@ describe("Format a time slot", () => {
   });
 
   it("should convert a JS Date object to simple time string in another timezone", () => {
+    Settings.defaultZone = "Europe/London";
     const timeSlot = formatTimeSlot(date, DateTime.local().zoneName);
     expect(timeSlot).toEqual(simpleTimeString);
   });


### PR DESCRIPTION
# Code Changes
- Removed 'text/calendar' for disallowed content types to allow display of .ics calendar attachments
- added check to `isFileAttachment` that verifies file has a `filename` property set.  .ics files are appending two files to file list, one without a set filename.

# Screenshots:

## Before
![Screen Shot 2022-03-28 at 10 42 57 PM](https://user-images.githubusercontent.com/43771331/160535410-6b7fa12f-ec8b-4271-827e-7686d01d796f.png)

## After
![Screen Shot 2022-03-28 at 10 47 06 PM](https://user-images.githubusercontent.com/43771331/160535434-7b0e4843-4ba6-4415-aea5-9d548706bf3a.png)

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner



