### PR TITLE
Feature: Show threads by ID

### DIFF
--- a/commons/src/store/mailbox.ts
+++ b/commons/src/store/mailbox.ts
@@ -50,11 +50,14 @@ function initializeThreads() {
       const queryKey = JSON.stringify(query);
 
       if (!query.component_id && !query.access_token) {
+        // FIXME: This should alert the user
         return [];
       }
 
       if (totalItems === undefined || forceRefresh) {
-        const threadCount = await fetchThreadCount(query).catch(silence);
+        const threadCount = query.thread_ids
+          ? query.thread_ids.length
+          : await fetchThreadCount(query).catch(silence);
 
         if (threadCount) {
           totalItems = threadCount;
@@ -67,6 +70,7 @@ function initializeThreads() {
       }
 
       if (typeof threadsMap[queryKey][currentPage] === "undefined") {
+        // FIXME: Shouldn't this be an internal error?
         return [];
       } else if (!threadsMap[queryKey][currentPage].isLoaded) {
         const threads = await fetchThreads(

--- a/commons/src/types/Nylas.ts
+++ b/commons/src/types/Nylas.ts
@@ -24,6 +24,7 @@ export interface ConversationQuery extends CommonQuery {
 
 export interface MailboxQuery extends CommonQuery {
   query: ThreadsQuery;
+  thread_ids?: string[];
   keywordToSearch?: string;
 }
 
@@ -218,6 +219,7 @@ export interface EmailProperties extends Manifest {
 export interface MailboxProperties extends Manifest {
   actions_bar: MailboxActions[];
   all_threads: Thread[];
+  thread_ids: string[];
   header: string;
   items_per_page: number;
   keyword_to_search: string;

--- a/components/mailbox/src/Mailbox.svelte
+++ b/components/mailbox/src/Mailbox.svelte
@@ -50,6 +50,7 @@
 
   export let actions_bar: MailboxActions[];
   export let all_threads: Thread[];
+  export let thread_ids: string[];
   export let header: string = "Mailbox";
   export let items_per_page: number;
   export let keyword_to_search: string;
@@ -70,6 +71,7 @@
     actions_bar: [],
     items_per_page: 13,
     query_string: "in=inbox",
+    thread_ids: undefined,
     show_star: false,
     show_thread_checkbox: true,
     show_reply: false,
@@ -181,6 +183,7 @@
       query: Object.fromEntries(
         new URLSearchParams(_this.query_string?.replaceAll(" ", "&")),
       ),
+      thread_ids,
     };
 
     if (_this.keyword_to_search) {


### PR DESCRIPTION
# Code changes

We have a list of threads that we've assembled using our app's "secret sauce," and now want to show the user this curated lists of threads as kind of an automatically created folder. We don't want to create folders or labels for the user, because that gets into preferences of if (and how) they'd like their email data modified.

We also want to make the mailbox UI interactive, which is to say, we want the Nylas component to run HTTP requests. It should load the body of emails, contact data, and write data back, allowing for star/unstar etc. The only current way to display a specific set of threads in the Mailbox is to supply all_threads, but that requires optimistic loading of all data (very slow), and disables all the interactive parts of the component.

This change, previously discussed with Hazik Azfal, adds support for passing in a list of thread IDs, which fulfills all requirements. We're about to deploy the mailbox component to production with this modification (along with other changes in other PRs)

Closes https://github.com/nylas/components/issues/439

# Readiness checklist

- [ ] Added changes to component `CHANGELOG.md`
- [ ] New property added? make sure to update `component/src/properties.json`
- [ ] Cypress tests passing?
- [ ] New cypress tests added?
- [ ] Included before/after screenshots, if the change is visual

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
