### PR TITLE
Don't fetch manifest when all threads is set

### DIFF
--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -110,9 +110,13 @@
   onMount(async () => {
     await tick();
 
-    manifest = ((await $ManifestStore[
-      JSON.stringify({ component_id: id, access_token })
-    ]) || {}) as MailboxProperties;
+    // If using fake data, manifest isn't needed for anything and shouldn't be
+    // loaded
+    if (!$$props.all_threads) {
+      manifest = ((await $ManifestStore[
+        JSON.stringify({ component_id: id, access_token })
+      ]) || {}) as MailboxProperties;
+    }
 
     _this = buildInternalProps(
       $$props,


### PR DESCRIPTION
# Code changes

We include a fully stubbed-out/mocked-out instance of the mailbox component in our Storybook code. We then use Chromatic to take snapshots of it. This way, when we update the component, we'll get a visual comparison of any UI changes. It will help us upgrade our components quickly and easily, while still knowing if our UI will change somehow.

However, despite us supplying external data with `all_threads`, the component still makes an HTTP request to Nylas, requiring both a component ID and Nylas Access Token. We don't want to expose a secret token to access a mailbox to our CI and Storybook; to date, our frontend has zero secrets that cannot be exposed to the frontend. We'd like to keep it that way.

This change simply skips the manifest loading when all_threads is set. None of the manifest data would use used in this situation, anyway.

# Readiness checklist

- [ ] Added changes to component `CHANGELOG.md`
- [ ] New property added? make sure to update `component/src/properties.json`
- [ ] Cypress tests passing?
- [ ] New cypress tests added?
- [ ] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
