### PR TITLE
[composer] tabbing through to body doesn't work in firefox

### DIFF
--- a/components/composer/src/components/HTMLEditor.svelte
+++ b/components/composer/src/components/HTMLEditor.svelte
@@ -103,7 +103,28 @@
     });
   }
 
+  let focusing = false;
+
   const handleHtmlBodyFocus = () => {
+    console.log({ focusing });
+
+    if (focusing) {
+      focusing = false;
+    } else {
+      focusing = true;
+      setTimeout(() => {
+        container.blur();
+        container.focus();
+      }, 0);
+      return;
+    }
+    console.log("proceeding as normal");
+    // container.DOCUMENT_FRAGMENT_NODE.
+    // let shadowRoot = container.getRootNode();
+    // const selection = (shadowRoot as HTMLElement).getSelection();
+    // const range = selection.getRangeAt(0);
+    // console.log(range.toString())
+    //     console.log(.delgatesFocus);
     // if contenteditable area is empty we need to add something to add range
     if (container.innerHTML === "") {
       container.innerHTML = "\u00a0";

--- a/components/composer/src/components/HTMLEditor.svelte
+++ b/components/composer/src/components/HTMLEditor.svelte
@@ -117,6 +117,7 @@
       }, 0);
     }
 
+    // if contenteditable area is empty we need to add something to add range
     if (container.innerHTML === "") {
       container.innerHTML = "\u00a0";
       const selection = window.getSelection();

--- a/components/composer/src/components/HTMLEditor.svelte
+++ b/components/composer/src/components/HTMLEditor.svelte
@@ -106,8 +106,6 @@
   let focusing = false;
 
   const handleHtmlBodyFocus = () => {
-    console.log({ focusing });
-
     if (focusing) {
       focusing = false;
     } else {
@@ -116,16 +114,8 @@
         container.blur();
         container.focus();
       }, 0);
-      return;
     }
-    console.log("proceeding as normal");
-    // container.DOCUMENT_FRAGMENT_NODE.
-    // let shadowRoot = container.getRootNode();
-    // const selection = (shadowRoot as HTMLElement).getSelection();
-    // const range = selection.getRangeAt(0);
-    // console.log(range.toString())
-    //     console.log(.delgatesFocus);
-    // if contenteditable area is empty we need to add something to add range
+
     if (container.innerHTML === "") {
       container.innerHTML = "\u00a0";
       const selection = window.getSelection();

--- a/components/composer/src/components/HTMLEditor.svelte
+++ b/components/composer/src/components/HTMLEditor.svelte
@@ -104,8 +104,9 @@
   }
 
   let focusing = false;
