### PR TITLE
[Email/Mailbox] Show .ics files as attachments

### DIFF
--- a/commons/src/constants/attachment-content-types.ts
+++ b/commons/src/constants/attachment-content-types.ts
@@ -1,7 +1,6 @@
 export const DisallowedContentTypes = [
   "message/delivery-status",
   "message/rfc822",
-  "text/calendar",
 ];
 
 export const InlineImageTypes = [

--- a/commons/src/methods/isFileAnAttachment.ts
+++ b/commons/src/methods/isFileAnAttachment.ts
@@ -6,6 +6,7 @@ import {
 
 export const isFileAnAttachment = (message: Message, file: File): boolean =>
   file.content_disposition === "attachment" &&
+  file.filename &&
   !(
     file.content_id &&
     message.cids?.includes(file.content_id) &&

--- a/components/email/src/init.spec.js
+++ b/components/email/src/init.spec.js
@@ -38,6 +38,19 @@ const SAMPLE_THREAD = {
           id: "d1fop1j6savk2dqex9uvwvclt",
           size: 27174,
         },
+        {
+          content_disposition: "attachment",
+          content_type: "text/calendar",
+          filename: null,
+          id: "32yf13av2aiq6is5t1jov7ofd",
+          size: 1005,
+        },
+        {
+          content_disposition: "attachment",
+          content_type: "application/ics",
+          filename: "invite.ics",
+          id: "cvmampvjwqvunwmey4b5fp84f",
+        },
       ],
       from: [
         {
@@ -950,6 +963,7 @@ describe("Email: Images and Files", () => {
     cy.get("@email").find(".email-row.condensed .attachment").should("exist");
     cy.get("@email")
       .find(".email-row.condensed .attachment button")
+      .first()
       .should("have.text", "invoice_2062.pdf ");
   });
 });

--- a/components/email/src/init.spec.js
+++ b/components/email/src/init.spec.js
@@ -50,6 +50,14 @@ const SAMPLE_THREAD = {
           content_type: "application/ics",
           filename: "invite.ics",
           id: "cvmampvjwqvunwmey4b5fp84f",
+          size: 1005,
+        },
+        {
+          content_disposition: "attachment",
+          content_type: "text/calendar",
+          filename: "US_Holidays.ics",
+          id: "64qp23bc3asd6ih7t47ofd",
+          size: 4321,
         },
       ],
       from: [
@@ -965,6 +973,30 @@ describe("Email: Images and Files", () => {
       .find(".email-row.condensed .attachment button")
       .first()
       .should("have.text", "invoice_2062.pdf ");
+  });
+
+  it("Shows .ics attachments when condensed", () => {
+    cy.get("@email").invoke("prop", "show_expanded_email_view_onload", false);
+    cy.get("@email").invoke("prop", "thread", SAMPLE_THREAD);
+
+    cy.get("@email").find(".email-row.condensed .attachment").should("exist");
+    cy.get("@email")
+      .find(".email-row.condensed .attachment button")
+      .first()
+      .nextAll()
+      .should("have.text", "invite.ics US_Holidays.ics ");
+  });
+
+  it("Does not show ghost/unnamed .ics attachments included in calendar invites", () => {
+    cy.get("@email").invoke("prop", "show_expanded_email_view_onload", false);
+    cy.get("@email").invoke("prop", "thread", SAMPLE_THREAD);
+
+    cy.get("@email").find(".email-row.condensed .attachment").should("exist");
+    cy.get("@email")
+      .find(".email-row.condensed .attachment button")
+      .first()
+      .nextAll()
+      .should("not.include.text", "32yf13av2aiq6is5t1jov7ofd");
   });
 });
 

