### PR TITLE
Don't show loading state so low down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Prevented the loader from taking up 100% of the height of the browser [Pull Request](https://github.com/nylas/components/pull/462)
+
 # 2021-11-29
 
 ## 1.1.1

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -737,12 +737,6 @@
       gap: 8px;
     }
 
-    &.loading {
-      grid-template-rows: minmax(
-        auto,
-        calc(100vh - 16px)
-      ); /** loading mailbox minus padding **/
-    }
     &.empty {
       grid-template-rows: 68px 33.5px minmax(auto, calc(100vh - 117.5px)); /** header, toolbar, empty mailbox (100vh) minus header, toolbar and padding **/
       ul {


### PR DESCRIPTION
# Code changes

The current styling assumes this mailbox will be the only component on the screen. If it's included in a UI that has something above it, that means the loading UI may even be below the fold, making the UI appear blank & broken until loading finishes. In error states, when loading never finishes, it's even worse. The sizing of the loading screen should be the responsibility of the consumer, as it knows the size the component should be.

Edit: here's a writeup that I've previously sent to Nylas Product Management:

> The loading page assumes the mailbox is the only thing on the screen. It takes up essentially 100% of the height of the browser — even if there's stuff displayed above it. When it's displayed lower down on a page, with stuff above it, the loading spinner likely is often not visible unless you scroll down.

# Readiness checklist

- [ ] Added changes to component `CHANGELOG.md`
- [ ] New property added? make sure to update `component/src/properties.json`
- [ ] Cypress tests passing?
- [ ] New cypress tests added?
- [ ] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