-
   const handleHtmlBodyFocus = () => {
+    // refocus editor to return cursor to editor - workaround for
+    // firefox selection API / shadow DOM issues)
     if (focusing) {
       focusing = false;
     } else {

--- a/components/mailbox/src/init.spec.js
+++ b/components/mailbox/src/init.spec.js
@@ -108,7 +108,7 @@ const DRAFT_THREAD = {
 
 const defaultSize = 13;
 
-describe("Mailbox Display", () => {
+xdescribe("Mailbox Display", () => {
   let thread1;
   let thread2;
   let THREAD_WITH_MESSAGE_THAT_DOES_NOT_HAVE_FROM_OR_TO_FIELDS;
@@ -231,7 +231,7 @@ describe("Mailbox Display", () => {
   });
 });
 
-describe("Mailbox Files/Images", () => {
+xdescribe("Mailbox Files/Images", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -281,7 +281,7 @@ describe("Mailbox Files/Images", () => {
   });
 });
 
-describe("Mailbox Unread/Read", () => {
+xdescribe("Mailbox Unread/Read", () => {
   let thread1;
   let thread2;
 
@@ -391,7 +391,7 @@ describe("Mailbox Unread/Read", () => {
   });
 });
 
-describe("Mailbox Props", () => {
+xdescribe("Mailbox Props", () => {
   let thread1;
   let thread2;
 
@@ -496,7 +496,7 @@ describe("Mailbox Props", () => {
   });
 });
 
-describe("Mailbox Interactions", () => {
+xdescribe("Mailbox Interactions", () => {
   let thread1;
   let thread2;
 
@@ -592,7 +592,7 @@ describe("Mailbox Interactions", () => {
   });
 });
 
-describe("Mailbox Pagination: threads not intercepted", () => {
+xdescribe("Mailbox Pagination: threads not intercepted", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -660,7 +660,7 @@ describe("Mailbox Pagination: threads not intercepted", () => {
   });
 });
 
-describe("Mailbox: updating 'to' field correctly for reply and reply-all", () => {
+xdescribe("Mailbox: updating 'to' field correctly for reply and reply-all", () => {
   beforeEach(() => {
     cy.batchIntercept("GET", {
       "https://web-components.nylas.com/middleware/manifest":
@@ -726,7 +726,7 @@ describe("Mailbox: updating 'to' field correctly for reply and reply-all", () =>
   });
 });
 
-describe("Mailbox: updating cc fields correctly for reply and reply-all", () => {
+xdescribe("Mailbox: updating cc fields correctly for reply and reply-all", () => {
   beforeEach(() => {
     cy.batchIntercept("GET", {
       "https://web-components.nylas.com/middleware/manifest":
@@ -797,7 +797,7 @@ describe("Mailbox: updating cc fields correctly for reply and reply-all", () => 
   });
 });
 
-describe("Mailbox Bulk actions", () => {
+xdescribe("Mailbox Bulk actions", () => {
   let thread1;
   let thread2;
 
@@ -969,7 +969,7 @@ describe("Mailbox Bulk actions", () => {
   });
 });
 
-describe("Mailbox Custom events", () => {
+xdescribe("Mailbox Custom events", () => {
   let thread1;
   let thread2;
 
@@ -1513,7 +1513,7 @@ describe("Mailbox Integration: Save draft and update draft", () => {
   });
 });
 
-describe("Display Participants in thread row", () => {
+xdescribe("Display Participants in thread row", () => {
   beforeEach(() => {
     cy.batchIntercept("GET", {
       "**/middleware/manifest": "mailbox/manifest",

--- a/components/mailbox/src/init.spec.js
+++ b/components/mailbox/src/init.spec.js
@@ -108,7 +108,7 @@ const DRAFT_THREAD = {
 
 const defaultSize = 13;
 
-xdescribe("Mailbox Display", () => {
+describe("Mailbox Display", () => {
   let thread1;
   let thread2;
   let THREAD_WITH_MESSAGE_THAT_DOES_NOT_HAVE_FROM_OR_TO_FIELDS;
@@ -231,7 +231,7 @@ xdescribe("Mailbox Display", () => {
   });
 });
 
-xdescribe("Mailbox Files/Images", () => {
+describe("Mailbox Files/Images", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -281,7 +281,7 @@ xdescribe("Mailbox Files/Images", () => {
   });
 });
 
-xdescribe("Mailbox Unread/Read", () => {
+describe("Mailbox Unread/Read", () => {
   let thread1;
   let thread2;
 
@@ -391,7 +391,7 @@ xdescribe("Mailbox Unread/Read", () => {
   });
 });
 
-xdescribe("Mailbox Props", () => {
+describe("Mailbox Props", () => {
   let thread1;
   let thread2;
 
@@ -496,7 +496,7 @@ xdescribe("Mailbox Props", () => {
   });
 });
 
-xdescribe("Mailbox Interactions", () => {
+describe("Mailbox Interactions", () => {
   let thread1;
   let thread2;
 
@@ -592,7 +592,7 @@ xdescribe("Mailbox Interactions", () => {
   });
 });
 
-xdescribe("Mailbox Pagination: threads not intercepted", () => {
+describe("Mailbox Pagination: threads not intercepted", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
@@ -660,7 +660,7 @@ xdescribe("Mailbox Pagination: threads not intercepted", () => {
   });
 });
 
-xdescribe("Mailbox: updating 'to' field correctly for reply and reply-all", () => {
+describe("Mailbox: updating 'to' field correctly for reply and reply-all", () => {
   beforeEach(() => {
     cy.batchIntercept("GET", {
       "https://web-components.nylas.com/middleware/manifest":
@@ -726,7 +726,7 @@ xdescribe("Mailbox: updating 'to' field correctly for reply and reply-all", () =
   });
 });
 
-xdescribe("Mailbox: updating cc fields correctly for reply and reply-all", () => {
+describe("Mailbox: updating cc fields correctly for reply and reply-all", () => {
   beforeEach(() => {
     cy.batchIntercept("GET", {
       "https://web-components.nylas.com/middleware/manifest":
@@ -797,7 +797,7 @@ xdescribe("Mailbox: updating cc fields correctly for reply and reply-all", () =>
   });
 });
 
-xdescribe("Mailbox Bulk actions", () => {
+describe("Mailbox Bulk actions", () => {
   let thread1;
   let thread2;
 
@@ -969,7 +969,7 @@ xdescribe("Mailbox Bulk actions", () => {
   });
 });
 
-xdescribe("Mailbox Custom events", () => {
+describe("Mailbox Custom events", () => {
   let thread1;
   let thread2;
 
@@ -1513,7 +1513,7 @@ describe("Mailbox Integration: Save draft and update draft", () => {
   });
 });
 
-xdescribe("Display Participants in thread row", () => {
+describe("Display Participants in thread row", () => {
   beforeEach(() => {
     cy.batchIntercept("GET", {
       "**/middleware/manifest": "mailbox/manifest",


### PR DESCRIPTION
# Issues:
The following issues were identified with the Composer component in Firefox, and seem to be known issues with the Firefox's Selection API implementation with `contenteditable` elements in the Shadow DOM.
- Focusing non-body elements directly prior to focusing the HTML editor prevents cursor from displaying.
- Focusing non-body elements which store selection caret/range prior to focusing the HTML editor prevents selection caret from switching to the HTML editor.
  - The selection caret seems to get trapped in `<input>` elements and prevents typing into the HTML editor unless `document.activeElement` is updated by clicking on the background/body.

# What you did:
- Add `focusing` flag that triggers a re-focusing of the HTML editor via a `setTimeout` to update `selection`'s `anchorNode`/`focusNode`, and focus on correct element in the shadow DOM.
  - Adapted from ProseMirror plugin solution found here: https://github.com/ProseMirror/prosemirror/issues/1113

# Screen Captures
## Lost cursor and typing lockout on tab-through
![broken](https://user-images.githubusercontent.com/43771331/195006657-3149fcd3-a375-4825-8b9c-b115804def6b.gif)

## Re-focus solution
![fixed](https://user-images.githubusercontent.com/43771331/195006644-bdb27b48-0cc6-4e0e-9ebd-71edb377d24f.gif)

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
