### PR TITLE
Fixed: reply and reply all were mutating the message object

### DIFF
--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -578,7 +578,7 @@
       }
       dispatchEvent(event_identifier, {
         event,
-        message: { ...existingDraft, subject, to, cc },
+        message: { ...existingDraft },
         thread: activeThread,
         value,
       });
@@ -586,7 +586,7 @@
       //Creating new reply message
       dispatchEvent(event_identifier, {
         event,
-        message: { ...message, subject, to, cc },
+        message: { ...message },
         thread: activeThread,
         value,
       });
@@ -612,7 +612,7 @@
       }
       dispatchEvent("forwardClicked", {
         event,
-        message: { ...existingDraft, subject },
+        message: { ...existingDraft },
         thread: activeThread,
         value,
       });
@@ -620,7 +620,7 @@
       //Create new message
       dispatchEvent("forwardClicked", {
         event,
-        message: { ...message, subject },
+        message: { ...message },
         thread: activeThread,
         value,
       });

--- a/components/email/src/init.spec.js
+++ b/components/email/src/init.spec.js
@@ -1342,6 +1342,43 @@ describe("Should Render Reply Button And Dispatch Event When Clicked", () => {
         expect(replyClicked).to.be.true;
       });
   });
+
+  it("Should Dispatch Event When Reply Button Is Clicked With Proper Event Message", () => {
+    let container = {};
+    const EVENT_ID = "replyClicked";
+    cy.get("@email").invoke("prop", "message", SINGLE_SENDER_MESSAGE);
+    cy.get("@email").find("div.reply button").as("replyButton");
+    cy.get("@replyButton").should("exist");
+
+    cy.get("@email").then((elements) => {
+      const component = elements[0];
+      const listener = (event) => {
+        component.removeEventListener(EVENT_ID, listener);
+        container.e = event;
+      };
+      component.addEventListener(EVENT_ID, listener);
+    });
+
+    cy.get("@replyButton")
+      .click()
+      .then(() => {
+        cy.wrap(container).should(
+          (container) => expect(container.e).not.to.be.undefined,
+        );
+        cy.wrap(container).then((container) => {
+          expect(container.e.detail.message).to.not.to.be.undefined;
+          expect(container.e.detail.message.to).to.equal(
+            SINGLE_SENDER_MESSAGE.to,
+          );
+          expect(container.e.detail.message.from).to.equal(
+            SINGLE_SENDER_MESSAGE.from,
+          );
+          expect(container.e.detail.message.subject).to.equal(
+            SINGLE_SENDER_MESSAGE.subject,
+          );
+        });
+      });
+  });
 });
 
 describe("Should Render Reply All Button And Respond To Clicks", () => {
@@ -1430,6 +1467,43 @@ describe("Should Render Reply All Button And Respond To Clicks", () => {
       .click()
       .then(() => {
         expect(replyAllClicked).to.be.true;
+      });
+  });
+
+  it("Should Dispatch Event When Reply All Button Is Clicked With Proper Event Message", () => {
+    let container = {};
+    const EVENT_ID = "replyAllClicked";
+    cy.get("@email").invoke("prop", "message", MULTIPLE_SENDER_MESSAGE);
+    cy.get("@email").find("div.reply-all button").as("replyAllButton");
+    cy.get("@replyAllButton").should("exist");
+
+    cy.get("@email").then((elements) => {
+      const component = elements[0];
+      const listener = (event) => {
+        component.removeEventListener(EVENT_ID, listener);
+        container.e = event;
+      };
+      component.addEventListener(EVENT_ID, listener);
+    });
+
+    cy.get("@replyAllButton")
+      .click()
+      .then(() => {
+        cy.wrap(container).should(
+          (container) => expect(container.e).not.to.be.undefined,
+        );
+        cy.wrap(container).then((container) => {
+          expect(container.e.detail.message).to.not.to.be.undefined;
+          expect(container.e.detail.message.to).to.equal(
+            MULTIPLE_SENDER_MESSAGE.to,
+          );
+          expect(container.e.detail.message.from).to.equal(
+            MULTIPLE_SENDER_MESSAGE.from,
+          );
+          expect(container.e.detail.message.subject).to.equal(
+            MULTIPLE_SENDER_MESSAGE.subject,
+          );
+        });
       });
   });
 });


### PR DESCRIPTION
# Code changes

- [x] Remove mutations from the `event.detail.message` object that is submitted when the `replyClicked` and `replyAllClicked` events are fired

# Readiness checklist

- [ ] Added changes to component `CHANGELOG.md`
- [ ] New property added? make sure to update `component/src/properties.json`
- [ ] Cypress tests passing?
- [ ] New cypress tests added?
- [ ] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
