### PR TITLE
Added error message when no Email data provided

### DIFF
--- a/commons/src/components/NError.svelte
+++ b/commons/src/components/NError.svelte
@@ -59,6 +59,15 @@
       </h4>
     {:else if errorName === "IncompatibleProperties"}
       <h3>Your component properties do not work with each other.</h3>
+    {:else if errorName === "MissingDataProperties"}
+      <div>
+        <h3>
+          {error.message ?? ""}
+          {#if error.link}
+            <a href={error.link} target="_blank">{error.linkName}</a>
+          {/if}
+        </h3>
+      </div>
     {/if}
     <span class="details">Debug info:</span>
     <textarea class="details" readonly>

--- a/commons/src/methods/api.ts
+++ b/commons/src/methods/api.ts
@@ -54,6 +54,10 @@ export function handleError(id: string, error: Manifest["error"]): never {
   throw error;
 }
 
+export function clearError(id: string): void {
+  ErrorStore.update((errorMap) => ({ ...errorMap, [id]: {} }));
+}
+
 const REGION_MAPPING: Record<string, string> = {
   "001": "", // US
   "002": "ireland-", // EU

--- a/commons/src/methods/api.ts
+++ b/commons/src/methods/api.ts
@@ -54,8 +54,10 @@ export function handleError(id: string, error: Manifest["error"]): never {
   throw error;
 }
 
-export function clearError(id: string): void {
-  ErrorStore.update((errorMap) => ({ ...errorMap, [id]: {} }));
+export function clearError(id: string, name: string): void {
+  ErrorStore.update((errorMap) => {
+    return errorMap[id]?.name === name ? { ...errorMap, [id]: {} } : errorMap;
+  });
 }
 
 const REGION_MAPPING: Record<string, string> = {

--- a/commons/src/types/Nylas.ts
+++ b/commons/src/types/Nylas.ts
@@ -160,6 +160,8 @@ export interface MiddlewareResponse<T = unknown> {
 export interface NError {
   name?: string;
   message?: Error | string;
+  linkName?: string;
+  link?: string;
 }
 
 export interface Manifest {
@@ -212,6 +214,7 @@ export interface EmailProperties extends Manifest {
   show_reply: boolean;
   show_reply_all: boolean;
   show_forward: boolean;
+  loading: boolean;
 }
 
 export interface MailboxProperties extends Manifest {

--- a/commons/src/types/Nylas.ts
+++ b/commons/src/types/Nylas.ts
@@ -160,7 +160,7 @@ export interface MiddlewareResponse<T = unknown> {
 export interface NError {
   name?: string;
   message?: Error | string;
-  linkName?: string;
+  link_name?: string;
   link?: string;
 }
 

--- a/components/email/CHANGELOG.md
+++ b/components/email/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - [Email] Checks existing draft in thread when clicking on reply/forward, and opens composer with draft if exists. [#405](https://github.com/nylas/components/pull/405)
 - [Email] Highlights draft in thread when its opened with Composer. [#405](https://github.com/nylas/components/pull/405)
+- [Email] Show and log an error message when no email data is passed in component, instead of showing blank page. [#424](https://github.com/nylas/components/pull/424)
+- [Email] Added boolean propety `loading` that user can passing to indicate loading status of the component. [#424](https://github.com/nylas/components/pull/424)
 
 ## Breaking
 

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -190,7 +190,7 @@
             message:
               "Email data is not populated with Email component, please find more details on how to setup Email component in Nylas docs:",
             link: "https://developer.nylas.com/docs/user-experience/components/email-component/",
-            linkName: "Setup Email Component",
+            link_name: "Setup Email Component",
           });
         } catch (error) {
           console.error(
@@ -199,7 +199,7 @@
           );
         }
       } else {
-        clearError(id);
+        clearError(id, "MissingDataProperties");
       }
     }
   })();

--- a/components/email/src/init.spec.js
+++ b/components/email/src/init.spec.js
@@ -907,6 +907,24 @@ describe("Email: Displays threads and messages", () => {
         expect($div).to.contain("This is a draft email");
       });
   });
+
+  it("Shows error message when no email data is found", () => {
+    cy.get("@email").find(".snippet").should("not.exist");
+    cy.get("@email").find("nylas-error").should("exist").as("error");
+    cy.get("@error")
+      .find(".message-container")
+      .contains("Email data is not populated with Email component");
+  });
+
+  it("Shows loading status when no email data and loading is true", () => {
+    cy.get("@email").then((element) => {
+      const component = element[0];
+      component.loading = true;
+    });
+
+    cy.get("@email").find(".snippet").should("not.exist");
+    cy.get("@email").find(".email-loader .spinner").should("exist");
+  });
 });
 
 describe("Email: Images and Files", () => {


### PR DESCRIPTION
# Description
- For Email component, if user didn't pass any one of the following properties, we show the error message saying that no email data provided:
    - `thread`, `thread_id`, `message` or `message_id`
- To correctly show this message in component's lifecycle, we only show it after component is `mounted` and `$$props` are loaded.
- For users who want to control the time when the email data is passed in, added new Email component property `loading` to allow it to show a loading spinner when no email data provided.

# Code changes

- [x] Added handleError in Email component when no email data is populated
- [x] Update `nylas-error` component to include the link to the corresponding Nylas Docs


# Readiness checklist

- [x] Added changes to component `CHANGELOG.md`
- [x] Cypress tests passing?
- [x] New cypress tests added?
- [x] Included before/after screenshots, if the change is visual

# Screenshots
![Screen Shot 2022-03-29 at 1 46 55 PM](https://user-images.githubusercontent.com/14408339/160674387-32eecb43-adc8-470f-a45b-4fed2d085f33.png)

![Screen Shot 2022-03-29 at 1 46 49 PM](https://user-images.githubusercontent.com/14408339/160674394-b766b04c-8eed-45e5-8a61-0ecb4d3caf14.png)


# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
