### PR TITLE
Don't delay loading fetching labels/folders

### DIFF
--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -134,9 +134,13 @@
     };
     // Initialize labels / folders
     if (you?.organization_unit === AccountOrganizationUnit.Label) {
-      labels = await LabelStore.getLabels(accountOrganizationUnitQuery);
+      LabelStore.getLabels(accountOrganizationUnitQuery).then(
+        (ls) => (labels = ls),
+      );
     } else if (you?.organization_unit === AccountOrganizationUnit.Folder) {
-      folders = await FolderStore.getFolders(accountOrganizationUnitQuery);
+      FolderStore.getFolders(accountOrganizationUnitQuery).then(
+        (fs) => (folders = fs),
+      );
     }
 
     await updateDisplayedThreads();


### PR DESCRIPTION
# Code changes

Currently, the await stops loading while all folders/labels are loaded, slowing down initial load time. This changes to a callback, which allows the rest of the component to load asynchronously.

Also, these folders/labels are ONLY used to fetch the ID of the trash folder/label. Loading a list of all folders/labels seems really inefficient for just that...

Edit: here's a writeup that I've previously sent to Nylas Product Management:

> The mailbox component loads quite slowly (I count 3-4s when loading zero threads), and there are some basic optimizations that could help. For instance, threads are only loaded after the folders or labels are fetched, which takes at least half a second. But the folders/labels are only used when a thread is deleted, so it could be fetched after threads with minimal risk, or even on demand, when the user deletes the thread. And, in fact, the component fetches a list of all folders/labels — but then uses that list only to search through and find the ID of trash, ignoring all the rest. This will unnecessarily impact load time especially for people with lots of folders or threads.

# Readiness checklist

- [ ] Added changes to component `CHANGELOG.md`
- [ ] New property added? make sure to update `component/src/properties.json`
- [ ] Cypress tests passing?
- [ ] New cypress tests added?
- [ ] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
