### PR TITLE
Composer Component: Update the ability to consume Nylas Contact type

### DIFF
--- a/commons/src/methods/participants.ts
+++ b/commons/src/methods/participants.ts
@@ -59,3 +59,30 @@ export function buildParticipants({
 
   return { to, cc };
 }
+
+export const isValidParticipant = (participant: Participant): boolean => {
+  if ("email" in participant && "name" in participant) {
+    return true;
+  }
+  return false;
+};
+
+export const cleanParticipants = (contacts: any[]): Participant[] => {
+  const participants = contacts.reduce((result: Participant[], contact) => {
+    if (isValidParticipant(contact)) {
+      // If it is a valid Participant type
+      result.push(contact);
+    } else {
+      // If it is a Contact type, consumed /contacts api
+      if ("emails" in contact && contact.emails?.length > 0) {
+        result.push({
+          name: `${contact.given_name ?? ""} ${contact.surname ?? ""}`,
+          email: contact.emails[0].email,
+          contact,
+        });
+      }
+    }
+    return result;
+  }, []);
+  return participants;
+};

--- a/components/composer/CHANGELOG.md
+++ b/components/composer/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## New Features
 
+- Added the ability for Composer to consume [Nylas Contact](https://developer.nylas.com/docs/api#tag--Contacts) type into `to` `from`, `cc` and `bcc`. [#447](https://github.com/nylas/components/pull/447)
+
 ## Bug Fixes
 
 - Focus the HTML editor textbox when a formatting option is clicked [#342](https://github.com/nylas/components/pull/342)

--- a/components/composer/src/components/ContactsSearch.svelte
+++ b/components/composer/src/components/ContactsSearch.svelte
@@ -3,12 +3,14 @@
 <script lang="ts">
   import { debounce, isValidEmail } from "../lib/utils";
   import { tick } from "svelte";
+  import { cleanParticipants } from "@commons/methods/participants";
   import type { Participant } from "@commons/types/Nylas";
   import type {
     FetchContactsCallback,
     ChangeCallback,
     BlurOptions,
   } from "@commons/types/ContactsSearch";
+
   export let contacts: Participant[] | FetchContactsCallback;
 
   export let value: Participant[] = [];
@@ -28,14 +30,14 @@
   // Initial state setup
   const initialSetup = () => {
     if (Array.isArray(contacts)) {
-      contactsList = contacts;
+      contactsList = cleanParticipants(contacts);
     }
     if (Array.isArray(value)) {
       selectedContacts = value;
     }
   };
 
-  const nylasContacts = () => {
+  const nylasContacts = (): any[] => {
     return [];
   };
   const getContactsSetup = (term: string) => {
@@ -49,7 +51,10 @@
     const getContactsFunc =
       typeof contacts === "function" ? contacts : nylasContacts;
     try {
-      contactsList = await getContactsFunc(term);
+      const contactsResponse = await getContactsFunc(term);
+      if (Array.isArray(contactsResponse)) {
+        contactsList = cleanParticipants(contactsResponse);
+      }
 
       loading = false;
     } catch (error) {
@@ -316,8 +321,7 @@
             <button
               type="button"
               name="term"
-              on:click={() => removeContact(contact.email)}>&times;</button
-            >
+              on:click={() => removeContact(contact.email)}>&times;</button>
           </div>
         {/each}
       </div>
@@ -336,8 +340,7 @@
           on:blur={() => {
             blurSearch({ addContact: true });
           }}
-          bind:value={term}
-        />
+          bind:value={term} />
       </form>
     {/if}
   </div>
@@ -352,8 +355,7 @@
             class:active={currentContactIndex === i}
             class:selected={isSelected(contact.email)}
             on:mousedown={() => selectContact(contact)}
-            on:mouseenter={() => setActiveContact(i)}
-          >
+            on:mouseenter={() => setActiveContact(i)}>
             {#if contact.name}
               <div class="dropdown-item__name">{contact.name}</div>
               <div class="dropdown-item__email">{contact.email}</div>

--- a/components/composer/src/index.html
+++ b/components/composer/src/index.html
@@ -6,8 +6,7 @@
     <link rel="shortcut icon" href="data:;base64,=" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
-    />
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
 
     <script src="../index.js"></script>
     <script>
@@ -40,9 +39,29 @@
         composer.addEventListener("composerOpened", function (event) {
           console.log("Composer Opened", event.detail);
         });
+
+        // Consume different Contact structures
         composer.to = () =>
           new Promise((resolve) => {
-            resolve([{ name: "async", email: "async@test.com" }]);
+            resolve([
+              { name: "Async Contact", email: "async@test.com" },
+              { name: "Async Contact 2", email: "async2@test.com" },
+            ]);
+          });
+        composer.cc = () =>
+          new Promise((resolve) => {
+            resolve([
+              {
+                emails: [
+                  {
+                    email: "test@nylas.com",
+                    type: "work",
+                  },
+                ],
+                given_name: "Name",
+                surname: "Test",
+              },
+            ]);
           });
       });
     </script>

--- a/components/composer/src/init.spec.js
+++ b/components/composer/src/init.spec.js
@@ -152,6 +152,30 @@ describe("Composer `to` prop", () => {
 
     cy.contains("async@test.com");
   });
+
+  it("Replace to field with Nylas contact type", () => {
+    cy.wait(["@getMiddlewareManifest", "@getMiddlewareAccount"]);
+    cy.get("@composer")
+      .then((el) => {
+        const composer = el[0];
+        composer.to = () =>
+          Promise.resolve([
+            {
+              emails: [
+                {
+                  email: "contacttype@test.com",
+                  type: "work",
+                },
+              ],
+              given_name: "Contact",
+              surname: "Test",
+            },
+          ]);
+      })
+      .wait(500);
+    cy.get("[data-cy=contacts-search-field]").first().click().wait(500);
+    cy.contains("contacttype@test.com");
+  });
 });
 
 describe("Composer interactions", () => {

--- a/components/email/src/Email.svelte
+++ b/components/email/src/Email.svelte
@@ -23,7 +23,10 @@
     downloadAttachedFile,
     getEventDispatcher,
   } from "@commons/methods/component";
-  import { buildParticipants, includesMyEmail } from "./methods/participants";
+  import {
+    buildParticipants,
+    includesMyEmail,
+  } from "@commons/methods/participants";
   import { addKeyValue } from "./methods/lib";
   import DropdownSymbol from "./assets/chevron-down.svg";
   import TrashIcon from "./assets/trash-alt.svg";


### PR DESCRIPTION
# Code changes

- [x] Updated contact search so Composer can consume [Nylas Contact](https://developer.nylas.com/docs/api#tag--Contacts) type into `to` `from`, `cc` and `bcc`.
- [x] Added function to clean up the contact list user passed in as prop.

# Readiness checklist

- [x] Added changes to component `CHANGELOG.md`
- [ ] Cypress tests passing?

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
