### PR TITLE
[Email]: Prevent trying to fetch email before external properties fully load.

### DIFF
--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -114,8 +114,11 @@
   $: userEmail = <string>_this.you?.email_address;
   const PARTICIPANTS_TO_TRUNCATE = 3;
 
+  let propsLoaded = false;
   onMount(async () => {
     await tick();
+    propsLoaded = true;
+
     manifest = ((await $ManifestStore[
       JSON.stringify({ component_id: id, access_token })
     ]) || {}) as EmailProperties;
@@ -150,18 +153,19 @@
   });
 
   let previousProps = $$props;
-  $: (async () => {
-    if (JSON.stringify(previousProps) !== JSON.stringify($$props)) {
-      _this = buildInternalProps(
-        $$props,
-        manifest,
-        defaultValueMap,
-      ) as EmailProperties;
+  $: propsLoaded &&
+    (async () => {
+      if (JSON.stringify(previousProps) !== JSON.stringify($$props)) {
+        _this = buildInternalProps(
+          $$props,
+          manifest,
+          defaultValueMap,
+        ) as EmailProperties;
 
-      await transformPropertyValues();
-      previousProps = $$props;
-    }
-  })();
+        await transformPropertyValues();
+        previousProps = $$props;
+      }
+    })();
 
   async function transformPropertyValues() {
     _this.thread_id = !thread && !message_id && !message ? _this.thread_id : "";


### PR DESCRIPTION
# Issue
Address issue where 422 response was received when some properties were passed to the `<nylas-email>` custom element before the `access_token` property was passed ([JIRA](https://nylas.atlassian.net/jira/software/c/projects/TW/boards/44?modal=detail&selectedIssue=TW-465)).

On investigation, props are passed one-by-one and reactivity was triggering an API request if the `id` attribute was present.  Requests sent with the `id` property before the `access_token` was loaded return a 422 error if there is a token in the database.

# Code changes

- adds boolean `propsLoaded` value that prevents first request from running until after `tick()`

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.