### PR TITLE
[Composer] bring focus on editor when text formatting option clicked

### DIFF
--- a/components/composer/src/components/HTMLEditor.svelte
+++ b/components/composer/src/components/HTMLEditor.svelte
@@ -108,14 +108,14 @@
     // if contenteditable area is empty we need to add something to add range
     if (container.innerHTML === "") {
       container.innerHTML = "\u00a0";
-    }
-    const selection = window.getSelection();
-    const range = document.createRange();
-    range.selectNodeContents(container);
-    range.collapse(false); // collapse range to the end
+      const selection = window.getSelection();
+      const range = document.createRange();
+      range.selectNodeContents(container);
+      range.collapse(false); // collapse range to the end
 
-    selection.removeAllRanges();
-    selection.addRange(range);
+      selection.removeAllRanges();
+      selection.addRange(range);
+    }
   };
 </script>
 
@@ -187,14 +187,12 @@
         <button
           on:click={handleAction(item)}
           title={item.title}
-          class={item.state && item.state() ? "active" : ""}
-        >
+          class={item.state && item.state() ? "active" : ""}>
           {#if item.icon}
             <svelte:component
               this={item.icon}
               class="icon"
-              style="fill: var(--composer-icons-color, #666774) !important; width: 12px; height: 12px;"
-            />
+              style="fill: var(--composer-icons-color, #666774) !important; width: 12px; height: 12px;" />
           {:else}{item.title.charAt(0)}{/if}
         </button>
       {/each}
@@ -226,6 +224,5 @@
     role="textbox"
     aria-label="HTML Editor"
     on:keyup={updateToolbarUI}
-    on:mouseup={updateToolbarUI}
-  />
+    on:mouseup={updateToolbarUI} />
 </div>

--- a/components/composer/src/components/HTMLEditor.svelte
+++ b/components/composer/src/components/HTMLEditor.svelte
@@ -84,14 +84,13 @@
 
   const handleAction = (item: ToolbarItem) => () => {
     if (item.result) {
+      if (container) {
+        container.focus();
+      }
       item.result();
     }
 
     updateToolbarUI();
-
-    if (container) {
-      container.focus();
-    }
   };
 
   // This function updates the toolbar UI state when you select text (eg. select bold text)

--- a/components/composer/src/init.spec.js
+++ b/components/composer/src/init.spec.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-xdescribe("Composer loading state", () => {
+describe("Composer loading state", () => {
   it("displays loading screen", () => {
     cy.visit("/components/composer/src/cypress.html");
 
@@ -8,7 +8,7 @@ xdescribe("Composer loading state", () => {
   });
 });
 
-xdescribe("Composer dispatches events", () => {
+describe("Composer dispatches events", () => {
   const eventsFired = {
     minimized: false,
     maximized: false,
@@ -96,7 +96,7 @@ xdescribe("Composer dispatches events", () => {
   });
 });
 
-xdescribe("Composer `to` prop", () => {
+describe("Composer `to` prop", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -151,7 +151,7 @@ xdescribe("Composer `to` prop", () => {
   });
 });
 
-xdescribe("Composer interactions", () => {
+describe("Composer interactions", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -265,7 +265,7 @@ xdescribe("Composer interactions", () => {
   });
 });
 
-xdescribe("Composer customizations", () => {
+describe("Composer customizations", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -562,7 +562,7 @@ xdescribe("Composer customizations", () => {
   });
 });
 
-xdescribe("Composer integration", () => {
+describe("Composer integration", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -751,7 +751,7 @@ xdescribe("Composer integration", () => {
   });
 });
 
-xdescribe("Composer callbacks and options", () => {
+describe("Composer callbacks and options", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -807,7 +807,7 @@ xdescribe("Composer callbacks and options", () => {
   });
 });
 
-xdescribe("Composer file upload", () => {
+describe("Composer file upload", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -969,7 +969,7 @@ xdescribe("Composer file upload", () => {
   });
 });
 
-xdescribe("Composer subject", () => {
+describe("Composer subject", () => {
   beforeEach(() => {
     cy.visitComponentPage(
       "/components/composer/src/index.html",
@@ -998,7 +998,7 @@ xdescribe("Composer subject", () => {
   });
 });
 
-xdescribe("Save composer message as draft", () => {
+describe("Save composer message as draft", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -1087,7 +1087,7 @@ xdescribe("Save composer message as draft", () => {
   });
 });
 
-xdescribe("Composer `value` prop", () => {
+describe("Composer `value` prop", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -1370,7 +1370,7 @@ describe("Composer formatting", () => {
       .should("contain", "<b><i><u>hello</u></i></b>");
   });
 
-  it.only("Existing text can be selected, formatted, and formatting holds for continued text", () => {
+  it("Existing text can be selected, formatted, and formatting holds for continued text", () => {
     cy.get("@composer")
       .shadow()
       .get("nylas-html-editor")

--- a/components/composer/src/init.spec.js
+++ b/components/composer/src/init.spec.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-describe("Composer loading state", () => {
+xdescribe("Composer loading state", () => {
   it("displays loading screen", () => {
     cy.visit("/components/composer/src/cypress.html");
 
@@ -8,7 +8,7 @@ describe("Composer loading state", () => {
   });
 });
 
-describe("Composer dispatches events", () => {
+xdescribe("Composer dispatches events", () => {
   const eventsFired = {
     minimized: false,
     maximized: false,
@@ -96,7 +96,7 @@ describe("Composer dispatches events", () => {
   });
 });
 
-describe("Composer `to` prop", () => {
+xdescribe("Composer `to` prop", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -151,7 +151,7 @@ describe("Composer `to` prop", () => {
   });
 });
 
-describe("Composer interactions", () => {
+xdescribe("Composer interactions", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -265,7 +265,7 @@ describe("Composer interactions", () => {
   });
 });
 
-describe("Composer customizations", () => {
+xdescribe("Composer customizations", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -562,7 +562,7 @@ describe("Composer customizations", () => {
   });
 });
 
-describe("Composer integration", () => {
+xdescribe("Composer integration", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -751,7 +751,7 @@ describe("Composer integration", () => {
   });
 });
 
-describe("Composer callbacks and options", () => {
+xdescribe("Composer callbacks and options", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -807,7 +807,7 @@ describe("Composer callbacks and options", () => {
   });
 });
 
-describe("Composer file upload", () => {
+xdescribe("Composer file upload", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -969,7 +969,7 @@ describe("Composer file upload", () => {
   });
 });
 
-describe("Composer subject", () => {
+xdescribe("Composer subject", () => {
   beforeEach(() => {
     cy.visitComponentPage(
       "/components/composer/src/index.html",
@@ -998,7 +998,7 @@ describe("Composer subject", () => {
   });
 });
 
-describe("Save composer message as draft", () => {
+xdescribe("Save composer message as draft", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -1087,7 +1087,7 @@ describe("Save composer message as draft", () => {
   });
 });
 
-describe("Composer `value` prop", () => {
+xdescribe("Composer `value` prop", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -1273,5 +1273,132 @@ describe("Composer `value` prop", () => {
       .shadow()
       .get("nylas-composer-alert-bar")
       .should("contain", "Message sent successfully!");
+  });
+});
+
+describe("Composer formatting", () => {
+  beforeEach(() => {
+    cy.visit("/components/composer/src/cypress.html");
+
+    cy.get("nylas-composer").should("exist").as("composer");
+    cy.get("nylas-composer").shadow().get(".nylas-composer").should("exist");
+  });
+
+  it("With editor empty, 'Bold' button sets editor focus and begins typing in bold", () => {
+    cy.get("@composer")
+      .shadow()
+      .get("nylas-html-editor")
+      .shadow()
+      .findByRole("button", { name: /Bold/i })
+      .focus()
+      .type("hello"); // focus leaves editor when grabbing .focused() element; use .type()'s implicit submission instead
+
+    cy.get("@composer")
+      .shadow()
+      .get("nylas-html-editor")
+      .shadow()
+      .get(".html-editor-content[contenteditable]")
+      .invoke("html")
+      .should("contain", "<b>hello</b>");
+  });
+
+  it("With editor empty, 'Italics' button sets editor focus and begins typing italics", () => {
+    cy.get("@composer")
+      .shadow()
+      .get("nylas-html-editor")
+      .shadow()
+      .findByRole("button", { name: /Italic/i })
+      .focus()
+      .type("hello"); // using .type()'s implicit submission; focus leaves editor when grabbing .focused() element
+
+    cy.get("@composer")
+      .shadow()
+      .get("nylas-html-editor")
+      .shadow()
+      .get(".html-editor-content[contenteditable]")
+      .invoke("html")
+      .should("contain", "<i>hello</i>");
+  });
+
+  it("With editor empty, 'Underline' button sets editor focus and begins typing with underline", () => {
+    cy.get("@composer")
+      .shadow()
+      .get("nylas-html-editor")
+      .shadow()
+      .findByRole("button", { name: /Underline/i })
+      .focus()
+      .type("hello"); // using .type()'s implicit submission; focus leaves editor when grabbing .focused() element
+
+    cy.get("@composer")
+      .shadow()
+      .get("nylas-html-editor")
+      .shadow()
+      .get(".html-editor-content[contenteditable]")
+      .invoke("html")
+      .should("contain", "<u>hello</u>");
+  });
+
+  it("Selecting all three text formatting options begins typing bold, italic, and underlined text", () => {
+    cy.get("@composer")
+      .shadow()
+      .get("nylas-html-editor")
+      .shadow()
+      .findByRole("button", { name: /Bold/i })
+      .click();
+
+    cy.get("@composer")
+      .shadow()
+      .get("nylas-html-editor")
+      .shadow()
+      .findByRole("button", { name: /Italic/i })
+      .click();
+
+    cy.get("@composer")
+      .shadow()
+      .get("nylas-html-editor")
+      .shadow()
+      .findByRole("button", { name: /Underline/i })
+      .focus()
+      .type("hello"); // using .type()'s implicit submission; focus leaves editor when grabbing .focused() element
+
+    cy.get("@composer")
+      .shadow()
+      .get("nylas-html-editor")
+      .shadow()
+      .get(".html-editor-content[contenteditable]")
+      .invoke("html")
+      .should("contain", "<b><i><u>hello</u></i></b>");
+  });
+
+  it.only("Existing text can be selected, formatted, and formatting holds for continued text", () => {
+    cy.get("@composer")
+      .shadow()
+      .get("nylas-html-editor")
+      .shadow()
+      .get(".html-editor-content[contenteditable]")
+      .type("{selectall}{backspace}hello{selectAll}");
+
+    cy.get("@composer")
+      .shadow()
+      .get("nylas-html-editor")
+      .shadow()
+      .findByRole("button", { name: /Bold/i })
+      .click();
+
+    cy.get("@composer")
+      .shadow()
+      .get("nylas-html-editor")
+      .shadow()
+      .get(".html-editor-content[contenteditable]")
+      .clear()
+      .type("{rightArrow}, world!");
+
+    cy.get("@composer")
+      .shadow()
+      .get("nylas-html-editor")
+      .shadow()
+      .get(".html-editor-content[contenteditable]")
+      .invoke("html")
+      .should("contain", "<b>hello, world!</b>");
   });
 });


### PR DESCRIPTION
# Code Changes
- Focuses on editor before formatting is executed to get caret position
- Only creates and collapses new range for dummy character if editor is empty (Firefox fix)
- Tests rely on implicit button submission of `.type()` method to keep formatting at the active caret position; focus leaves the editor between executing `.click()` and then typing into the element found with `.focused()`

# Screen Captures
## Before

![before](https://user-images.githubusercontent.com/43771331/162129518-403d98a6-1a6e-4877-885e-26c406cea496.gif)

## After

![After](https://user-images.githubusercontent.com/43771331/162129699-1fd5a085-7e9a-4239-b70f-2ca59ed3df1f.gif)

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.