### PR TITLE
Fix actions_bar display when checkboxes disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Fix actions_bar display when checkboxes disabled [Pull Request](https://github.com/nylas/components/pull/463)
+
 # 2021-11-29
 
 ## 1.1.1

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -1030,12 +1030,12 @@
           <h1>{header}</h1>
         </header>
       {/if}
-      {#if _this.actions_bar.length}
+      {#if _this.show_thread_checkbox && _this.actions_bar.length}
         <div
           role="toolbar"
           aria-label="Bulk actions"
           aria-controls="mailboxlist">
-          {#if _this.show_thread_checkbox && _this.actions_bar.includes(MailboxActions.SELECTALL)}
+          {#if _this.actions_bar.includes(MailboxActions.SELECTALL)}
             <div class="thread-checkbox">
               {#each [areAllSelected ? "Deselect all" : "Select all"] as selectAllTitle}
                 <input


### PR DESCRIPTION
# Code changes

The actions bar is UI to act on selected email threads. When checkboxes are disabled, it will never have any content, and so it shouldn't be displayed.

# Readiness checklist

- [ ] Added changes to component `CHANGELOG.md`
- [ ] New property added? make sure to update `component/src/properties.json`
- [ ] Cypress tests passing?
- [ ] New cypress tests added?
- [ ] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