--- a/components/mailbox/src/init.spec.js
+++ b/components/mailbox/src/init.spec.js
@@ -108,6 +108,7 @@ describe("Mailbox Display", () => {
   let thread1;
   let thread2;
   let THREAD_WITH_MESSAGE_THAT_DOES_NOT_HAVE_FROM_OR_TO_FIELDS;
+  let THREAD_WITH_CALENDAR_ATTACHMENTS;
 
   beforeEach(() => {
     cy.intercept(
@@ -153,6 +154,12 @@ describe("Mailbox Display", () => {
       THREAD_WITH_MESSAGE_THAT_DOES_NOT_HAVE_FROM_OR_TO_FIELDS = f.response;
     });
 
+    cy.fixture("mailbox/threads/threadWithCalendarAttachments.json").then(
+      (f) => {
+        THREAD_WITH_CALENDAR_ATTACHMENTS = f.response;
+      },
+    );
+
     cy.fixture("mailbox/threads/SAMPLE_1.json").then((f) => {
       thread1 = f;
     });
@@ -191,6 +198,32 @@ describe("Mailbox Display", () => {
     cy.get("@email")
       .find(".snippet")
       .contains("Sorry, looks like this thread is currently unavailable");
+  });
+
+  it("Shows both .ics files and calendar invites as attachments", () => {
+    cy.get("@mailbox").invoke(
+      "prop",
+      "all_threads",
+      THREAD_WITH_CALENDAR_ATTACHMENTS,
+    );
+
+    cy.get("@email").find(".email-row.condensed .attachment").should("exist");
+    cy.get("@email")
+      .find(".email-row.condensed .attachment button")
+      .should("have.text", "invite.ics US_Holidays.ics ");
+  });
+
+  it.only("Does not show attachment button for unnamed .ics files attached with invites", () => {
+    cy.get("@mailbox").invoke(
+      "prop",
+      "all_threads",
+      THREAD_WITH_CALENDAR_ATTACHMENTS,
+    );
+
+    cy.get("@email").find(".email-row.condensed .attachment").should("exist");
+    cy.get("@email")
+      .find(".email-row.condensed .attachment button")
+      .should("not.include.text", "32yf13av2aiq6is5t1jov7ofd");
   });
 });
 

--- a/cypress/fixtures/mailbox/threads/threadWithCalendarAttachments copy.json
+++ b/cypress/fixtures/mailbox/threads/threadWithCalendarAttachments copy.json
@@ -1,0 +1,82 @@
+{
+  "account_id": "1xrddnl99frq3b7son9j32aba",
+  "drafts": [],
+  "first_message_timestamp": 1629832405,
+  "has_attachments": true,
+  "id": "dlrwnv5oc3v3apxc2j0ht8vop",
+  "labels": [
+    {
+      "display_name": "Inbox",
+      "id": "dx62wkpj57erbkargbr3zew3j",
+      "name": "inbox"
+    }
+  ],
+  "last_message_received_timestamp": 1629832405,
+  "last_message_sent_timestamp": null,
+  "last_message_timestamp": 1629832405,
+  "messages": [
+    {
+      "account_id": "1xrddnl99frq3b7son9j32aba",
+      "bcc": [],
+      "cc": [],
+      "date": 1629832405,
+      "files": [
+        {
+          "content_disposition": "attachment",
+          "content_type": "application/pdf",
+          "filename": "invoice_2062.pdf",
+          "id": "d1fop1j6savk2dqex9uvwvclt",
+          "size": 27174
+        },
+        {
+          "content_disposition": "attachment",
+          "content_type": "text/calendar",
+          "filename": null,
+          "id": "32yf13av2aiq6is5t1jov7ofd",
+          "size": 1005
+        },
+        {
+          "content_disposition": "attachment",
+          "content_type": "application/ics",
+          "filename": "invite.ics",
+          "id": "cvmampvjwqvunwmey4b5fp84f",
+          "size": 1005
+        },
+        {
+          "content_disposition": "attachment",
+          "content_type": "text/calendar",
+          "filename": "US_Holidays.ics",
+          "id": "64qp23bc3asd6ih7t47ofd",
+          "size": 4321
+        }
+      ],
+      "from": [{ "email": "tips@nylas.com", "name": "J Valdivia" }],
+      "id": "3ozrqu3obfwzmsltxj72ll86m",
+      "labels": [
+        {
+          "display_name": "Inbox",
+          "id": "dx62wkpj57erbkargbr3zew3j",
+          "name": "inbox"
+        }
+      ],
+      "object": "message",
+      "reply_to": [{ "email": "tips@nylas.com", "name": "" }],
+      "snippet": "Set yourself up for an integration that scales by avoiding common roadblocks and pitfalls. Learn how to boost revenue, accelerate your roadmap, and meet & exceed your customers’ needs with these assets.",
+      "starred": false,
+      "subject": "API Integration Pitfalls and How to Avoid Them",
+      "thread_id": "dlrwnv5oc3v3apxc2j0ht8vop",
+      "to": [{ "email": "nylascypresstest+trialuser2@gmail.com", "name": "" }],
+      "unread": true
+    }
+  ],
+  "object": "thread",
+  "participants": [
+    { "email": "tips@nylas.com", "name": "J Valdivia" },
+    { "email": "nylascypresstest+trialuser2@gmail.com", "name": "" }
+  ],
+  "snippet": "Set yourself up for an integration that scales by avoiding common roadblocks and pitfalls. Learn how to boost revenue, accelerate your roadmap, and meet & exceed your customers’ needs with these assets.",
+  "starred": false,
+  "subject": "API Integration Pitfalls and How to Avoid Them",
+  "unread": true,
+  "version": 2
+}

--- a/cypress/fixtures/mailbox/threads/threadWithCalendarAttachments.json
+++ b/cypress/fixtures/mailbox/threads/threadWithCalendarAttachments.json
@@ -1,0 +1,84 @@
+{
+  "component": {
+    "theming": {}
+  },
+  "response": [
+    {
+      "account_id": "1xrddnl99frq3b7son9j32aba",
+      "drafts": [],
+      "first_message_timestamp": 1629832405,
+      "has_attachments": true,
+      "id": "dlrwnv5oc3v3apxc2j0ht8vop",
+      "labels": [
+        {
+          "display_name": "Inbox",
+          "id": "dx62wkpj57erbkargbr3zew3j",
+          "name": "inbox"
+        }
+      ],
+      "last_message_received_timestamp": 1629832405,
+      "last_message_sent_timestamp": null,
+      "last_message_timestamp": 1629832405,
+      "messages": [
+        {
+          "account_id": "1xrddnl99frq3b7son9j32aba",
+          "bcc": [],
+          "cc": [],
+          "date": 1629832405,
+          "files": [
+            {
+              "content_disposition": "attachment",
+              "content_type": "text/calendar",
+              "filename": null,
+              "id": "32yf13av2aiq6is5t1jov7ofd",
+              "size": 1005
+            },
+            {
+              "content_disposition": "attachment",
+              "content_type": "application/ics",
+              "filename": "invite.ics",
+              "id": "cvmampvjwqvunwmey4b5fp84f",
+              "size": 1005
+            },
+            {
+              "content_disposition": "attachment",
+              "content_type": "text/calendar",
+              "filename": "US_Holidays.ics",
+              "id": "64qp23bc3asd6ih7t47ofd",
+              "size": 4321
+            }
+          ],
+          "from": [{ "email": "tips@nylas.com", "name": "J Valdivia" }],
+          "id": "3ozrqu3obfwzmsltxj72ll86m",
+          "labels": [
+            {
+              "display_name": "Inbox",
+              "id": "dx62wkpj57erbkargbr3zew3j",
+              "name": "inbox"
+            }
+          ],
+          "object": "message",
+          "reply_to": [{ "email": "tips@nylas.com", "name": "" }],
+          "snippet": "Set yourself up for an integration that scales by avoiding common roadblocks and pitfalls. Learn how to boost revenue, accelerate your roadmap, and meet & exceed your customers’ needs with these assets.",
+          "starred": false,
+          "subject": "API Integration Pitfalls and How to Avoid Them",
+          "thread_id": "dlrwnv5oc3v3apxc2j0ht8vop",
+          "to": [
+            { "email": "nylascypresstest+trialuser2@gmail.com", "name": "" }
+          ],
+          "unread": true
+        }
+      ],
+      "object": "thread",
+      "participants": [
+        { "email": "tips@nylas.com", "name": "J Valdivia" },
+        { "email": "nylascypresstest+trialuser2@gmail.com", "name": "" }
+      ],
+      "snippet": "Set yourself up for an integration that scales by avoiding common roadblocks and pitfalls. Learn how to boost revenue, accelerate your roadmap, and meet & exceed your customers’ needs with these assets.",
+      "starred": false,
+      "subject": "API Integration Pitfalls and How to Avoid Them",
+      "unread": true,
+      "version": 2
+    }
+  ]
+}


### PR DESCRIPTION
# Code Changes
- Removed 'text/calendar' for disallowed content types to allow display of .ics calendar attachments
- added check to `isFileAttachment` that verifies file has a `filename` property set.  .ics files are appending two files to file list, one without a set filename.

# Screenshots:

## Before
![Screen Shot 2022-03-28 at 10 42 57 PM](https://user-images.githubusercontent.com/43771331/160535410-6b7fa12f-ec8b-4271-827e-7686d01d796f.png)

## After
![Screen Shot 2022-03-28 at 10 47 06 PM](https://user-images.githubusercontent.com/43771331/160535434-7b0e4843-4ba6-4415-aea5-9d548706bf3a.png)

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner
