### PR TITLE
Fix: email thread would collapse if the header or body would be clicked.

### DIFF
--- a/components/composer/package.json
+++ b/components/composer/package.json
@@ -13,5 +13,5 @@
     "start": "echo 'Nothing to start'"
   },
   "main": "index.js",
-  "gitHead": "cca94159c114ecff613f41caa0a4468e0f698e2c"
+  "gitHead": "65fe465e0fe71d5cc4601a56615d53d1d93e29e4"
 }


### PR DESCRIPTION
# Code changes

- [x] Added a new "mousedown" handler for detecting text selection highlight attempts to prevent message thread handlers from firing.
- [x] Moved the thread click handlers to only the parts of the UI that need it (instead of the whole thread container). 

https://github.com/nylas/components/assets/314152/738eb1eb-20c0-4810-96f3-57c5b93f725a

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
