### PR TITLE
Double-clicking a thread puts the mailbox component in a broken state

### DIFF
--- a/components/availability/src/init.spec.js
+++ b/components/availability/src/init.spec.js
@@ -537,7 +537,7 @@ describe("Booking time slots", () => {
 
           // Change to next date
           cy.get("div.change-dates").should("exist");
-          cy.get(".change-dates button:eq(1)").click();
+          cy.get(".change-dates button").should("not.exist");
 
           expect(selectedTimeslots).to.have.lengthOf(0);
           cy.get(".slot.free")
@@ -803,23 +803,26 @@ describe("Booking time slots", () => {
       cy.get("@testComponent").invoke("attr", "show_as_week", false);
       cy.get("div.day:eq(0) header h2").invoke("text").should("eq", "15 Wed");
       cy.get("div.day:eq(2) header h2").invoke("text").should("eq", "17 Fri");
-      cy.get(".change-dates button:eq(1)").click();
+      cy.get(".change-dates button[aria-label='Next date']").click();
       cy.get("div.day:eq(0) header h2").invoke("text").should("eq", "18 Sat");
       cy.get("div.day:eq(2) header h2").invoke("text").should("eq", "20 Mon");
     });
 
     it("Handles moving forward show_as_week gracefully when squashed", () => {
       cy.viewport(800, 550);
-      cy.get(".change-dates button:eq(1)").click();
+      cy.get(".change-dates button[aria-label='Next date']").click();
       cy.get("div.day:eq(0) header h2").invoke("text").should("eq", "18 Sat");
       cy.get("div.day:eq(2) header h2").invoke("text").should("eq", "20 Mon");
     });
 
     it("Handles moving backward show_as_week gracefully when squashed", () => {
       cy.viewport(800, 550);
-      cy.get(".change-dates button:eq(0)").click();
-      cy.get("div.day:eq(0) header h2").invoke("text").should("eq", "12 Sun");
-      cy.get("div.day:eq(2) header h2").invoke("text").should("eq", "14 Tue");
+      cy.get(".change-dates button[aria-label='Next date']").click(); // Move forward 1 day
+      cy.get(".change-dates button[aria-label='Next date']").click(); // Move forward 1 more day
+      cy.get("div.day:eq(0) header h2").invoke("text").should("eq", "21 Tue");
+      cy.get(".change-dates button[aria-label='Previous date']").click(); // Move backward 1 day
+      cy.get("div.day:eq(0) header h2").invoke("text").should("eq", "18 Sat");
+      cy.get("div.day:eq(2) header h2").invoke("text").should("eq", "20 Mon");
     });
   });
 

