### PR TITLE
Expand/Collapse thread in email components when click_action is default

### DIFF
--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -408,16 +408,15 @@
     }
     loading = true;
     if (_this.click_action === "default" || _this.click_action === "mailbox") {
-      //#region read/unread
-      if (
-        activeThread &&
-        activeThread.unread &&
-        _this.click_action !== "mailbox"
-      ) {
-        activeThread.unread = !activeThread.unread;
-        await saveActiveThread();
+      // default click action
+      if (activeThread && _this.click_action === "default") {
+        // Setting read/unread status
+        if (activeThread.unread) {
+          activeThread.unread = !activeThread.unread;
+          await saveActiveThread();
+        }
+        activeThread.expanded = !activeThread.expanded;
       }
-      //#endregion read/unread
 
       if (!emailManuallyPassed && messageType !== MessageType.DRAFTS) {
         const { messages } = activeThread;


### PR DESCRIPTION
# Expected behaviour
- If the property `click_action` is `default`, when clicking on the thread will close the Email if it's an expanded thread, expand the Email if it's a closed thread, and set the active thread to read if previously unread.

# Code changes
- [x] Expand/Collapse thread in email components when click_action is default

# Readiness checklist
- [ ] Cypress tests passing?

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
