### PR TITLE
Expand/Collapse thread in email components when click_action is default

### DIFF
--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -1378,7 +1378,7 @@
       .from-message-count {
         align-items: center;
         display: grid;
-        grid-template-columns: repeat(3, auto);
+        grid-template-columns: repeat(2, auto);
         grid-gap: $spacing-m;
         justify-content: flex-start;
         max-width: 350px;
@@ -1554,7 +1554,7 @@
           }
         }
         &.condensed {
-          padding: $spacing-xs 0;
+          padding: $spacing-xs;
           justify-content: initial;
 
           div.starred {

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -408,16 +408,15 @@
     }
     loading = true;
     if (_this.click_action === "default" || _this.click_action === "mailbox") {
-      //#region read/unread
-      if (
-        activeThread &&
-        activeThread.unread &&
-        _this.click_action !== "mailbox"
-      ) {
-        activeThread.unread = !activeThread.unread;
-        await saveActiveThread();
+      // default click action
+      if (activeThread && _this.click_action === "default") {
+        // Setting read/unread status
+        if (activeThread.unread) {
+          activeThread.unread = !activeThread.unread;
+          await saveActiveThread();
+        }
+        activeThread.expanded = !activeThread.expanded;
       }
-      //#endregion read/unread
 
       if (!emailManuallyPassed && messageType !== MessageType.DRAFTS) {
         const { messages } = activeThread;

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -818,7 +818,6 @@
     #mailboxlist li {
       display: grid;
       grid-template-columns: auto 1fr;
-      gap: 0.5rem;
       align-items: center;
       justify-content: left;
       position: relative;
@@ -937,7 +936,7 @@
     main {
       #mailboxlist li {
         .checkbox-container.thread-checkbox {
-          padding: 0.6rem 0.5rem 0 $spacing-m;
+          padding: 0.6rem 0 0 $spacing-m;
           display: flex;
           min-height: 2rem;
           align-items: center;


### PR DESCRIPTION
# Expected behaviour
- If the property `click_action` is `default`, when clicking on the thread will close the Email if it's an expanded thread, expand the Email if it's a closed thread, and set the active thread to read if previously unread.

# Code changes
- [x] Expand/Collapse thread in email components when click_action is default
- [x] Updated Email component style so there's padding on the left of avatar, and updated the corresponding style in Mailbox component.

# Screenshot
## Before
![Screen Shot 2022-05-26 at 10 45 09 PM](https://user-images.githubusercontent.com/14408339/170618589-453101c2-9b7c-4311-8b69-af276b3166b2.png)
## After
![Screen Shot 2022-05-26 at 10 42 32 PM](https://user-images.githubusercontent.com/14408339/170618500-585fd6c9-f3bb-4fae-92ad-b116fabc5abe.png)

# Readiness checklist
- [x] Cypress tests passing?

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