--- a/components/email/CHANGELOG.md
+++ b/components/email/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [Email] UI tweaks that improve design [#270](https://github.com/nylas/components/pull/270)
 - [Email] Added new loading indicator [#270](https://github.com/nylas/components/pull/270)
 - [Email] Updated border style + variables [#270](https://github.com/nylas/components/pull/270)
+- Fixed double clicking a thread caused the component to become unresponsive [#425](https://github.com/nylas/components/pull/425)
 
 # v1.1.7 (2021-12-22)
 

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -387,12 +387,18 @@
     }
   }
 
+  let loading: boolean = false;
   async function handleThread(event: MouseEvent | KeyboardEvent) {
+    if (loading) {
+      return;
+    }
+
     const messageType = getMessageType(activeThread);
 
     if (activeThread[messageType].length <= 0) {
       return;
     }
+    loading = true;
     if (_this.click_action === "default" || _this.click_action === "mailbox") {
       //#region read/unread
       if (
@@ -420,6 +426,7 @@
     } else if (messageType !== MessageType.DRAFTS && !activeThread.expanded) {
       activeThread.expanded = !activeThread.expanded;
     }
+    loading = false;
 
     dispatchEvent("threadClicked", {
       event,
@@ -927,7 +934,9 @@
     }
   }
 
-  function getMessageType(currentThread: Thread): string {
+  function getMessageType(
+    currentThread: Thread,
+  ): keyof Pick<Conversation, "messages" | "drafts"> {
     return currentThread[MessageType.DRAFTS].length &&
       !currentThread[MessageType.MESSAGES].length
       ? MessageType.DRAFTS

--- a/components/mailbox/CHANGELOG.md
+++ b/components/mailbox/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Fixed TypeError was being thrown if all_threads prop was used and user clicked a message to expand it's body [315](https://github.com/nylas/components/pull/315)
 - Fixed dispatched event `threadClicked` being dispatched multiple times on a single click [315](https://github.com/nylas/components/pull/315)
 - Fixed the issue where deleting a sent thread by self using non-gmail account was not working [#374](https://github.com/nylas/components/pull/374)
+- Fixed double clicking a thread caused the component to become unresponsive [#425](https://github.com/nylas/components/pull/425)
 
 # v1.1.5 (2021-12-15)
 

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -348,9 +348,14 @@
     }
   }
 
+  let loading = false;
   async function threadClicked(event: CustomEvent) {
     const { thread, messageType } = event.detail;
     const messages = thread[messageType];
+    if (loading) {
+      return;
+    }
+    loading = true;
     if (_this.thread_click_action === MailboxThreadClickAction.DEFAULT) {
       let message = await fetchIndividualMessage(messages[messages.length - 1]);
 
@@ -391,6 +396,7 @@
         }
       }
     }
+    loading = false;
   }
 
   async function getMessageWithInlineFiles(message: Message): Promise<Message> {
@@ -409,7 +415,6 @@
     return message;
   }
 
-  let loading = false;
   async function refreshClicked(event: MouseEvent) {
     loading = true;
     dispatchEvent("refreshClicked", { event });

--- a/components/mailbox/src/init.spec.js
+++ b/components/mailbox/src/init.spec.js
@@ -491,6 +491,23 @@ describe("Mailbox Interactions", () => {
     cy.get("@mailbox").find("nylas-email").as("email");
   });
 
+  it("Should expand a thread when clicked once", () => {
+    cy.get("@mailbox").find(".email-row.condensed").as("emailRow");
+    cy.get("@mailbox").find(".email-row.expanded").should("not.exist");
+
+    cy.get("@emailRow").first().click();
+    cy.get("@mailbox").find(".email-row.expanded").should("have.length", 1);
+  });
+
+  it.only("Should expand a thread when clicked twice", () => {
+    cy.get("@mailbox").find(".email-row.condensed").as("emailRow");
+    cy.get("@mailbox").find(".email-row.expanded").should("not.exist");
+
+    cy.get("@emailRow").first().click();
+    cy.get("@emailRow").first().click();
+    cy.get("@mailbox").find(".email-row.expanded").should("have.length", 1);
+  });
+
   it("Refresh button works", () => {
     let refreshed = false;
     cy.get("@mailbox").invoke("prop", "header", "Test");

--- a/components/mailbox/src/init.spec.js
+++ b/components/mailbox/src/init.spec.js
@@ -503,8 +503,7 @@ describe("Mailbox Interactions", () => {
     cy.get("@mailbox").find(".email-row.condensed").as("emailRow");
     cy.get("@mailbox").find(".email-row.expanded").should("not.exist");
 
-    cy.get("@emailRow").first().click();
-    cy.get("@emailRow").first().click();
+    cy.get("@emailRow").first().dblclick();
     cy.get("@mailbox").find(".email-row.expanded").should("have.length", 1);
   });
 

--- a/tests/methods/convertDateTimeZone.spec.ts
+++ b/tests/methods/convertDateTimeZone.spec.ts
@@ -8,7 +8,12 @@ const date = new Date("2041-11-01T17:00:00.000Z");
 const simpleTimeString = "5:00 pm";
 const atlanticZone = "Atlantic/South_Georgia";
 
-Settings.defaultLocale = "en-CA";
+const defaults = () => {
+  Settings.defaultLocale = "en-CA";
+  Settings.defaultZone = "system";
+};
+
+beforeEach(defaults);
 
 describe("Format a time slot", () => {
   it("should convert a JS Date object to simple time string", () => {
@@ -29,6 +34,7 @@ describe("Format a time slot", () => {
   });
 
   it("should convert a JS Date object to simple time string in another timezone", () => {
+    Settings.defaultZone = "Europe/London";
     const timeSlot = formatTimeSlot(date, DateTime.local().zoneName);
     expect(timeSlot).toEqual(simpleTimeString);
   });


### PR DESCRIPTION
# Code changes

- [x] Added `loader` checks for the thread click handler in them mailbox and email components. This prevents a user from invoking the handlers over and over again while the previous invocation is still running. This also now makes it so that when a thread is expanding, we see the top loader animation.
- [x] Fixed failing tests after the UK entered DST (thanks @yifanplanet for tracking this!) 
- [x] Fixed failing availability tests

# Readiness checklist

- [x] Added changes to component `CHANGELOG.md`
- [x] Cypress tests passing?
- [x] New cypress tests added?

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
