### PR TITLE
[Email] Fixed thread_id is not loaded from the manifest if/when set

### DIFF
--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -168,7 +168,10 @@
     })();
 
   async function transformPropertyValues() {
-    _this.thread_id = !thread && !message_id && !message ? _this.thread_id : "";
+    _this.thread_id =
+      !thread && !message_id && !message
+        ? _this.thread_id || manifest.thread_id
+        : "";
 
     if (id && !_this.thread_id && !_this.thread && _this.message_id) {
       fetchOneMessage();

--- a/components/email/src/init.spec.js
+++ b/components/email/src/init.spec.js
@@ -826,6 +826,11 @@ describe("Email: Displays threads and messages", () => {
     cy.get("@email").find(".subject").should("contain", "Test subject");
   });
 
+  it("Shows Email with only demo id by fetching manifest", () => {
+    cy.get("@email").find(".subject").should("exist");
+    cy.get("@email").find(".subject").should("contain", "Test subject");
+  });
+
   it("Shows Email with passed thread", () => {
     cy.get("@email").invoke("prop", "thread", SAMPLE_THREAD);
 

--- a/cypress/fixtures/email/manifest.json
+++ b/cypress/fixtures/email/manifest.json
@@ -2,7 +2,7 @@
   "component": {
     "theming": {
       "show_received_timestamp": true,
-      "thread_id": "b3z0fd5kbbwcxvf4q1ele5us6",
+      "thread_id": "b3z0fd5kbbwcxbvf4q1ele5us6",
       "clean_conversation": false,
       "unread": false,
       "show_star": false,


### PR DESCRIPTION
# Code changes

- [x] Fixed `thread_id` is not loaded from the manifest if/when set

# Readiness checklist
- [x] Cypress tests passing?
- [x] New cypress tests added?

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
